### PR TITLE
chore(react): omit css props from IconProps

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -16,7 +16,7 @@ export interface KnownIconType extends Record<KnownIconFile, unknown> {}
 export interface Props
   extends Omit<
     React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>,
-    'className'
+    'className' | 'css'
   > {
   name: keyof KnownIconType
   scale?: 1 | 2 | 3 | '1' | '2' | '3'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,9 +48,9 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
+    "@charcoal-ui/icons": "^1.0.1-alpha.2",
     "@charcoal-ui/styled": "^1.0.1-alpha.3",
     "@charcoal-ui/theme": "^2.0.0-alpha.2",
-    "@charcoal-ui/icons": "^1.0.1-alpha.2",
     "@charcoal-ui/utils": "^1.0.1-alpha.0",
     "@react-aria/checkbox": "^3.2.3",
     "@react-aria/switch": "^3.1.3",

--- a/packages/react/src/components/Icon/index.story.tsx
+++ b/packages/react/src/components/Icon/index.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Icon, { OwnProps } from '.'
+import Icon, { IconProps } from '.'
 import { KNOWN_ICON_FILES } from '@charcoal-ui/icons'
 import { Story } from '../../_lib/compat'
 
@@ -22,8 +22,8 @@ export default {
   },
 }
 
-const Template: Story<OwnProps> = (props) => <Icon {...props} />
+const Template: Story<IconProps> = (props) => <Icon {...props} />
 
-export const Default: Story<OwnProps> = Template.bind({})
+export const Default: Story<IconProps> = Template.bind({})
 
 Default.args = { name: KNOWN_ICON_FILES[0], scale: 1 }

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -10,7 +10,9 @@ export interface OwnProps {
 
 export interface IconProps
   extends OwnProps,
-    Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css' | 'ref'> {}
+    React.PropsWithoutRef<
+      Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css'>
+    > {}
 
 const Icon = React.forwardRef<PixivIcon, IconProps>(function IconInner(
   { name, scale, unsafeNonGuidelineScale, className, ...rest },

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,17 +1,16 @@
 import React from 'react'
 
 import '@charcoal-ui/icons'
-import type { KnownIconType, PixivIcon, Props } from '@charcoal-ui/icons'
+import type { PixivIcon, Props } from '@charcoal-ui/icons'
 
 export interface OwnProps {
-  name: keyof KnownIconType
-  scale?: 1 | 2 | 3
   unsafeNonGuidelineScale?: number
   className?: string
 }
 
-export type IconProps = OwnProps &
-  Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css'>
+export interface IconProps
+  extends OwnProps,
+    Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css'> {}
 
 const Icon = React.forwardRef<PixivIcon, IconProps>(function IconInner(
   { name, scale, unsafeNonGuidelineScale, className, ...rest },

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -10,7 +10,7 @@ export interface OwnProps {
 
 export interface IconProps
   extends OwnProps,
-    Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css'> {}
+    Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css' | 'ref'> {}
 
 const Icon = React.forwardRef<PixivIcon, IconProps>(function IconInner(
   { name, scale, unsafeNonGuidelineScale, className, ...rest },

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -11,7 +11,7 @@ export interface OwnProps {
 }
 
 export type IconProps = OwnProps &
-  Omit<Props, 'class' | 'unsafe-non-guideline-scale'>
+  Omit<Props, 'class' | 'unsafe-non-guideline-scale' | 'css'>
 
 const Icon = React.forwardRef<PixivIcon, IconProps>(function IconInner(
   { name, scale, unsafeNonGuidelineScale, className, ...rest },


### PR DESCRIPTION
## やったこと

`@charcoal-ui/react` の `<Icon>` に何故か `{ css: unknown }` という必須の props が生えてしまう問題がある。

<img width="615" alt="スクリーンショット 2022-05-19 10 13 27" src="https://user-images.githubusercontent.com/5250706/169181184-00a10ad5-5e19-4957-87a8-8511d941273d.png">

原因は、`IconProps` に `css` が含まれてしまっている（ おそらく根っこには `React.DetailedHTMLProps` に `css` が含まれてしまっている ）こと。

これを除いた型定義にしたい。

### 迷っていること

`@charcoal-ui/react` でだけ Omit するのが良いか、それとも `@charcoal-ui/icons` の方も除いてしまうほうが良いか。

今の所 `@charcoal-ui/react` でしかこの問題は発見されてないが、`@charcoal-ui/icons` を直で `styled-components` と合わせた時に同じ問題が起きうるか？

## 動作確認環境

実は Next.js 環境でしか再現したのを見たことないのでなんか適当にプロジェクトを作る必要がありそう…

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
