### PR TITLE
UNLICENSED => Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "@pixiv-elements monorepo",
   "author": "pixiv",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/foundation",
   "version": "1.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/icons-cli",
   "version": "1.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/icons",
   "version": "1.0.1",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/pixiv-theme/package.json
+++ b/packages/pixiv-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/pixiv-theme",
   "version": "5.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/react-sandbox",
   "version": "1.0.1",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/react",
   "version": "1.0.1",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/styled",
   "version": "3.0.1",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/tailwind-config",
   "version": "4.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/tailwind-diff-cli/examples/npm/package.json
+++ b/packages/tailwind-diff-cli/examples/npm/package.json
@@ -7,7 +7,7 @@
     "build": "tailwind build source.css -o dump.css"
   },
   "author": "",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "devDependencies": {
     "autoprefixer": "^10.3.4",
     "postcss": "^8.3.6",

--- a/packages/tailwind-diff-cli/examples/yarn/package.json
+++ b/packages/tailwind-diff-cli/examples/yarn/package.json
@@ -7,7 +7,7 @@
     "build": "tailwind build source.css -o dump.css"
   },
   "author": "",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "devDependencies": {
     "autoprefixer": "^10.3.4",
     "postcss": "^8.3.6",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/theme",
   "version": "4.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixiv-elements/utils",
   "version": "3.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## やったこと

https://github.com/pixiv/charcoal/commit/15bb49dd9d6dc002bb5f98427d92edd15736047b で LICENSE を追加した際に package.json の license 欄を変更し忘れていた。

同様に Apache-2.0 に変更する

## 動作確認環境

## バージョニング

<!-- yarn lerna version --conventional-commits --no-git-tag-version --no-push -->

```

```

{+ 破壊的変更なし +} / {- 破壊的変更あり -}

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 追加したコンポーネントが index.ts から再 export されている
