### PR TITLE
fix(tailwind-config): spreading Set<string> does not result in string[]

### DIFF
--- a/packages/tailwind-config/src/util.ts
+++ b/packages/tailwind-config/src/util.ts
@@ -38,7 +38,7 @@ export function getVariantOption(
 }
 
 function setEquals<T>(a: Set<T>, b: Set<T>) {
-  return a.size === b.size && [...a].every((value) => b.has(value))
+  return a.size === b.size && Array.from(a).every((value) => b.has(value))
 }
 
 export function assertAllThemeHaveSameKeys(themeMap: ThemeMap): void {
@@ -53,15 +53,15 @@ export function assertAllThemeHaveSameKeys(themeMap: ThemeMap): void {
     if (!setEquals(colorKeys, expectedColorKeys)) {
       throw new Error(`:root and ${name} does not have same colors.
 
-Expected( :root ): ${JSON.stringify([...expectedColorKeys])}
-Got: ${JSON.stringify([...colorKeys])}`)
+Expected( :root ): ${JSON.stringify(Array.from(expectedColorKeys))}
+Got: ${JSON.stringify(Array.from(colorKeys))}`)
     }
 
     if (!setEquals(effectKeys, expectedEffectKeys)) {
       throw new Error(`:root and ${name} does not have same effects.
 
-Expected( :root ): ${JSON.stringify([...expectedEffectKeys])}
-Got: ${JSON.stringify([...effectKeys])}`)
+Expected( :root ): ${JSON.stringify(Array.from(expectedEffectKeys))}
+Got: ${JSON.stringify(Array.from(effectKeys))}`)
     }
   }
 }


### PR DESCRIPTION
## 問題

tailwind-config をアップデートすると次のエラーが起こると報告があった。

```
Tailwind CSS: :root and :root does not have same colors. Expected( :root ): [{}] Got: [{}]
```

実際にリポジトリ内で以下を実行すると、require した瞬間に同じエラーをはいて死ぬことがわかった。

```
$ node

Welcome to Node.js v16.5.0.
Type ".help" for more information.
> require("@pixiv-elements/tailwind-config")

Uncaught Error: :root and :root does not have same colors.

Expected( :root ): [{}]
Got: [{}]
    at /Users/f_subal/Development/elements/packages/tailwind-config/dist/index.cjs:1:4072
```

## 原因

tailwind-config には `assertAllThemeHaveSameKeys` という関数がある。

新しい tailwind-config は次のように複数のテーマを渡すことができるが、これらが違うスキーマを持っていると困るので、同じキーを持っているかを検証する。

これは createTailwindConfig の先頭で呼ばれる（ そしてデフォルトの config はこれを呼んだ結果の返り値なので、 import した瞬間に呼ばれることになる。 ）

```ts
  const config = createTailwindConfig({
    version: 'v3',
    theme: {
      ':root': light,
      '@media (prefers-color-scheme: dark)': dark,
    },
  })
```

`assertAllThemeHaveSameKeys` はテーマの colors や effects のキーを `Set<string>` で表現し、2つずつ比較する。

```ts
function setEquals<T>(a: Set<T>, b: Set<T>) {
  return a.size === b.size && [...a].every((value) => b.has(value))
}
```

ここに一見何の問題もないように見えるが、なんとビルド結果の JS が以下のようになっていた。

```js
function setEquals(a, b) {
  return a.size === b.size && [].concat(a).every((value) => b.has(value))
}
```

<img width="871" alt="スクリーンショット_2022-02-28_10 39 16" src="https://user-images.githubusercontent.com/5250706/156364574-9e467c31-cbb9-4450-9151-30b3ecf99ed6.png">

`Array.prototype.concat` は引数に Array が渡されれば配列同士の結合になるが、そうでない値が渡ると push のような挙動をする。

```js
[].concat([1]) // => [1]
[].concat(new Set([1])) // => [new Set(1)]
```

これにより、先のコードは `Set<string>[]` と `string[]` の比較を中でやることになり、常に false となる。

## やったこと

microbundle が babel の loose mode を使っている（意図的に）のでこれはしょうがないことらしい。

https://github.com/developit/microbundle/issues/894#issuecomment-918262646

ビルドしないと起こらない問題なので、型エラーやユニットテストで気づくのは無理。

とりあえず Array.from になおしてみる。

## 動作確認環境

直した後に `yarn build` を実行し、もう一度 node REPL で require をする。

```
$ node

Welcome to Node.js v16.5.0.
Type ".help" for more information.
> require("@pixiv-elements/tailwind-config").config
{
  theme: {
    screens: {
      screen1: '0px',
      screen2: '744px',
      screen3: '952px',
      screen4: '1160px',
      screen5: '1368px'
    },
...
```

こうなった。

## バージョニング

`yarn lerna version --conventional-commits --no-git-tag-version --no-push`

```
Changes:
 - @pixiv-elements/tailwind-config: 4.0.0 => 4.0.1
```

{+ 破壊的変更なし +}

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 追加したコンポーネントが index.ts から再 export されている