### PR TITLE
icons-cliにshebangを追加

### DIFF
--- a/packages/icons-cli/src/index.ts
+++ b/packages/icons-cli/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { readFile, writeFile } from 'fs-extra'
 import yargs from 'yargs'
 import { FigmaFileClient } from './FigmaFileClient'


### PR DESCRIPTION
`npx @charcoal-ui/icons-cli` などとしたときにnodeと認識されずにエラーが出てしまう問題を解決したい

```
/Users/xxx/node_modules/.bin/icons-cli: line 1: syntax error near unexpected token `('
/Users/xxx/node_modules/.bin/icons-cli: line 1: `var fsExtra = require('fs-extra');'
```

## やったこと

- icons-cliにshebangを追加

## 動作確認環境

- distに生成されるindex.cjsとindex.modern.jsにshebangがついているのを確認