### PR TITLE
@charcoal-ui/styled のドキュメントを修正

### DIFF
--- a/docs/pages/utilities/styled.md
+++ b/docs/pages/utilities/styled.md
@@ -171,9 +171,11 @@ const StyledText = styled.h1`
   **注意: デフォルトでハーフリーディングを削る処理が入っている**
 
   ハーフリーディングを削る処理
-  ![ハーフリーディングを削る処理](images/styled-with-halfleading.png)
+
+  ![ハーフリーディングを削る処理](images/styled-without-halfleading.png)
 
   本来の処理 (preserveHalfLeading 指定時)
+
   ![本来の処理 (preserveHalfLeading 指定時)](images/styled-with-halfleading.png)
 
   - `typography(number).[...(bold|monospace|preserveHalfLeading)]`

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fmt:stylelint": "stylelint '**/*.{css,jsx,tsx}' --fix -f verbose",
     "release": "yarn run clean && yarn run build && lerna publish",
     "postpublish": "./postpublish.sh",
-    "website": "vite docs --base=docs --port 5000"
+    "website": "vite docs --base=charcoal/docs --port 5000"
   },
   "devDependencies": {
     "@charcoal-ui/icons-cli": "workspace:^",


### PR DESCRIPTION
## やったこと

- @charcoal-ui/styled のドキュメント内の画像URLのパスが間違っていたものを修正
- viteで起動するwebsiteのサーバーのbase pathを更新

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
