### PR TITLE
chore: run version workflow only on approve

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,10 +1,13 @@
 name: version
 
 on:
-  push:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   version:
+    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == github.event.repository.default_branch
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## やったこと

現在コミットごとに「この状態で yarn publish すると各パッケージのバージョンがどうなるか」をコメントする GitHub Actions （ version.yml ）がいる。

しかし、Pull Request やコミットに対するコメントは readonly な GITHUB_TOKEN を使っていると実行ができない。

具体的には、Dependabot が作成した PR に対して常に version が失敗する状況になっている。

`on: push` で走るワークフローに権限の強いトークンを使わせることは望ましくない（し、多分できない？）ぽいので別の方法を考える。

Maintainer 起因で発火すればよいはずなので、起点を push ではなく PR への approve に変えてみる。

## 動作確認環境

この PR

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
