### PR TITLE
icons: SSR 対応を簡単にするため lit-html の利用をやめる

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -15,8 +15,6 @@ const defaultConfig = () => ({
   transform: {
     '^.+\\.(t|j)sx?$': ['esbuild-jest', { target: 'esnext', format: 'cjs' }],
   },
-  // commonjsが提供されていないパッケージをコンパイル
-  transformIgnorePatterns: ['../../node_modules/(?!(lit-html))'],
   // tsconfigのpathsに対応 (依存パッケージをビルドせずにテストが可能)
   moduleNameMapper: {
     '^@charcoal-ui/(.*)$': '<rootDir>/../$1/src',
@@ -30,7 +28,6 @@ const strictConfig = () => ({
   transform: {
     '^.+\\.(t|j)sx?$': 'ts-jest',
   },
-  transformIgnorePatterns: ['../../node_modules/(?!(lit-html))'],
   moduleNameMapper: {
     // TODO: 一貫性のために外したい
     // es5になった`PixivIcon.ts`がjsdomの提供するHTMLElementと互換がないため、したかなくマッピング

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
+    "@types/dompurify": "^2.3.3",
     "@types/jest": "^27.4.0",
     "@types/react": "^17.0.38",
     "microbundle": "^0.14.2",
@@ -27,7 +28,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "lit-html": "^2.1.2"
+    "dompurify": "^2.3.6",
+    "warning": "^4.0.3"
   },
   "files": [
     "src",

--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -1,8 +1,10 @@
-import { html, render } from 'lit-html'
-import { unsafeSVG } from 'lit-html/directives/unsafe-svg.js'
 import type React from 'react'
+import warning from 'warning'
 import { KnownIconFile } from './filenames'
 import { loaders as defaultLoaders, Loader } from './loaders'
+import { BaseElement, __SERVER__ } from './ssr'
+import { sanitize } from 'dompurify'
+
 const { loadFromFile, loadFromRawUrl } = defaultLoaders
 
 const attributes = ['name', 'scale', 'unsafe-non-guideline-scale'] as const
@@ -32,7 +34,7 @@ type Extended = [ExtendedIconFile] extends [never] // NOTE: ExtendedIconFileがn
   ? false
   : true
 
-export class PixivIcon extends HTMLElement {
+export class PixivIcon extends BaseElement {
   static readonly tagName = 'pixiv-icon'
 
   static extend(
@@ -40,6 +42,11 @@ export class PixivIcon extends HTMLElement {
       ? Record<ExtendedIconFile, string>
       : Record<string, string>
   ) {
+    warning(!__SERVER__, 'Using `PixivIcon.extend()` on server has no effect')
+    if (__SERVER__) {
+      return
+    }
+
     Object.entries(map).forEach(([name, url]) => {
       if (!name.includes('/')) {
         throw new TypeError(
@@ -152,26 +159,29 @@ export class PixivIcon extends HTMLElement {
   render() {
     const size = this.forceResizedSize ?? this.scaledSize
 
-    return render(
-      html`
-        <style>
-          :host {
-            display: inline-flex;
-            --size: ${size}px;
-          }
+    const style = sanitize(
+      `<style>
+  :host {
+    display: inline-flex;
+    --size: ${size}px;
+  }
 
-          svg {
-            width: var(--size);
-            height: var(--size);
-          }
-        </style>
-        ${this.svgContent !== undefined
-          ? unsafeSVG(this.svgContent)
-          : html`<svg viewBox="0 0 ${size} ${size}"></svg>`}
-      `,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this.shadowRoot!
+  svg {
+    width: var(--size);
+    height: var(--size);
+  }
+</style>`,
+      { ALLOWED_TAGS: ['style'], FORCE_BODY: true }
     )
+
+    const svg = sanitize(
+      this.svgContent !== undefined
+        ? this.svgContent
+        : `<svg viewBox="0 0 ${size} ${size}"></svg>`,
+      { USE_PROFILES: { svg: true, svgFilters: true } }
+    )
+
+    this.shadowRoot!.innerHTML = style + svg
   }
 
   private update() {

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,4 +1,5 @@
 import { PixivIcon, Props } from './PixivIcon'
+import { __SERVER__ } from './ssr'
 export { PixivIcon, type KnownIconType, type Props } from './PixivIcon'
 export { PixivIconLoadError } from './loaders'
 
@@ -15,8 +16,10 @@ declare global {
   }
 }
 
-// TODO: HMR対応
-if (!window.customElements.get(PixivIcon.tagName)) {
-  window.PixivIcon = PixivIcon
-  window.customElements.define(PixivIcon.tagName, PixivIcon)
+if (!__SERVER__) {
+  // TODO: HMR対応
+  if (!window.customElements.get(PixivIcon.tagName)) {
+    window.PixivIcon = PixivIcon
+    window.customElements.define(PixivIcon.tagName, PixivIcon)
+  }
 }

--- a/packages/icons/src/ssr.ts
+++ b/packages/icons/src/ssr.ts
@@ -1,0 +1,12 @@
+export const __SERVER__ = typeof window === 'undefined'
+
+const CAN_USE_DOM = typeof HTMLElement !== 'undefined'
+
+/**
+ * NOTICE: SSR 環境では `extends HTMLElement` できない
+ *
+ * @see https://github.com/vuejs/core/blob/9c304bfe7942a20264235865b4bb5f6e53fdee0d/packages/runtime-dom/src/apiCustomElement.ts#L143-L145
+ */
+export const BaseElement = (
+  !__SERVER__ && CAN_USE_DOM ? HTMLElement : class {}
+) as typeof HTMLElement

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,14 +1636,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/icons@workspace:packages/icons"
   dependencies:
+    "@types/dompurify": ^2.3.3
     "@types/jest": ^27.4.0
     "@types/react": ^17.0.38
-    lit-html: ^2.1.2
+    dompurify: ^2.3.6
     microbundle: ^0.14.2
     react: ^17.0.2
     rimraf: ^3.0.2
     styled-components: ^5.3.3
     typescript: ^4.5.5
+    warning: ^4.0.3
   languageName: unknown
   linkType: soft
 
@@ -6129,6 +6131,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dompurify@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@types/dompurify@npm:2.3.3"
+  dependencies:
+    "@types/trusted-types": "*"
+  checksum: 427e2dc60d94d13d7860a293b926b376727cb2f545a3334a3f2e7de695a2bb23058dd15108e49e0651378229b443ee8ae0028034b6f2df9a9008c04fb7ad6f8f
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.0":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
@@ -6571,7 +6582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:^2.0.2":
+"@types/trusted-types@npm:*":
   version: 2.0.2
   resolution: "@types/trusted-types@npm:2.0.2"
   checksum: 3371eef5f1c50e1c3c07a127c1207b262ba65b83dd167a1c460fc1b135a3fb0c97b9f508efebd383f239cc5dd5b7169093686a692a501fde9c3f7208657d9b0d
@@ -10771,6 +10782,13 @@ __metadata:
   dependencies:
     domelementtype: ^2.2.0
   checksum: d2a2dbf40dd99abf936b65ad83c6b530afdb3605a87cad37a11b5d9220e68423ebef1b86c89e0f6d93ffaf315cc327cf1a988652e7a9a95cce539e3984f4c64d
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "dompurify@npm:2.3.6"
+  checksum: 4b2bbf6bc68ebd776aec4a533cef74a5ae30391eed528f3df748af71da318afdc298b6f40449bef093b7454ffd2ae82656636560474de5a3b34316b762c85b12
   languageName: node
   linkType: hard
 
@@ -16005,15 +16023,6 @@ fsevents@^1.2.7:
   version: 1.1.6
   resolution: "lines-and-columns@npm:1.1.6"
   checksum: 198a5436b1fa5cf703bae719c01c686b076f0ad7e1aafd95a58d626cabff302dc0414822126f2f80b58a8c3d66cda8a7b6da064f27130f87e1d3506d6dfd0d68
-  languageName: node
-  linkType: hard
-
-"lit-html@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "lit-html@npm:2.1.2"
-  dependencies:
-    "@types/trusted-types": ^2.0.2
-  checksum: 0c87d83b3577dbb0a2c50743296b6600a6872eac2f23b48da7ba3e604b8c72a8b0e1e48cfe0e00dd6f4ca921ab57f97e20709756f2115077478ffb05efa6cea0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
関連 #45 

## やったこと

- icons は Custom Elements として実装されており、現状 lit-html を使っている
- React の SSR で icons を使いたい需要に答えようと思うと lit-html が問題になる
    - lit-html はバリバリ DOM API を使っており、node.js 環境では import しただけでエラーになる
    - lit-labs/ssr というものがあるが、実体は DOM API の polyfill（グローバル変数）を node.js に定義しまくるというもので、あまり Universal に設計する気がなさそう
    - https://github.com/lit/lit/blob/main/packages/labs/ssr/src/lib/dom-shim.ts

というわけで lit-html をやめる。

単純に innerHTML をいじる実装にしつつ、安全のため DOMPurify を使うようにする。PixivIcon のクラスはサーバーサイドでインスタンス化さえしなければ OK という設計にする。

innerHTML 全置換えにした結果レンダリングパフォーマンスが悪化しないかが気になる

## 動作確認環境

Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
