### PR TITLE
orgに所属していない人からのPRがきたときにジョブがエラーになっていたのを修正（したつもり）

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,6 +3,9 @@ name: version
 on:
   push:
 
+permissions:
+  contents: write
+
 jobs:
   version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## やったこと

https://github.com/pixiv/charcoal/runs/5769574325?check_suite_focus=true のようにorgに所属していない人からのPRによるビルドでエラーになってたのを修正（したつもり）

https://github.com/pixiv/charcoal/blob/1396b1fda5e4a1201acd5e4da542035a5b211b6b/.github/workflows/version.yml#L50-L61 で行ってるコミットコメントには `contents: write` が必要なので明示的に付与しています。が、この設定が外部の人からのビルドにも適用されるか自身はないです

## 動作確認環境
おそらくこのPR自身もエラーになる可能性があるのでマージ後に動作確認する必要があると思います。

## チェックリスト

