### PR TITLE
icons-cli: GitHubClient が PR の作成に失敗する

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -7,8 +7,6 @@ on:
 
   workflow_dispatch:
 
-  push:
-
 jobs:
   icons:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## やったこと

- icons-cli の GitHubClient が PR の作成に失敗する
- どうやらコミットの作成には成功するが、そのコミットがどのブランチにも属さない状態になっていそう
- この状態で PR を作ろうとすると、main となんの差もない、1コミットもないブランチに対する PR を作成する形になり、エラーとなる

正しくは、`octokit.createCommit` の後に `updateRef` でブランチを渡す必要がある。

##  やらないこと

https://github.com/pixiv/charcoal/pull/9#issuecomment-1060518342 の件は別途何とかする

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 追加したコンポーネントが index.ts から再 export されている
