### PR TITLE
docs: iconsはdevパッケージではないためdevオプションを削除した

### DIFF
--- a/docs/pages/components/icons.md
+++ b/docs/pages/components/icons.md
@@ -7,13 +7,13 @@ SVG アイコンを [Custom Elements](https://developer.mozilla.org/ja/docs/Web/
 npm
 
 ```bash
-npm i --save-dev @charcoal-ui/icons
+npm i @charcoal-ui/icons
 ```
 
 yarn
 
 ```bash
-yarn add -D @charcoal-ui/icons
+yarn add @charcoal-ui/icons
 ```
 
 ### 使い方


### PR DESCRIPTION
## やったこと

- iconsはdevのパッケージではなくdependenciesに入っていてほしいので `--save-dev` と `-D` のオプションをdocsから削除しました

## 動作確認環境

## チェックリスト

- docsだけなので特にありません
