### PR TITLE
<Filter> の story も React Router 関連でコケている

### DIFF
--- a/packages/react-sandbox/src/components/Filter/index.story.tsx
+++ b/packages/react-sandbox/src/components/Filter/index.story.tsx
@@ -7,6 +7,7 @@ import {
   Route,
   useParams,
   useNavigate,
+  Routes,
 } from 'react-router-dom'
 import Filter, { FilterButton, FilterLink } from '.'
 import { ComponentAbstraction } from '@charcoal-ui/react'
@@ -27,7 +28,9 @@ export function Default() {
         initialEntries={Array.from({ length: 5 }).map((_, i) => makeUrl(i + 1))}
         initialIndex={0}
       >
-        <Route path="/:page" element={<FilterButtons />} />
+        <Routes>
+          <Route path="/:page" element={<FilterButtons />} />
+        </Routes>
       </Router>
     </ComponentAbstraction>
   )


### PR DESCRIPTION
## やったこと

関連: #27

おそらく Pager と同じ?理由で `<Filter>`の story もコケている

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
