### PR TITLE
すべての @pixiv-elements/ を @charcoal/ に置換する

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -49,7 +49,7 @@ const alias = async () =>
   Object.fromEntries(
     (await glob(path.resolve(packagesDir, '*'))).map((absolute) => {
       const relative = path.relative(packagesDir, absolute)
-      const from = path.join('@pixiv-elements', relative)
+      const from = path.join('@charcoal', relative)
       const to = path.resolve(absolute, 'src')
       return [from, to]
     })

--- a/.storybook/theme-decorator.tsx
+++ b/.storybook/theme-decorator.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
 import { useDarkMode } from 'storybook-dark-mode'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 
 const { light, dark } = createTheme
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @pixiv-elements ― PIXIV Design System monorepo
+# @charcoal ― PIXIV Design System monorepo
 
-This is the monorepo for the `@pixiv-elements` packages by pixiv.
+This is the monorepo for the `@charcoal` packages by pixiv.
 
 # Development
 
@@ -17,8 +17,8 @@ yarn lerna bootstrap
 yarn build
 ```
 
-You should build all the packages first so that each package can import another `@pixiv-elements/*` package.
+You should build all the packages first so that each package can import another `@charcoal/*` package.
 
 ## Commit
 
-`@pixiv-elements` is using [commintlint](https://github.com/conventional-changelog/commitlint) and following the [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) rules.
+`@charcoal` is using [commintlint](https://github.com/conventional-changelog/commitlint) and following the [Conventional Commits](https://www.conventionalcommits.org/ja/v1.0.0/) rules.

--- a/docs/pages/components/icons.md
+++ b/docs/pages/components/icons.md
@@ -1,4 +1,4 @@
-# `@pixiv-elements/icons`
+# `@charcoal/icons`
 
 ピクシブのすべてのプロダクトで利用可能なアイコンライブラリです。中身
 は[Custom Element](https://developer.mozilla.org/ja/docs/Web/Web_Components/Using_custom_elements)と
@@ -7,7 +7,7 @@
 ### インストール
 
 ```
-$ yarn add @pixiv-elements/icons
+$ yarn add @charcoal/icons
 ```
 
 ### 使い方
@@ -16,7 +16,7 @@ $ yarn add @pixiv-elements/icons
 良いでしょう。
 
 ```ts
-import '@pixiv-elements/icons'
+import '@charcoal/icons'
 ```
 
 これだけで、 `<pixiv-icon>` という HTML タグが利用可能になります。
@@ -46,7 +46,7 @@ TypeScript 環境下では、`KnownIconType` という型を拡張すること�
 くようになります。
 
 ```ts
-import PixivIcon from '@pixiv-elements/icons'
+import PixivIcon from '@charcoal/icons'
 import NewFeature from './NewFeature.svg'
 
 PixivIcon.extend({
@@ -55,7 +55,7 @@ PixivIcon.extend({
   '32/NewFeature': NewFeature,
 })
 
-declare module '@pixiv-elements/icons' {
+declare module '@charcoal/icons' {
   export interface KnownIconType {
     '16/NewFeature': unknown
     '24/NewFeature': unknown
@@ -74,7 +74,7 @@ https://ja.reactjs.org/docs/web-components.html#using-web-components-in-react
 ントを作ってください。
 
 ```tsx
-import { Props as IconProps } from '@pixiv-elements/icons'
+import { Props as IconProps } from '@charcoal/icons'
 
 interface Props extends Omit<IconProps, 'class'> {
   className?: string

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -19,7 +19,7 @@ const defaultConfig = () => ({
   transformIgnorePatterns: ['../../node_modules/(?!(lit-html))'],
   // tsconfigのpathsに対応 (依存パッケージをビルドせずにテストが可能)
   moduleNameMapper: {
-    '^@pixiv-elements/(.*)$': '<rootDir>/../$1/src',
+    '^@charcoal/(.*)$': '<rootDir>/../$1/src',
   },
 })
 
@@ -33,7 +33,7 @@ const strictConfig = () => ({
   moduleNameMapper: {
     // TODO: 一貫性のために外したい
     // es5になった`PixivIcon.ts`がjsdomの提供するHTMLElementと互換がないため、したかなくマッピング
-    '^@pixiv-elements/icons$': '<rootDir>/../icons/src',
+    '^@charcoal/icons$': '<rootDir>/../icons/src',
   },
   globals: {
     'ts-jest': {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixiv-elements",
   "version": "1.0.0",
-  "description": "@pixiv-elements monorepo",
+  "description": "@charcoal monorepo",
   "author": "pixiv",
   "license": "UNLICENSED",
   "private": true,
@@ -30,10 +30,10 @@
     "website": "docsify serve website -p 5000"
   },
   "devDependencies": {
+    "@charcoal/icons-cli": "workspace:packages/icons-cli",
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
     "@commitlint/config-lerna-scopes": "^16.0.0",
-    "@pixiv-elements/icons-cli": "workspace:packages/icons-cli",
     "@storybook/addon-a11y": "^6.4.17",
     "@storybook/addon-essentials": "^6.4.17",
     "@storybook/addon-knobs": "^6.4.0",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/foundation",
+  "name": "@charcoal/foundation",
   "version": "1.0.0",
   "license": "UNLICENSED",
   "type": "module",

--- a/packages/icons-cli/README.md
+++ b/packages/icons-cli/README.md
@@ -1,3 +1,3 @@
-# `@pixiv-elements/icons-cli`
+# `@charcoal/icons-cli`
 
 SVG Icon collectors & merge request creator

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/icons-cli",
+  "name": "@charcoal/icons-cli",
   "version": "1.0.0",
   "license": "UNLICENSED",
   "type": "module",

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,11 +1,11 @@
-# `@pixiv-elements/icons`
+# `@charcoal/icons`
 
 Icon library for PIXIV products, written as a [custom element](https://developer.mozilla.org/ja/docs/Web/Web_Components/Using_custom_elements).
 
 ### Install
 
 ```
-$ yarn add @pixiv-elements/icons
+$ yarn add @charcoal/icons
 ```
 
 ### How to use
@@ -13,7 +13,7 @@ $ yarn add @pixiv-elements/icons
 Import once in the entrypoint of your project. For Storybook, `preview.(js|ts)` would be the place.
 
 ```ts
-import '@pixiv-elements/icons'
+import '@charcoal/icons'
 ```
 
 Then you can write `<pixiv-icon>` tag in your markup.
@@ -39,7 +39,7 @@ You need to name the new icon like `${size}/${name}`.
 And if you like to use `<pixiv-icon>` in TypeScript environment, you need to extend `KnownIconType` in your d.ts!
 
 ```ts
-import PixivIcon from '@pixiv-elements/icons'
+import PixivIcon from '@charcoal/icons'
 import NewFeature from './NewFeature.svg'
 
 PixivIcon.extend({
@@ -48,7 +48,7 @@ PixivIcon.extend({
   '32/NewFeature': NewFeature,
 })
 
-declare module '@pixiv-elements/icons' {
+declare module '@charcoal/icons' {
   export interface KnownIconType {
     '16/NewFeature': unknown
     '24/NewFeature': unknown
@@ -66,7 +66,7 @@ https://ja.reactjs.org/docs/web-components.html#using-web-components-in-react
 If you like to pass `className` (e.g. you are using `styled-components`), you need to create a wrapper component to forward `className`.
 
 ```tsx
-import { Props as IconProps } from '@pixiv-elements/icons'
+import { Props as IconProps } from '@charcoal/icons'
 
 interface Props extends Omit<IconProps, 'class'> {
   className?: string

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/icons",
+  "name": "@charcoal/icons",
   "version": "1.0.1",
   "license": "UNLICENSED",
   "type": "module",

--- a/packages/pixiv-theme/package.json
+++ b/packages/pixiv-theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/pixiv-theme",
+  "name": "@charcoal/pixiv-theme",
   "version": "5.0.0",
   "license": "UNLICENSED",
   "type": "module",
@@ -28,8 +28,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/foundation": "^1.0.0",
-    "@pixiv-elements/theme": "^4.0.0",
+    "@charcoal/foundation": "^1.0.0",
+    "@charcoal/theme": "^4.0.0",
     "polished": "^4.1.4"
   },
   "files": [

--- a/packages/pixiv-theme/src/common.ts
+++ b/packages/pixiv-theme/src/common.ts
@@ -7,7 +7,7 @@ import {
   maxWidth,
   spacing,
   typography,
-} from '@pixiv-elements/foundation'
+} from '@charcoal/foundation'
 
 export const common: CommonTheme = {
   typography: {

--- a/packages/pixiv-theme/src/index.ts
+++ b/packages/pixiv-theme/src/index.ts
@@ -4,13 +4,9 @@ import {
   Typography,
   TypographyVariant,
   TypographyWeight,
-} from '@pixiv-elements/foundation'
+} from '@charcoal/foundation'
 
-import {
-  GradientMaterial,
-  Material,
-  Theme as BaseTheme,
-} from '@pixiv-elements/theme'
+import { GradientMaterial, Material, Theme as BaseTheme } from '@charcoal/theme'
 
 interface PixivColor {
   /**

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/react-sandbox",
+  "name": "@charcoal/react-sandbox",
   "version": "1.0.1",
   "license": "UNLICENSED",
   "type": "module",
@@ -47,11 +47,11 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/foundation": "^1.0.0",
-    "@pixiv-elements/pixiv-theme": "^5.0.0",
-    "@pixiv-elements/react": "^1.0.1",
-    "@pixiv-elements/styled": "^3.0.1",
-    "@pixiv-elements/utils": "^3.0.0",
+    "@charcoal/foundation": "^1.0.0",
+    "@charcoal/pixiv-theme": "^5.0.0",
+    "@charcoal/react": "^1.0.1",
+    "@charcoal/styled": "^3.0.1",
+    "@charcoal/utils": "^3.0.0",
     "polished": "^4.1.4",
     "warning": "^4.0.3"
   },

--- a/packages/react-sandbox/src/components/CarouselButton/index.tsx
+++ b/packages/react-sandbox/src/components/CarouselButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { unreachable } from '../../foundation/utils'
 import NextIcon, { WedgeDirection } from '../icons/NextIcon'
-import { applyEffect } from '@pixiv-elements/utils'
+import { applyEffect } from '@charcoal/utils'
 
 export enum Direction {
   Right = 'right',

--- a/packages/react-sandbox/src/components/Filter/index.story.tsx
+++ b/packages/react-sandbox/src/components/Filter/index.story.tsx
@@ -9,7 +9,7 @@ import {
   useNavigate,
 } from 'react-router-dom'
 import Filter, { FilterButton, FilterLink } from '.'
-import { ComponentAbstraction } from '@pixiv-elements/react'
+import { ComponentAbstraction } from '@charcoal/react'
 
 export default {
   title: 'Sandbox/Filter',

--- a/packages/react-sandbox/src/components/Filter/index.tsx
+++ b/packages/react-sandbox/src/components/Filter/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { useComponentAbstraction, LinkProps } from '@pixiv-elements/react'
-import { maxWidth } from '@pixiv-elements/utils'
+import { useComponentAbstraction, LinkProps } from '@charcoal/react'
+import { maxWidth } from '@charcoal/utils'
 
 interface Props<T extends HTMLElement> {
   active?: boolean

--- a/packages/react-sandbox/src/components/HintText/index.tsx
+++ b/packages/react-sandbox/src/components/HintText/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import InfoIcon from '../icons/InfoIcon'
-import { maxWidth } from '@pixiv-elements/utils'
+import { maxWidth } from '@charcoal/utils'
 
 type Context = 'page' | 'section'
 interface Props {

--- a/packages/react-sandbox/src/components/Layout/index.tsx
+++ b/packages/react-sandbox/src/components/Layout/index.tsx
@@ -6,8 +6,8 @@ import {
   RESPONSIVE_MAIN_MAX_WIDTH,
 } from '../../foundation/contants'
 import { useMediaScreen1 } from '../../foundation/hooks'
-import { columnPx, GUTTER_UNIT } from '@pixiv-elements/foundation'
-import { maxWidth } from '@pixiv-elements/utils'
+import { columnPx, GUTTER_UNIT } from '@charcoal/foundation'
+import { maxWidth } from '@charcoal/utils'
 
 interface Props {
   menu?: React.ReactNode

--- a/packages/react-sandbox/src/components/LeftMenu/index.tsx
+++ b/packages/react-sandbox/src/components/LeftMenu/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { MenuListLinkItem } from '../MenuListItem'
-import { useComponentAbstraction } from '@pixiv-elements/react'
+import { useComponentAbstraction } from '@charcoal/react'
 
 interface Props<ID extends string> {
   links: readonly {

--- a/packages/react-sandbox/src/components/MenuListItem/index.tsx
+++ b/packages/react-sandbox/src/components/MenuListItem/index.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import { TextEllipsis } from '../TextEllipsis'
-import { LinkProps, useComponentAbstraction } from '@pixiv-elements/react'
-import { disabledSelector } from '@pixiv-elements/utils'
+import { LinkProps, useComponentAbstraction } from '@charcoal/react'
+import { disabledSelector } from '@charcoal/utils'
 
 interface MenuListItemContextProps {
   padding: 16 | 24

--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-router-dom'
 import { Story } from '../../_lib/compat'
 import Pager, { LinkPager } from '.'
-import { ComponentAbstraction } from '@pixiv-elements/react'
+import { ComponentAbstraction } from '@charcoal/react'
 
 export default {
   title: 'Sandbox/Pager',

--- a/packages/react-sandbox/src/components/Pager/index.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import warning from 'warning'
 import DotsIcon from '../icons/DotsIcon'
 import WedgeIcon, { WedgeDirection } from '../icons/WedgeIcon'
-import { useComponentAbstraction } from '@pixiv-elements/react'
+import { useComponentAbstraction } from '@charcoal/react'
 
 declare const __DEV__: object | undefined // actually object|false, but using undefined allows ! assertion
 

--- a/packages/react-sandbox/src/components/SwitchCheckbox/index.tsx
+++ b/packages/react-sandbox/src/components/SwitchCheckbox/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import styled, { css } from 'styled-components'
-import { applyEffect } from '@pixiv-elements/utils'
+import { applyEffect } from '@charcoal/utils'
 
 export interface Props extends React.ComponentPropsWithoutRef<'input'> {
   gtmClass?: string

--- a/packages/react-sandbox/src/components/WithIcon/index.story.tsx
+++ b/packages/react-sandbox/src/components/WithIcon/index.story.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import WithIcon from '.'
-import { applyEffect } from '@pixiv-elements/utils'
+import { applyEffect } from '@charcoal/utils'
 
 export default {
   title: 'Sandbox/WithIcon',

--- a/packages/react-sandbox/src/foundation/contants.ts
+++ b/packages/react-sandbox/src/foundation/contants.ts
@@ -1,4 +1,4 @@
-import { columnPx, GUTTER_UNIT } from '@pixiv-elements/foundation'
+import { columnPx, GUTTER_UNIT } from '@charcoal/foundation'
 
 export const MAIN_COLUMN_HORIZONTAL_MIN_MARGIN = 72
 

--- a/packages/react-sandbox/src/foundation/hooks.ts
+++ b/packages/react-sandbox/src/foundation/hooks.ts
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import ReactDOM from 'react-dom'
 import { useTheme } from 'styled-components'
-import { maxWidth } from '@pixiv-elements/utils'
+import { maxWidth } from '@charcoal/utils'
 
 declare const __TEST__: object | undefined // actually object|false, but using undefined allows ! assertion
 

--- a/packages/react-sandbox/src/index.ts
+++ b/packages/react-sandbox/src/index.ts
@@ -30,10 +30,7 @@ export {
 export { default as SwitchCheckbox } from './components/SwitchCheckbox'
 export { TextEllipsis } from './components/TextEllipsis'
 export { default as WithIcon } from './components/WithIcon'
-export {
-  ComponentAbstraction,
-  useComponentAbstraction,
-} from '@pixiv-elements/react'
+export { ComponentAbstraction, useComponentAbstraction } from '@charcoal/react'
 export {
   MAIN_COLUMN_HORIZONTAL_MIN_MARGIN,
   RESPONSIVE_LEFT_WIDTH,

--- a/packages/react-sandbox/src/styled.ts
+++ b/packages/react-sandbox/src/styled.ts
@@ -1,3 +1,3 @@
 import styled from 'styled-components'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 export const theme = createTheme(styled)

--- a/packages/react-sandbox/src/type.d.ts
+++ b/packages/react-sandbox/src/type.d.ts
@@ -1,4 +1,4 @@
-import { ElementsTheme, ThemeProp } from '@pixiv-elements/styled'
+import { ElementsTheme, ThemeProp } from '@charcoal/styled'
 import { CSSProp, DefaultTheme } from 'styled-components'
 
 declare module 'react' {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/react",
+  "name": "@charcoal/react",
   "version": "1.0.1",
   "license": "UNLICENSED",
   "type": "module",
@@ -18,7 +18,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@pixiv-elements/icons": "^1.0.1",
+    "@charcoal/icons": "^1.0.1",
     "@react-types/switch": "^3.1.2",
     "@storybook/addon-actions": "^6.4.17",
     "@storybook/addon-knobs": "^6.4.0",
@@ -49,9 +49,9 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/pixiv-theme": "^5.0.0",
-    "@pixiv-elements/styled": "^3.0.1",
-    "@pixiv-elements/utils": "^3.0.0",
+    "@charcoal/pixiv-theme": "^5.0.0",
+    "@charcoal/styled": "^3.0.1",
+    "@charcoal/utils": "^3.0.0",
     "@react-aria/checkbox": "^3.2.3",
     "@react-aria/switch": "^3.1.3",
     "@react-aria/textfield": "^3.5.0",

--- a/packages/react/src/components/Clickable/index.tsx
+++ b/packages/react/src/components/Clickable/index.tsx
@@ -4,7 +4,7 @@ import {
   LinkProps,
   useComponentAbstraction,
 } from '../../core/ComponentAbstraction'
-import { disabledSelector } from '@pixiv-elements/utils'
+import { disabledSelector } from '@charcoal/utils'
 
 interface BaseProps {
   /**

--- a/packages/react/src/components/FieldLabel/index.tsx
+++ b/packages/react/src/components/FieldLabel/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 
 export interface FieldLabelProps
   extends React.LabelHTMLAttributes<HTMLLabelElement> {

--- a/packages/react/src/components/IconButton/index.story.tsx
+++ b/packages/react/src/components/IconButton/index.story.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import type { Story } from '../../_lib/compat'
-import '@pixiv-elements/icons'
+import '@charcoal/icons'
 import IconButton from '.'
-import type { KnownIconType } from '@pixiv-elements/icons'
+import type { KnownIconType } from '@charcoal/icons'
 
 export default {
   title: 'IconButton',

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { theme } from '../../styled'
 import Clickable, { ClickableElement, ClickableProps } from '../Clickable'
-import type { KnownIconType } from '@pixiv-elements/icons'
+import type { KnownIconType } from '@charcoal/icons'
 
 type Variant = 'Default' | 'Overlay'
 type Size = 'XS' | 'S' | 'M'

--- a/packages/react/src/components/Radio/index.story.tsx
+++ b/packages/react/src/components/Radio/index.story.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { css } from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Radio, { RadioGroup } from '.'
-import { px } from '@pixiv-elements/utils'
+import { px } from '@charcoal/utils'
 
 const options = ['value1', 'value2']
 

--- a/packages/react/src/components/Radio/index.test.tsx
+++ b/packages/react/src/components/Radio/index.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
 import Radio, { RadioGroup } from '.'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 const { light } = createTheme
 
 describe('Radio', () => {

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useState } from 'react'
 import styled from 'styled-components'
 import warning from 'warning'
 import { theme } from '../../styled'
-import { px } from '@pixiv-elements/utils'
+import { px } from '@charcoal/utils'
 
 export type RadioProps = React.PropsWithChildren<{
   value: string

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useMemo } from 'react'
 import { useToggleState } from 'react-stately'
 import styled from 'styled-components'
 import { theme } from '../../styled'
-import { disabledSelector, px } from '@pixiv-elements/utils'
+import { disabledSelector, px } from '@charcoal/utils'
 
 export type SwitchProps = {
   name: string

--- a/packages/react/src/components/TextField/index.story.tsx
+++ b/packages/react/src/components/TextField/index.story.tsx
@@ -8,7 +8,7 @@ import TextField, {
   SingleLineTextFieldProps,
   TextFieldProps,
 } from '.'
-import { px } from '@pixiv-elements/utils'
+import { px } from '@charcoal/utils'
 
 export default {
   title: 'TextField',

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -3,7 +3,7 @@ import { useVisuallyHidden } from '@react-aria/visually-hidden'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 
 const theme = createTheme(styled)
 

--- a/packages/react/src/components/a11y.test.tsx
+++ b/packages/react/src/components/a11y.test.tsx
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 import { Story } from '../_lib/compat'
 import ComponentAbstraction, { DefaultLink } from '../core/ComponentAbstraction'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 const { light, dark } = createTheme
 
 expect.extend(toHaveNoViolations)

--- a/packages/react/src/styled.ts
+++ b/packages/react/src/styled.ts
@@ -1,3 +1,3 @@
 import styled from 'styled-components'
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 export const theme = createTheme(styled)

--- a/packages/react/src/type.d.ts
+++ b/packages/react/src/type.d.ts
@@ -1,5 +1,5 @@
 import { CSSProp, DefaultTheme } from 'styled-components'
-import { ElementsTheme as Theme } from '@pixiv-elements/styled'
+import { ElementsTheme as Theme } from '@charcoal/styled'
 
 declare module 'styled-components' {
   export interface DefaultTheme extends Theme {}

--- a/packages/styled/cli/index.js
+++ b/packages/styled/cli/index.js
@@ -1,11 +1,11 @@
-import createTheme from '@pixiv-elements/styled'
+import createTheme from '@charcoal/styled'
 import fs from 'fs'
 import { parseToRgb } from 'polished'
 
 /**
  * transform color string to [0, 1] clamped value of color object
  *
- * @param { import('@pixiv-elements/theme').Material } material
+ * @param { import('@charcoal/theme').Material } material
  */
 function parseMaterial(material) {
   const { red, green, blue, ...rest } = parseToRgb(material)

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/styled",
+  "name": "@charcoal/styled",
   "version": "3.0.1",
   "license": "UNLICENSED",
   "type": "module",
@@ -32,10 +32,10 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/foundation": "^1.0.0",
-    "@pixiv-elements/pixiv-theme": "^5.0.0",
-    "@pixiv-elements/theme": "^4.0.0",
-    "@pixiv-elements/utils": "^3.0.0",
+    "@charcoal/foundation": "^1.0.0",
+    "@charcoal/pixiv-theme": "^5.0.0",
+    "@charcoal/theme": "^4.0.0",
+    "@charcoal/utils": "^3.0.0",
     "warning": "^4.0.3"
   },
   "peerDependencies": {

--- a/packages/styled/src/index.story.tsx
+++ b/packages/styled/src/index.story.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import styled, { CSSProp, DefaultTheme, ThemeProvider } from 'styled-components'
 import { ElementsTheme } from './theme'
 import createTheme, { ThemeProp } from '.'
-import { GradientMaterial } from '@pixiv-elements/theme'
-import { disabledSelector } from '@pixiv-elements/utils'
+import { GradientMaterial } from '@charcoal/theme'
+import { disabledSelector } from '@charcoal/utils'
 
 export default {
   title: 'styled',

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -14,7 +14,7 @@ import {
   objectKeys,
   isPresent,
 } from './util'
-import { columnPx, halfLeading } from '@pixiv-elements/foundation'
+import { columnPx, halfLeading } from '@charcoal/foundation'
 import {
   applyEffect,
   applyEffectToGradient,
@@ -24,7 +24,7 @@ import {
   notDisabledSelector,
   disabledSelector,
   px,
-} from '@pixiv-elements/utils'
+} from '@charcoal/utils'
 export { type Modified, type ModifiedArgumented } from './lib'
 
 import { light, dark } from './theme'

--- a/packages/styled/src/theme.ts
+++ b/packages/styled/src/theme.ts
@@ -8,10 +8,10 @@ import {
   typography,
   Breakpoint,
   breakpoint,
-} from '@pixiv-elements/foundation'
-import { light as l, dark as d } from '@pixiv-elements/pixiv-theme'
-import { Effect, Material, OpacityEffect, Theme } from '@pixiv-elements/theme'
-import { applyEffect } from '@pixiv-elements/utils'
+} from '@charcoal/foundation'
+import { light as l, dark as d } from '@charcoal/pixiv-theme'
+import { Effect, Material, OpacityEffect, Theme } from '@charcoal/theme'
+import { applyEffect } from '@charcoal/utils'
 
 export interface ElementsTheme extends StyledTheme {
   color: Theme['color']

--- a/packages/styled/src/types.ts
+++ b/packages/styled/src/types.ts
@@ -1,10 +1,10 @@
-import { TypographyDescriptor } from '@pixiv-elements/foundation'
+import { TypographyDescriptor } from '@charcoal/foundation'
 import {
   Effect,
   GradientMaterial,
   Material,
   OpacityEffect,
-} from '@pixiv-elements/theme'
+} from '@charcoal/theme'
 
 export type EffectType = 'hover' | 'press' | 'disabled'
 

--- a/packages/tailwind-config/README.md
+++ b/packages/tailwind-config/README.md
@@ -1,4 +1,4 @@
-# `@pixiv-elements/tailwind-config`
+# `@charcoal/tailwind-config`
 
 Provides tailwind.css config based on PIXIV Design System.
 
@@ -7,13 +7,13 @@ Provides tailwind.css config based on PIXIV Design System.
 When you just use default config,
 
 ```js:tailwind.config.js
-module.exports = require('@pixiv-elements/tailwind-config').default;
+module.exports = require('@charcoal/tailwind-config').default;
 ```
 
 or if you prefer
 
 ```js:tailwind.config.js
-const { createTailwindConfig } = require('@pixiv-elements/tailwind-config')
+const { createTailwindConfig } = require('@charcoal/tailwind-config')
 
 // pass color theme
 module.exports = createTailwindConfig({ theme: yourColorTheme });

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/tailwind-config",
+  "name": "@charcoal/tailwind-config",
   "version": "4.0.0",
   "license": "UNLICENSED",
   "type": "module",
@@ -26,10 +26,10 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/foundation": "^1.0.0",
-    "@pixiv-elements/pixiv-theme": "^5.0.0",
-    "@pixiv-elements/theme": "^4.0.0",
-    "@pixiv-elements/utils": "^3.0.0"
+    "@charcoal/foundation": "^1.0.0",
+    "@charcoal/pixiv-theme": "^5.0.0",
+    "@charcoal/theme": "^4.0.0",
+    "@charcoal/utils": "^3.0.0"
   },
   "peerDependencies": {
     "csstype": ">=3.0.0",

--- a/packages/tailwind-config/src/colors/plugin.test.ts
+++ b/packages/tailwind-config/src/colors/plugin.test.ts
@@ -1,5 +1,5 @@
 import { defineCssVariables } from './plugin'
-import { dark, light } from '@pixiv-elements/pixiv-theme'
+import { dark, light } from '@charcoal/pixiv-theme'
 
 describe('colors/plugin/defineCssVariables', () => {
   const DARK = '@media(prefers-color-scheme: dark)'

--- a/packages/tailwind-config/src/colors/plugin.ts
+++ b/packages/tailwind-config/src/colors/plugin.ts
@@ -1,5 +1,5 @@
-import { Material, Theme } from '@pixiv-elements/theme'
-import { applyEffect } from '@pixiv-elements/utils'
+import { Material, Theme } from '@charcoal/theme'
+import { applyEffect } from '@charcoal/utils'
 import plugin, { TailwindPlugin } from 'tailwindcss/plugin'
 import { mergeEffect } from '../foundation'
 import { CSSVariableName, CSSVariables, Definition, ThemeMap } from '../types'

--- a/packages/tailwind-config/src/colors/toTailwindConfig.test.ts
+++ b/packages/tailwind-config/src/colors/toTailwindConfig.test.ts
@@ -1,5 +1,5 @@
 import { colorsToTailwindConfig } from './toTailwindConfig'
-import { light } from '@pixiv-elements/pixiv-theme'
+import { light } from '@charcoal/pixiv-theme'
 import { mergeEffect } from '../foundation'
 
 describe('colors/colorsToTailwindConfig', () => {

--- a/packages/tailwind-config/src/colors/toTailwindConfig.ts
+++ b/packages/tailwind-config/src/colors/toTailwindConfig.ts
@@ -1,5 +1,5 @@
-import { Material } from '@pixiv-elements/theme'
-import { applyEffect } from '@pixiv-elements/utils'
+import { Material } from '@charcoal/theme'
+import { applyEffect } from '@charcoal/utils'
 import { TailwindConfig } from 'tailwindcss/tailwind-config'
 import { MergedEffect } from '../foundation'
 

--- a/packages/tailwind-config/src/colors/utils.ts
+++ b/packages/tailwind-config/src/colors/utils.ts
@@ -1,4 +1,4 @@
-import { GradientMaterial, Material } from '@pixiv-elements/theme'
+import { GradientMaterial, Material } from '@charcoal/theme'
 
 export const COLOR_PREFIX = '--tailwind-color-'
 

--- a/packages/tailwind-config/src/foundation.ts
+++ b/packages/tailwind-config/src/foundation.ts
@@ -1,4 +1,4 @@
-import { Theme, Effect } from '@pixiv-elements/theme'
+import { Theme, Effect } from '@charcoal/theme'
 
 export const GRID_COUNT = 12
 

--- a/packages/tailwind-config/src/gradient/plugin.ts
+++ b/packages/tailwind-config/src/gradient/plugin.ts
@@ -1,11 +1,11 @@
 import plugin from 'tailwindcss/plugin'
 import { camelToKebab, flatMapObject, mapKeys, mapObject } from '../util'
-import { GradientMaterial, ThemeColorGradient } from '@pixiv-elements/theme'
+import { GradientMaterial, ThemeColorGradient } from '@charcoal/theme'
 import {
   applyEffectToGradient,
   gradient,
   GradientDirection,
-} from '@pixiv-elements/utils'
+} from '@charcoal/utils'
 import { Values } from '../types'
 import { MergedEffect } from '../foundation'
 

--- a/packages/tailwind-config/src/index.test.ts
+++ b/packages/tailwind-config/src/index.test.ts
@@ -1,6 +1,6 @@
 import { TailwindBuild } from './_lib/TailwindBuild'
 import { createTailwindConfig } from '.'
-import { dark, light } from '@pixiv-elements/pixiv-theme'
+import { dark, light } from '@charcoal/pixiv-theme'
 
 describe('tailwind.config.js', () => {
   const defaultConfig = createTailwindConfig({

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -15,9 +15,9 @@ import {
   spacing,
   borderRadius,
   breakpoint,
-} from '@pixiv-elements/foundation'
-import { light } from '@pixiv-elements/pixiv-theme'
-import { px } from '@pixiv-elements/utils'
+} from '@charcoal/foundation'
+import { light } from '@charcoal/pixiv-theme'
+import { px } from '@charcoal/utils'
 import { colorsToTailwindConfig } from './colors/toTailwindConfig'
 
 import cssVariableColorPlugin from './colors/plugin'

--- a/packages/tailwind-config/src/types.ts
+++ b/packages/tailwind-config/src/types.ts
@@ -1,4 +1,4 @@
-import { Material, Theme } from '@pixiv-elements/theme'
+import { Material, Theme } from '@charcoal/theme'
 
 export type TailwindVersion = 'v1' | 'v2' | 'v3'
 

--- a/packages/tailwind-config/src/typography/plugin.ts
+++ b/packages/tailwind-config/src/typography/plugin.ts
@@ -3,8 +3,8 @@ import {
   halfLeading,
   typography,
   TypographyDescriptor,
-} from '@pixiv-elements/foundation'
-import { px } from '@pixiv-elements/utils'
+} from '@charcoal/foundation'
+import { px } from '@charcoal/utils'
 import { mapObject } from '../util'
 
 const leadingCancel = {

--- a/packages/tailwind-diff-cli/package.json
+++ b/packages/tailwind-diff-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/tailwind-diff",
+  "name": "@charcoal/tailwind-diff",
   "version": "1.0.1",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/theme",
+  "name": "@charcoal/theme",
   "version": "4.0.0",
   "license": "UNLICENSED",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pixiv-elements/utils",
+  "name": "@charcoal/utils",
   "version": "3.0.0",
   "license": "UNLICENSED",
   "type": "module",
@@ -24,7 +24,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@pixiv-elements/theme": "^4.0.0",
+    "@charcoal/theme": "^4.0.0",
     "polished": "^4.1.4"
   },
   "files": [

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,7 +8,7 @@ import {
   GradientMaterial,
   OpacityEffect,
   ReplaceEffect,
-} from '@pixiv-elements/theme'
+} from '@charcoal/theme'
 
 export const GRADIENT_DIRECTIONS = [
   'to top',
@@ -85,7 +85,7 @@ function applySingleEffect(baseColor: string, effect: Effect): string {
       throw new RangeError(
         `Unknown effect type ${
           (effect as Effect).type
-        }, upgrade @pixiv-elements/utils`
+        }, upgrade @charcoal/utils`
       )
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,7 @@
     "declaration": true,
     "declarationMap": true,
     "paths": {
-      "@pixiv-elements/*": ["./packages/*/src"]
+      "@charcoal/*": ["./packages/*/src"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,6 +1591,261 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@charcoal/foundation@^1.0.0, @charcoal/foundation@workspace:packages/foundation":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/foundation@workspace:packages/foundation"
+  dependencies:
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    rimraf: ^3.0.2
+    typescript: ^4.5.5
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/icons-cli@workspace:packages/icons-cli":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/icons-cli@workspace:packages/icons-cli"
+  dependencies:
+    "@gitbeaker/core": ^25.6.0
+    "@gitbeaker/node": ^25.6.0
+    "@octokit/rest": ^18.12.0
+    "@types/fs-extra": ^9.0.13
+    "@types/jsdom": ^16.2.14
+    "@types/parse5": ^6.0.3
+    "@types/svgo": ^1.3.3
+    "@types/yargs": ^17.0.8
+    camelcase: ^6.3.0
+    figma-js: ^1.14.0
+    fs-extra: ^10.0.0
+    got: ^11.8.3
+    jsdom: ^19.0.0
+    microbundle: ^0.14.2
+    p-queue: ^6.6.2
+    path-to-regexp: ^6.2.0
+    polished: ^4.1.4
+    rimraf: ^3.0.2
+    svgo: ^1.3.2
+    typescript: ^4.5.5
+    yargs: ^17.3.1
+  bin:
+    icons-cli: ./dist/index.cjs
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/icons@^1.0.1, @charcoal/icons@workspace:packages/icons":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/icons@workspace:packages/icons"
+  dependencies:
+    "@types/jest": ^27.4.0
+    "@types/react": ^17.0.38
+    lit-html: ^2.1.2
+    microbundle: ^0.14.2
+    react: ^17.0.2
+    rimraf: ^3.0.2
+    styled-components: ^5.3.3
+    typescript: ^4.5.5
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/pixiv-theme@^5.0.0, @charcoal/pixiv-theme@workspace:packages/pixiv-theme":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/pixiv-theme@workspace:packages/pixiv-theme"
+  dependencies:
+    "@charcoal/foundation": ^1.0.0
+    "@charcoal/theme": ^4.0.0
+    "@types/react": ^17.0.38
+    "@types/styled-components": ^5.1.21
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    polished: ^4.1.4
+    react: ^17.0.2
+    rimraf: ^3.0.2
+    styled-components: ^5.3.3
+    typescript: ^4.5.5
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/react-sandbox@workspace:packages/react-sandbox":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/react-sandbox@workspace:packages/react-sandbox"
+  dependencies:
+    "@charcoal/foundation": ^1.0.0
+    "@charcoal/pixiv-theme": ^5.0.0
+    "@charcoal/react": ^1.0.1
+    "@charcoal/styled": ^3.0.1
+    "@charcoal/utils": ^3.0.0
+    "@storybook/addon-actions": ^6.4.17
+    "@storybook/addon-knobs": ^6.4.0
+    "@storybook/addons": ^6.4.17
+    "@storybook/api": ^6.4.17
+    "@storybook/components": ^6.4.17
+    "@storybook/core-events": ^6.4.17
+    "@storybook/react": ^6.4.17
+    "@storybook/theming": ^6.4.17
+    "@testing-library/jest-dom": ^5.16.1
+    "@testing-library/react": ^12.1.2
+    "@testing-library/user-event": ^13.5.0
+    "@types/jest": ^27.4.0
+    "@types/jest-axe": ^3.5.3
+    "@types/react": ^17.0.38
+    "@types/react-router-dom": ^5.3.3
+    "@types/styled-components": ^5.1.21
+    "@types/warning": ^3.0.0
+    jest-axe: ^5.0.1
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    polished: ^4.1.4
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-router-dom: ^6.2.1
+    react-spring: ^9.4.2
+    rimraf: ^3.0.2
+    styled-components: ^5.3.3
+    typescript: ^4.5.5
+    warning: ^4.0.3
+  peerDependencies:
+    react: ">=16.13.1"
+    react-dom: ">=16.13.1"
+    react-spring: ^9.0.0-beta.34
+    styled-components: ">=5.1.1"
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/react@^1.0.1, @charcoal/react@workspace:packages/react":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/react@workspace:packages/react"
+  dependencies:
+    "@charcoal/icons": ^1.0.1
+    "@charcoal/pixiv-theme": ^5.0.0
+    "@charcoal/styled": ^3.0.1
+    "@charcoal/utils": ^3.0.0
+    "@react-aria/checkbox": ^3.2.3
+    "@react-aria/switch": ^3.1.3
+    "@react-aria/textfield": ^3.5.0
+    "@react-aria/visually-hidden": ^3.2.3
+    "@react-types/switch": ^3.1.2
+    "@storybook/addon-actions": ^6.4.17
+    "@storybook/addon-knobs": ^6.4.0
+    "@storybook/addons": ^6.4.17
+    "@storybook/api": ^6.4.17
+    "@storybook/components": ^6.4.17
+    "@storybook/core-events": ^6.4.17
+    "@storybook/react": ^6.4.17
+    "@storybook/theming": ^6.4.17
+    "@testing-library/jest-dom": ^5.16.1
+    "@testing-library/react": ^12.1.2
+    "@testing-library/user-event": ^13.5.0
+    "@types/jest": ^27.4.0
+    "@types/jest-axe": ^3.5.3
+    "@types/react": ^17.0.38
+    "@types/react-dom": ^17.0.11
+    "@types/react-router-dom": ^5.3.3
+    "@types/styled-components": ^5.1.21
+    "@types/warning": ^3.0.0
+    jest-axe: ^5.0.1
+    jest-styled-components: ^7.0.8
+    microbundle: ^0.14.2
+    polished: ^4.1.4
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-router-dom: ^6.2.1
+    react-stately: ^3.11.0
+    rimraf: ^3.0.2
+    styled-components: ^5.3.3
+    typescript: ^4.5.5
+    warning: ^4.0.3
+  peerDependencies:
+    react: ">=16.13.1"
+    styled-components: ">=5.1.1"
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/styled@^3.0.1, @charcoal/styled@workspace:packages/styled":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/styled@workspace:packages/styled"
+  dependencies:
+    "@charcoal/foundation": ^1.0.0
+    "@charcoal/pixiv-theme": ^5.0.0
+    "@charcoal/theme": ^4.0.0
+    "@charcoal/utils": ^3.0.0
+    "@types/react": ^17.0.38
+    "@types/styled-components": ^5.1.21
+    "@types/warning": ^3.0.0
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    polished: ^4.1.4
+    react: ^17.0.2
+    rimraf: ^3.0.2
+    styled-components: ^5.3.3
+    typescript: ^4.5.5
+    warning: ^4.0.3
+  peerDependencies:
+    react: ">=16.13.1"
+    styled-components: ">=5.1.1"
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/tailwind-config@workspace:packages/tailwind-config":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/tailwind-config@workspace:packages/tailwind-config"
+  dependencies:
+    "@charcoal/foundation": ^1.0.0
+    "@charcoal/pixiv-theme": ^5.0.0
+    "@charcoal/theme": ^4.0.0
+    "@charcoal/utils": ^3.0.0
+    microbundle: ^0.14.2
+    postcss: ^8.4.5
+    postcss-selector-parser: ^6.0.9
+    rimraf: ^3.0.2
+    tailwindcss: ^3.0.5
+    typescript: ^4.5.5
+  peerDependencies:
+    csstype: ">=3.0.0"
+    postcss: ">=7.0.32"
+    tailwindcss: ^1.4.6
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/tailwind-diff@workspace:packages/tailwind-diff-cli":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/tailwind-diff@workspace:packages/tailwind-diff-cli"
+  dependencies:
+    "@types/tailwindcss": ^2.2.4
+    "@types/yargs": ^17.0.8
+    import-from: ^4.0.0
+    postcss: ^8.4.5
+    postcss-selector-parser: ^6.0.9
+    typescript: ^4.5.5
+    yargs: ^17.3.1
+  bin:
+    tailwind-diff: bin/tailwind-diff.js
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/theme@^4.0.0, @charcoal/theme@workspace:packages/theme":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/theme@workspace:packages/theme"
+  dependencies:
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    rimraf: ^3.0.2
+    typescript: ^4.5.5
+  languageName: unknown
+  linkType: soft
+
+"@charcoal/utils@^3.0.0, @charcoal/utils@workspace:packages/utils":
+  version: 0.0.0-use.local
+  resolution: "@charcoal/utils@workspace:packages/utils"
+  dependencies:
+    "@charcoal/theme": ^4.0.0
+    microbundle: ^0.14.2
+    npm-run-all: ^4.1.5
+    polished: ^4.1.4
+    rimraf: ^3.0.2
+    typescript: ^4.5.5
+  languageName: unknown
+  linkType: soft
+
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
   resolution: "@cnakazawa/watch@npm:1.0.4"
@@ -3501,261 +3756,6 @@ __metadata:
   checksum: f122b9aee8f6baddd515e34a0913e73b21d4bc82d6ee59d77a8aaf01b4a02c10867dd013003d087a83dc96db23511893669015af6d30c27cece185e21cf1df89
   languageName: node
   linkType: hard
-
-"@pixiv-elements/foundation@^1.0.0, @pixiv-elements/foundation@workspace:packages/foundation":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/foundation@workspace:packages/foundation"
-  dependencies:
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    rimraf: ^3.0.2
-    typescript: ^4.5.5
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/icons-cli@workspace:packages/icons-cli":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/icons-cli@workspace:packages/icons-cli"
-  dependencies:
-    "@gitbeaker/core": ^25.6.0
-    "@gitbeaker/node": ^25.6.0
-    "@octokit/rest": ^18.12.0
-    "@types/fs-extra": ^9.0.13
-    "@types/jsdom": ^16.2.14
-    "@types/parse5": ^6.0.3
-    "@types/svgo": ^1.3.3
-    "@types/yargs": ^17.0.8
-    camelcase: ^6.3.0
-    figma-js: ^1.14.0
-    fs-extra: ^10.0.0
-    got: ^11.8.3
-    jsdom: ^19.0.0
-    microbundle: ^0.14.2
-    p-queue: ^6.6.2
-    path-to-regexp: ^6.2.0
-    polished: ^4.1.4
-    rimraf: ^3.0.2
-    svgo: ^1.3.2
-    typescript: ^4.5.5
-    yargs: ^17.3.1
-  bin:
-    icons-cli: ./dist/index.cjs
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/icons@^1.0.1, @pixiv-elements/icons@workspace:packages/icons":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/icons@workspace:packages/icons"
-  dependencies:
-    "@types/jest": ^27.4.0
-    "@types/react": ^17.0.38
-    lit-html: ^2.1.2
-    microbundle: ^0.14.2
-    react: ^17.0.2
-    rimraf: ^3.0.2
-    styled-components: ^5.3.3
-    typescript: ^4.5.5
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/pixiv-theme@^5.0.0, @pixiv-elements/pixiv-theme@workspace:packages/pixiv-theme":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/pixiv-theme@workspace:packages/pixiv-theme"
-  dependencies:
-    "@pixiv-elements/foundation": ^1.0.0
-    "@pixiv-elements/theme": ^4.0.0
-    "@types/react": ^17.0.38
-    "@types/styled-components": ^5.1.21
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    polished: ^4.1.4
-    react: ^17.0.2
-    rimraf: ^3.0.2
-    styled-components: ^5.3.3
-    typescript: ^4.5.5
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/react-sandbox@workspace:packages/react-sandbox":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/react-sandbox@workspace:packages/react-sandbox"
-  dependencies:
-    "@pixiv-elements/foundation": ^1.0.0
-    "@pixiv-elements/pixiv-theme": ^5.0.0
-    "@pixiv-elements/react": ^1.0.1
-    "@pixiv-elements/styled": ^3.0.1
-    "@pixiv-elements/utils": ^3.0.0
-    "@storybook/addon-actions": ^6.4.17
-    "@storybook/addon-knobs": ^6.4.0
-    "@storybook/addons": ^6.4.17
-    "@storybook/api": ^6.4.17
-    "@storybook/components": ^6.4.17
-    "@storybook/core-events": ^6.4.17
-    "@storybook/react": ^6.4.17
-    "@storybook/theming": ^6.4.17
-    "@testing-library/jest-dom": ^5.16.1
-    "@testing-library/react": ^12.1.2
-    "@testing-library/user-event": ^13.5.0
-    "@types/jest": ^27.4.0
-    "@types/jest-axe": ^3.5.3
-    "@types/react": ^17.0.38
-    "@types/react-router-dom": ^5.3.3
-    "@types/styled-components": ^5.1.21
-    "@types/warning": ^3.0.0
-    jest-axe: ^5.0.1
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    polished: ^4.1.4
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    react-router-dom: ^6.2.1
-    react-spring: ^9.4.2
-    rimraf: ^3.0.2
-    styled-components: ^5.3.3
-    typescript: ^4.5.5
-    warning: ^4.0.3
-  peerDependencies:
-    react: ">=16.13.1"
-    react-dom: ">=16.13.1"
-    react-spring: ^9.0.0-beta.34
-    styled-components: ">=5.1.1"
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/react@^1.0.1, @pixiv-elements/react@workspace:packages/react":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/react@workspace:packages/react"
-  dependencies:
-    "@pixiv-elements/icons": ^1.0.1
-    "@pixiv-elements/pixiv-theme": ^5.0.0
-    "@pixiv-elements/styled": ^3.0.1
-    "@pixiv-elements/utils": ^3.0.0
-    "@react-aria/checkbox": ^3.2.3
-    "@react-aria/switch": ^3.1.3
-    "@react-aria/textfield": ^3.5.0
-    "@react-aria/visually-hidden": ^3.2.3
-    "@react-types/switch": ^3.1.2
-    "@storybook/addon-actions": ^6.4.17
-    "@storybook/addon-knobs": ^6.4.0
-    "@storybook/addons": ^6.4.17
-    "@storybook/api": ^6.4.17
-    "@storybook/components": ^6.4.17
-    "@storybook/core-events": ^6.4.17
-    "@storybook/react": ^6.4.17
-    "@storybook/theming": ^6.4.17
-    "@testing-library/jest-dom": ^5.16.1
-    "@testing-library/react": ^12.1.2
-    "@testing-library/user-event": ^13.5.0
-    "@types/jest": ^27.4.0
-    "@types/jest-axe": ^3.5.3
-    "@types/react": ^17.0.38
-    "@types/react-dom": ^17.0.11
-    "@types/react-router-dom": ^5.3.3
-    "@types/styled-components": ^5.1.21
-    "@types/warning": ^3.0.0
-    jest-axe: ^5.0.1
-    jest-styled-components: ^7.0.8
-    microbundle: ^0.14.2
-    polished: ^4.1.4
-    react: ^17.0.2
-    react-dom: ^17.0.2
-    react-router-dom: ^6.2.1
-    react-stately: ^3.11.0
-    rimraf: ^3.0.2
-    styled-components: ^5.3.3
-    typescript: ^4.5.5
-    warning: ^4.0.3
-  peerDependencies:
-    react: ">=16.13.1"
-    styled-components: ">=5.1.1"
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/styled@^3.0.1, @pixiv-elements/styled@workspace:packages/styled":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/styled@workspace:packages/styled"
-  dependencies:
-    "@pixiv-elements/foundation": ^1.0.0
-    "@pixiv-elements/pixiv-theme": ^5.0.0
-    "@pixiv-elements/theme": ^4.0.0
-    "@pixiv-elements/utils": ^3.0.0
-    "@types/react": ^17.0.38
-    "@types/styled-components": ^5.1.21
-    "@types/warning": ^3.0.0
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    polished: ^4.1.4
-    react: ^17.0.2
-    rimraf: ^3.0.2
-    styled-components: ^5.3.3
-    typescript: ^4.5.5
-    warning: ^4.0.3
-  peerDependencies:
-    react: ">=16.13.1"
-    styled-components: ">=5.1.1"
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/tailwind-config@workspace:packages/tailwind-config":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/tailwind-config@workspace:packages/tailwind-config"
-  dependencies:
-    "@pixiv-elements/foundation": ^1.0.0
-    "@pixiv-elements/pixiv-theme": ^5.0.0
-    "@pixiv-elements/theme": ^4.0.0
-    "@pixiv-elements/utils": ^3.0.0
-    microbundle: ^0.14.2
-    postcss: ^8.4.5
-    postcss-selector-parser: ^6.0.9
-    rimraf: ^3.0.2
-    tailwindcss: ^3.0.5
-    typescript: ^4.5.5
-  peerDependencies:
-    csstype: ">=3.0.0"
-    postcss: ">=7.0.32"
-    tailwindcss: ^1.4.6
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/tailwind-diff@workspace:packages/tailwind-diff-cli":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/tailwind-diff@workspace:packages/tailwind-diff-cli"
-  dependencies:
-    "@types/tailwindcss": ^2.2.4
-    "@types/yargs": ^17.0.8
-    import-from: ^4.0.0
-    postcss: ^8.4.5
-    postcss-selector-parser: ^6.0.9
-    typescript: ^4.5.5
-    yargs: ^17.3.1
-  bin:
-    tailwind-diff: bin/tailwind-diff.js
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/theme@^4.0.0, @pixiv-elements/theme@workspace:packages/theme":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/theme@workspace:packages/theme"
-  dependencies:
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    rimraf: ^3.0.2
-    typescript: ^4.5.5
-  languageName: unknown
-  linkType: soft
-
-"@pixiv-elements/utils@^3.0.0, @pixiv-elements/utils@workspace:packages/utils":
-  version: 0.0.0-use.local
-  resolution: "@pixiv-elements/utils@workspace:packages/utils"
-  dependencies:
-    "@pixiv-elements/theme": ^4.0.0
-    microbundle: ^0.14.2
-    npm-run-all: ^4.1.5
-    polished: ^4.1.4
-    rimraf: ^3.0.2
-    typescript: ^4.5.5
-  languageName: unknown
-  linkType: soft
 
 "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.1":
   version: 0.5.4
@@ -18687,10 +18687,10 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "pixiv-elements@workspace:."
   dependencies:
+    "@charcoal/icons-cli": "workspace:packages/icons-cli"
     "@commitlint/cli": ^16.1.0
     "@commitlint/config-conventional": ^16.0.0
     "@commitlint/config-lerna-scopes": ^16.0.0
-    "@pixiv-elements/icons-cli": "workspace:packages/icons-cli"
     "@storybook/addon-a11y": ^6.4.17
     "@storybook/addon-essentials": ^6.4.17
     "@storybook/addon-knobs": ^6.4.0


### PR DESCRIPTION
## やったこと

- すべての `@pixiv-elements/` を `@charcoal/` に置換する

## 動作確認環境

とりあえず yarn install が通ることを確認。その他の環境は特になし

## バージョニング

<!-- yarn lerna version --conventional-commits --no-git-tag-version --no-push -->

```
Changes:
 - @charcoal/foundation: 1.0.0 => 1.0.1
 - @charcoal/icons-cli: 1.0.0 => 1.0.1
 - @charcoal/icons: 1.0.1 => 1.0.2
 - @charcoal/pixiv-theme: 5.0.0 => 5.0.1
 - @charcoal/react-sandbox: 1.0.1 => 1.0.2
 - @charcoal/react: 1.0.1 => 1.0.2
 - @charcoal/styled: 3.0.1 => 3.0.2
 - @charcoal/tailwind-config: 4.0.0 => 4.0.1
 - @charcoal/tailwind-diff: 1.0.1 => 1.0.2
 - @charcoal/theme: 4.0.0 => 4.0.1
 - @charcoal/utils: 3.0.0 => 3.0.1
```

{+ 破壊的変更なし +}

とりあえず lerna version でパッケージ名が変わることを確認

ある意味破壊的だけど……

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 追加したコンポーネントが index.ts から再 export されている