### PR TITLE
TextFieldの文字数カウントが壊れているのを修正

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -61,7 +61,9 @@ function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
 }
 
 function countStringInCodePoints(string: string) {
-  return [...string].length
+  // [...string] とするとproduction buildで動かなくなる
+  // cf. https://twitter.com/f_subal/status/1497214727511891972
+  return Array.from(string).length
 }
 
 const TextField = React.forwardRef<TextFieldElement, TextFieldProps>(

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -112,11 +112,17 @@ const SingleLineTextField = React.forwardRef<
       if (maxLength !== undefined && count > maxLength) {
         return
       }
-      setCount(count)
+      if (props.value === undefined) {
+        setCount(count)
+      }
       onChange?.(value)
     },
     [maxLength, onChange]
   )
+
+  useEffect(() => {
+    setCount(countStringInCodePoints(props.value ?? ''))
+  }, [props.value])
 
   const { inputProps, labelProps, descriptionProps, errorMessageProps } =
     useTextField(
@@ -238,7 +244,9 @@ const MultiLineTextField = React.forwardRef<
       if (maxLength !== undefined && count > maxLength) {
         return
       }
-      setCount(count)
+      if (props.value === undefined) {
+        setCount(count)
+      }
       if (autoHeight && textareaRef.current !== null) {
         syncHeight(textareaRef.current)
       }
@@ -246,6 +254,10 @@ const MultiLineTextField = React.forwardRef<
     },
     [autoHeight, maxLength, onChange, syncHeight]
   )
+
+  useEffect(() => {
+    setCount(countStringInCodePoints(props.value ?? ''))
+  }, [props.value])
 
   const { inputProps, labelProps, descriptionProps, errorMessageProps } =
     useTextField(

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -106,18 +106,19 @@ const SingleLineTextField = React.forwardRef<
   const [prefixWidth, setPrefixWidth] = useState(0)
   const [suffixWidth, setSuffixWidth] = useState(0)
 
+  const nonControlled = props.value === undefined
   const handleChange = useCallback(
     (value: string) => {
       const count = countCodePointsInString(value)
       if (maxLength !== undefined && count > maxLength) {
         return
       }
-      if (props.value === undefined) {
+      if (nonControlled) {
         setCount(count)
       }
       onChange?.(value)
     },
-    [maxLength, onChange]
+    [maxLength, nonControlled, onChange]
   )
 
   useEffect(() => {
@@ -238,13 +239,14 @@ const MultiLineTextField = React.forwardRef<
     [initialRows]
   )
 
+  const nonControlled = props.value === undefined
   const handleChange = useCallback(
     (value: string) => {
       const count = countCodePointsInString(value)
       if (maxLength !== undefined && count > maxLength) {
         return
       }
-      if (props.value === undefined) {
+      if (nonControlled) {
         setCount(count)
       }
       if (autoHeight && textareaRef.current !== null) {
@@ -252,7 +254,7 @@ const MultiLineTextField = React.forwardRef<
       }
       onChange?.(value)
     },
-    [autoHeight, maxLength, onChange, syncHeight]
+    [autoHeight, maxLength, nonControlled, onChange, syncHeight]
   )
 
   useEffect(() => {

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -60,7 +60,7 @@ function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
   }
 }
 
-function countStringInCodePoints(string: string) {
+function countCodePointsInString(string: string) {
   // [...string] とするとproduction buildで動かなくなる
   // cf. https://twitter.com/f_subal/status/1497214727511891972
   return Array.from(string).length
@@ -102,13 +102,13 @@ const SingleLineTextField = React.forwardRef<
   const ariaRef = useRef<HTMLInputElement>(null)
   const prefixRef = useRef<HTMLSpanElement>(null)
   const suffixRef = useRef<HTMLSpanElement>(null)
-  const [count, setCount] = useState(countStringInCodePoints(props.value ?? ''))
+  const [count, setCount] = useState(countCodePointsInString(props.value ?? ''))
   const [prefixWidth, setPrefixWidth] = useState(0)
   const [suffixWidth, setSuffixWidth] = useState(0)
 
   const handleChange = useCallback(
     (value: string) => {
-      const count = countStringInCodePoints(value)
+      const count = countCodePointsInString(value)
       if (maxLength !== undefined && count > maxLength) {
         return
       }
@@ -121,7 +121,7 @@ const SingleLineTextField = React.forwardRef<
   )
 
   useEffect(() => {
-    setCount(countStringInCodePoints(props.value ?? ''))
+    setCount(countCodePointsInString(props.value ?? ''))
   }, [props.value])
 
   const { inputProps, labelProps, descriptionProps, errorMessageProps } =
@@ -225,7 +225,7 @@ const MultiLineTextField = React.forwardRef<
   const { visuallyHiddenProps } = useVisuallyHidden()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const ariaRef = useRef<HTMLTextAreaElement>(null)
-  const [count, setCount] = useState(countStringInCodePoints(props.value ?? ''))
+  const [count, setCount] = useState(countCodePointsInString(props.value ?? ''))
   const [rows, setRows] = useState(initialRows)
 
   const syncHeight = useCallback(
@@ -240,7 +240,7 @@ const MultiLineTextField = React.forwardRef<
 
   const handleChange = useCallback(
     (value: string) => {
-      const count = countStringInCodePoints(value)
+      const count = countCodePointsInString(value)
       if (maxLength !== undefined && count > maxLength) {
         return
       }
@@ -256,7 +256,7 @@ const MultiLineTextField = React.forwardRef<
   )
 
   useEffect(() => {
-    setCount(countStringInCodePoints(props.value ?? ''))
+    setCount(countCodePointsInString(props.value ?? ''))
   }, [props.value])
 
   const { inputProps, labelProps, descriptionProps, errorMessageProps } =


### PR DESCRIPTION
## やったこと

- Production buildでbabelのloose modeが使われていることが原因で、TextFieldの文字数カウントが常に1になってしまうのを修正した。
- TextFieldのvalue propを変更したときに文字数カウントが更新されないのを修正した。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
