### PR TITLE
docs: add docs for some of the customized Tailwind config

### DIFF
--- a/packages/tailwind-config/src/docs/borderRadius/BorderRadius.tsx
+++ b/packages/tailwind-config/src/docs/borderRadius/BorderRadius.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { borderRadius } from '.'
+
+export const BorderRadius: React.FC = () => {
+  return (
+    <div className="space-y-40">
+      {Object.entries(borderRadius).map(([key, value]) => (
+        <div key={key}>
+          <p className="typography-14 text-text2">rounded-{key}</p>
+          <div className="space-x-16 flex">
+            <div
+              className={`bg-surface4 rounded-${key} h-64`}
+              style={{ width: '64px' }}
+            ></div>
+            <div
+              className={`bg-surface4 rounded-${key} h-64`}
+              style={{ width: '272px' }}
+            ></div>
+          </div>
+          <p className="typography-12 text-text3">
+            border-radius: <span className="text-text2">{value}</span>
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/tailwind-config/src/docs/borderRadius/index.story.mdx
+++ b/packages/tailwind-config/src/docs/borderRadius/index.story.mdx
@@ -1,0 +1,10 @@
+import { Meta, Story } from '@storybook/addon-docs'
+import { BorderRadius } from '.'
+
+<Meta title="tailwind-config/BorderRadius" component={[BorderRadius]} />
+
+# Border radius
+
+<br />
+
+<BorderRadius />

--- a/packages/tailwind-config/src/docs/borderRadius/index.ts
+++ b/packages/tailwind-config/src/docs/borderRadius/index.ts
@@ -1,0 +1,5 @@
+import { config } from '../../'
+
+export const borderRadius = config.theme.borderRadius ?? {}
+
+export { BorderRadius } from './BorderRadius'

--- a/packages/tailwind-config/src/docs/screens/Screens.tsx
+++ b/packages/tailwind-config/src/docs/screens/Screens.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { screens } from '.'
+
+export const Screens: React.FC = () => {
+  return (
+    <div className="space-y-40">
+      {Object.entries(screens).map(
+        ([screenName, value]) =>
+          typeof value === 'string' && (
+            <div key={screenName}>
+              <p className="typography-14 text-text2">{screenName}</p>
+              <div className="bg-surface4 h-64" style={{ width: value }}></div>
+              <p className="typography-12 text-text3">
+                @media (<span className="text-text2">min-width: {value}</span>)
+              </p>
+            </div>
+          )
+      )}
+    </div>
+  )
+}

--- a/packages/tailwind-config/src/docs/screens/index.story.mdx
+++ b/packages/tailwind-config/src/docs/screens/index.story.mdx
@@ -1,0 +1,10 @@
+import { Meta, Story } from '@storybook/addon-docs'
+import { Screens } from '.'
+
+<Meta title="tailwind-config/Screens" component={[Screens]} />
+
+# Screens
+
+<br />
+
+<Screens />

--- a/packages/tailwind-config/src/docs/screens/index.ts
+++ b/packages/tailwind-config/src/docs/screens/index.ts
@@ -1,0 +1,5 @@
+import { config } from '../../'
+
+export const screens = config.theme.screens ?? {}
+
+export { Screens } from './Screens'

--- a/packages/tailwind-config/src/docs/spacing/Spacing.tsx
+++ b/packages/tailwind-config/src/docs/spacing/Spacing.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { spacing } from '.'
+
+export const Spacing: React.FC = () => {
+  return (
+    <div className="space-y-40">
+      {Object.keys(spacing).map((space) => (
+        <div key={space}>
+          <p className="typography-14 text-text2">p-{space}</p>
+          <div className={`bg-surface3 p-${space} w-[min-content]`}>
+            <div className="bg-brand h-40" style={{ width: '40px' }}></div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/tailwind-config/src/docs/spacing/index.story.mdx
+++ b/packages/tailwind-config/src/docs/spacing/index.story.mdx
@@ -1,0 +1,10 @@
+import { Meta, Story } from '@storybook/addon-docs'
+import { Spacing } from '.'
+
+<Meta title="tailwind-config/Spacing" component={[Spacing]} />
+
+# Spacing
+
+<br />
+
+<Spacing />

--- a/packages/tailwind-config/src/docs/spacing/index.ts
+++ b/packages/tailwind-config/src/docs/spacing/index.ts
@@ -1,0 +1,5 @@
+import { config } from '../../'
+
+export const spacing = config.theme.spacing ?? {}
+
+export { Spacing } from './Spacing'


### PR DESCRIPTION
## やったこと

Tailwind config の `spacing` / `borderRadius` / `screens` などのドキュメントを実装した

![image](https://user-images.githubusercontent.com/17699481/165457102-cfd3450a-21a7-4661-96c4-29ada7a7efff.png)

![image](https://user-images.githubusercontent.com/17699481/165457143-ffbb1d23-b883-4efb-9b27-6695542ab8c5.png)

![image](https://user-images.githubusercontent.com/17699481/165457187-fc2ddf7c-1cbc-49cf-95a5-e72d2c3083ab.png)


## 動作確認環境

Storybook

## チェックリスト
