### PR TITLE
ルートのpackage.jsonのバージョンだけbumpされないので壊れる問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "fmt:prettier": "prettier . --write",
     "fmt:stylelint": "stylelint '**/*.{css,jsx,tsx}' --fix -f verbose",
     "release": "yarn run clean && yarn run build && lerna publish",
-    "version": "yarn install && git stage yarn.lock",
+    "postpublish": "./postpublish.sh",
     "website": "docsify serve docs -p 5000"
   },
   "devDependencies": {

--- a/postpublish.sh
+++ b/postpublish.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+default_branch=`git remote show origin | grep 'HEAD branch' | awk '{print $NF}'`
+
+if [[ $default_branch = `git symbolic-ref --short HEAD` ]]; then
+  yarn install
+
+  if [[ `git status --porcelain | grep yarn.lock` ]]; then
+    git add yarn.lock
+    git commit -m "chore: yarn install after publish"
+    git push origin $default_branch
+  else
+    echo 'No diff found after yarn install'
+  fi
+else
+  echo 'Not in default branch'
+fi


### PR DESCRIPTION
## やったこと

- ルートでワークスペース内のパッケージを利用する場合は`file:`の指定子を使う
- lerna versionのlifecycle hookを使ってpublish時にyarn.lockを更新する

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
