### PR TITLE
<Icon> コンポーネントを react に追加、pixiv-icon を SSR に対応

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/react": "^17.0.38",
+    "@types/warning": "^3.0.0",
     "microbundle": "^0.14.2",
     "react": "^17.0.2",
     "rimraf": "^3.0.2",
@@ -27,7 +28,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "lit-html": "^2.1.2"
+    "lit-html": "^2.1.2",
+    "warning": "^4.0.3"
   },
   "files": [
     "src",

--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -3,6 +3,7 @@ import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js'
 import type React from 'react'
 import { KnownIconFile } from './filenames'
 import { loaders as defaultLoaders, Loader } from './loaders'
+import { BaseElement } from './ssr'
 const { loadFromFile, loadFromRawUrl } = defaultLoaders
 
 const attributes = ['name', 'scale', 'unsafe-non-guideline-scale'] as const
@@ -32,7 +33,7 @@ type Extended = [ExtendedIconFile] extends [never] // NOTE: ExtendedIconFileがn
   ? false
   : true
 
-export class PixivIcon extends HTMLElement {
+export class PixivIcon extends BaseElement {
   static readonly tagName = 'pixiv-icon'
 
   static extend(

--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -1,9 +1,10 @@
 import { html, render } from 'lit-html'
 import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js'
 import type React from 'react'
+import warning from 'warning'
 import { KnownIconFile } from './filenames'
 import { loaders as defaultLoaders, Loader } from './loaders'
-import { BaseElement } from './ssr'
+import { BaseElement, __SERVER__ } from './ssr'
 const { loadFromFile, loadFromRawUrl } = defaultLoaders
 
 const attributes = ['name', 'scale', 'unsafe-non-guideline-scale'] as const
@@ -41,6 +42,11 @@ export class PixivIcon extends BaseElement {
       ? Record<ExtendedIconFile, string>
       : Record<string, string>
   ) {
+    warning(!__SERVER__, 'Using `PixivIcon.extend()` on server has no effect')
+    if (__SERVER__) {
+      return
+    }
+
     Object.entries(map).forEach(([name, url]) => {
       if (!name.includes('/')) {
         throw new TypeError(

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,4 +1,5 @@
 import { PixivIcon, Props } from './PixivIcon'
+import { __SERVER__ } from './ssr'
 export { PixivIcon, type KnownIconType, type Props } from './PixivIcon'
 export { PixivIconLoadError } from './loaders'
 
@@ -15,8 +16,10 @@ declare global {
   }
 }
 
-// TODO: HMR対応
-if (!window.customElements.get(PixivIcon.tagName)) {
-  window.PixivIcon = PixivIcon
-  window.customElements.define(PixivIcon.tagName, PixivIcon)
+if (!__SERVER__) {
+  // TODO: HMR対応
+  if (!window.customElements.get(PixivIcon.tagName)) {
+    window.PixivIcon = PixivIcon
+    window.customElements.define(PixivIcon.tagName, PixivIcon)
+  }
 }

--- a/packages/icons/src/ssr.ts
+++ b/packages/icons/src/ssr.ts
@@ -1,0 +1,12 @@
+export const __SERVER__ = typeof window === 'undefined'
+
+const CAN_USE_DOM = typeof HTMLElement !== 'undefined'
+
+/**
+ * NOTICE: SSR 環境では `extends HTMLElement` できない
+ *
+ * @see https://github.com/vuejs/core/blob/9c304bfe7942a20264235865b4bb5f6e53fdee0d/packages/runtime-dom/src/apiCustomElement.ts#L143-L145
+ */
+export const BaseElement = (
+  !__SERVER__ && CAN_USE_DOM ? HTMLElement : class {}
+) as typeof HTMLElement

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,7 +18,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@charcoal-ui/icons": "^1.0.1-alpha.0",
+    "@charcoal-ui/icons": "workspace:^",
     "@react-types/switch": "^3.1.2",
     "@storybook/addon-actions": "^6.4.17",
     "@storybook/addon-knobs": "^6.4.0",

--- a/packages/react/src/components/Icon/index.story.tsx
+++ b/packages/react/src/components/Icon/index.story.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Icon, { IconProps } from '.'
+import { KNOWN_ICON_FILES } from '../../../../icons/src/filenames'
+import { Story } from '../../_lib/compat'
+
+export default {
+  title: 'Icon',
+  component: Icon,
+  argTypes: {
+    name: {
+      control: {
+        type: 'select',
+        options: KNOWN_ICON_FILES,
+      },
+    },
+    scale: {
+      control: {
+        type: 'select',
+        options: [1, 2, 3],
+      },
+    },
+  },
+}
+
+const Template: Story<IconProps> = (props) => <Icon {...props} />
+
+export const Default: Story<IconProps> = Template.bind({})
+
+Default.args = { name: KNOWN_ICON_FILES[0], scale: 1 }

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import '@charcoal-ui/icons'
+import type { KnownIconType, PixivIcon } from '@charcoal-ui/icons'
+
+export interface IconProps {
+  name: keyof KnownIconType
+  scale?: 1 | 2 | 3
+  unsafeNonGuidelineScale?: number
+  className?: string
+}
+
+const Icon = React.forwardRef<PixivIcon, IconProps>(function IconInner(
+  { name, scale, unsafeNonGuidelineScale, className },
+  ref
+) {
+  return (
+    <pixiv-icon
+      ref={ref}
+      name={name}
+      scale={scale}
+      unsafe-non-guideline-scale={unsafeNonGuidelineScale}
+      class={className}
+    />
+  )
+})
+
+export default Icon

--- a/yarn.lock
+++ b/yarn.lock
@@ -1632,7 +1632,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/icons@^1.0.1-alpha.0, @charcoal-ui/icons@workspace:packages/icons":
+"@charcoal-ui/icons@workspace:^, @charcoal-ui/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/icons@workspace:packages/icons"
   dependencies:
@@ -1697,7 +1697,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/react@workspace:packages/react"
   dependencies:
-    "@charcoal-ui/icons": ^1.0.1-alpha.0
+    "@charcoal-ui/icons": "workspace:^"
     "@charcoal-ui/styled": ^1.0.1-alpha.0
     "@charcoal-ui/theme": ^1.0.0
     "@charcoal-ui/utils": ^1.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,12 +1638,14 @@ __metadata:
   dependencies:
     "@types/jest": ^27.4.0
     "@types/react": ^17.0.38
+    "@types/warning": ^3.0.0
     lit-html: ^2.1.2
     microbundle: ^0.14.2
     react: ^17.0.2
     rimraf: ^3.0.2
     styled-components: ^5.3.3
     typescript: ^4.5.5
+    warning: ^4.0.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## やったこと

#43 のように、共通コンポーネント内で `<pixiv-icon>` を使用すると、`import '@charcoal-ui/icons'` をするタイミングが問題になる（ライブラリがやるか、利用者側がいるか）

理想的には、React を使っているケースならそこをあまり意識せずに使えると良い。

`<Icon>` コンポーネントを用意して、その中で勝手に `import '@charcoal-ui/icons'` が行われるという作りにする。

## 動作確認環境

Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
