### PR TITLE
Use conventional-changelog-conventionalcommits preset for version bumping

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,9 @@
   "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "conventionalCommits": false,
+  "changelogPreset": {
+    "name": "conventionalcommits"
+  },
   "command": {
     "version": {
       "message": "chore: publish [skip ci]"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fmt:eslint": "cross-env DEBUG=eslint:cli-engine eslint . --fix --max-warnings=0",
     "fmt:prettier": "prettier . --write",
     "fmt:stylelint": "stylelint '**/*.{css,jsx,tsx}' --fix -f verbose",
-    "release": "yarn run clean && yarn run build && lerna publish",
+    "release": "yarn run clean && yarn run build && lerna publish --no-changelog",
     "postpublish": "./postpublish.sh",
     "website": "vite docs --base=charcoal/docs --port 5000"
   },


### PR DESCRIPTION
## やったこと

- `conventional-changelog-conventionalcommits` を `changelogPreset` に指定
  - デフォルトでは [Angular Commit Message Conventions](https://github.com/conventional-changelog/conventional-changelog/blob/21b73f974adc4490a318d9c892055655cb82c538/packages/conventional-changelog-angular/parser-opts.js) が使われていて、`feat!:` のような!の指定でBREAKING CHANGE判定になっていなかった
  - `changelogPreset` は changelog の生成とバージョン推論の両方に使われる
  - `--no-changelog` のcli引数で changelog の生成は抑制しつつ、バージョン推論に conventionalcommits が使われるようにした

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
