### PR TITLE
docs(icons): resolving import error in example

### DIFF
--- a/docs/pages/components/icons.md
+++ b/docs/pages/components/icons.md
@@ -51,7 +51,7 @@ TypeScript 環境下では、`KnownIconType` という型を拡張すること�
 くようになります。
 
 ```ts
-import PixivIcon from '@charcoal-ui/icons'
+import { PixivIcon } from '@charcoal-ui/icons'
 import NewFeature from './NewFeature.svg'
 
 PixivIcon.extend({

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -51,7 +51,7 @@ TypeScript 環境下では、`KnownIconType` という型を拡張すること�
 くようになります。
 
 ```ts
-import PixivIcon from '@charcoal-ui/icons'
+import { PixivIcon } from '@charcoal-ui/icons'
 import NewFeature from './NewFeature.svg'
 
 PixivIcon.extend({


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/33891531/170873241-1e61da5b-c8d9-4fa7-96e0-bc250a73174c.png)

## After
![image](https://user-images.githubusercontent.com/33891531/170873265-50c22694-e7fd-4f16-a5b1-376642cdbf65.png)


ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_single_export_from_a_module