### PR TITLE
icons-cli: secrets.GITHUB_TOKEN をやめて GitHub App Token を使う

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -49,9 +49,16 @@ jobs:
       - name: Optimize
         run: ./icons-cli-optimize.sh
 
+      - name: Generate github token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.CHARCOAL_BOT_APP_ID }}
+          private_key: ${{ secrets.CHARCOAL_BOT_PRIVATE_KEY }}
+
       - name: Create a Pull Request
         env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACCESS_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: main


### PR DESCRIPTION
## やったこと

GitHub Actionsで Figma から取ってきたアイコンから自動で Pull Request を作っている。

現状の secrets.GITHUB_TOKEN で作った PR だとその中で CI が実行されないという問題がある。
（ workflow が別の workflow を再帰的に起動できない制限のため ）

- https://sue445.hatenablog.com/entry/2020/08/31/081447
- https://zenn.dev/suzutan/articles/how-to-use-github-apps-token-in-github-actions

GitHub Apps を用いてチーム管理 Token を払い出し、Personal Access Token に依存することなく、secrets.GITHUB_TOKEN の権限を超えて GitHub を操作できるようにする。

## 動作確認環境

マージした後に icons-cli が動けば OK

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
