### PR TITLE
fix(react-sandbox): TextEllipsis コンポーネントで 2行以上の場合に ellipsis が表示されていなかった

### DIFF
--- a/packages/react-sandbox/src/components/TextEllipsis/index.tsx
+++ b/packages/react-sandbox/src/components/TextEllipsis/index.tsx
@@ -26,7 +26,7 @@ export const TextEllipsis = styled.div.attrs(
           white-space: nowrap;
         `
       : css`
-          display: box;
+          display: -webkit-box;
           -webkit-box-orient: vertical;
           -webkit-line-clamp: ${lineLimit};
           /* Fallback for -webkit-line-clamp */

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -12,6 +12,12 @@ const config = {
         ignoreAtRules: ['tailwind'],
       },
     ],
+    'value-no-vendor-prefix': [
+      true,
+      {
+        ignoreValues: ['box'],
+      },
+    ],
   },
   overrides: [
     {


### PR DESCRIPTION
## やったこと

- TextEllipsis の `display: box` を `display: -webkit-box` に
- stylelint の autofix によって書き換えられてしまっていたので、該当のルールで `-webkit-box` は無視するように
  - https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix/

## 動作確認環境

手元で storybook を立ち上げて確認しました

![スクリーンショット 2022-05-24 18 41 46](https://user-images.githubusercontent.com/28436261/170002089-46f7a0e9-7dbe-45ba-9c3d-83de5220b12e.png)

## チェックリスト

不要なチェック項目は消して構いません

- [ ] ~~破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した~~
- [ ] ~~追加したコンポーネントが index.ts から再 export されている~~
