### PR TITLE
icons の custom elements が esm bundle (es5) で動作しない問題を修正

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -2,7 +2,7 @@ import type React from 'react'
 import warning from 'warning'
 import { KnownIconFile } from './filenames'
 import { FileLoader, UrlLoader } from './loaders'
-import { BaseElement, __SERVER__ } from './ssr'
+import { __SERVER__ } from './ssr'
 import { sanitize } from 'dompurify'
 
 const attributes = ['name', 'scale', 'unsafe-non-guideline-scale'] as const
@@ -30,7 +30,7 @@ type Extended = [ExtendedIconFile] extends [never] // NOTE: ExtendedIconFileがn
   ? false
   : true
 
-export class PixivIcon extends BaseElement {
+export class PixivIcon extends HTMLElement {
   static readonly tagName = 'pixiv-icon'
 
   static extend(

--- a/packages/icons/src/ssr.ts
+++ b/packages/icons/src/ssr.ts
@@ -2,11 +2,8 @@ export const __SERVER__ = typeof window === 'undefined'
 
 const CAN_USE_DOM = typeof HTMLElement !== 'undefined'
 
-/**
- * NOTICE: SSR 環境では `extends HTMLElement` できない
- *
- * @see https://github.com/vuejs/core/blob/9c304bfe7942a20264235865b4bb5f6e53fdee0d/packages/runtime-dom/src/apiCustomElement.ts#L143-L145
- */
-export const BaseElement = (
-  !__SERVER__ && CAN_USE_DOM ? HTMLElement : class {}
-) as typeof HTMLElement
+// Workaround: `extends HTMLELement` の形式でないとbabelのトランスパイルがおかしくなる
+if (__SERVER__ || !CAN_USE_DOM) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  globalThis.HTMLElement = class {} as any
+}


### PR DESCRIPTION
## やったこと

- `extends HTMLElement` の形状を保つように修正
  - 継承元に式があるパターンでbabelのトランスパイル結果が変わる
- 本質的にはCustom Elementsはes6 classを用いる仕様になっている。しかしes6ターゲットにビルド環境を変更するのが困難であるため、いったん回避策を取ることにした。

#### エラーの概要

index.module.js で以下のエラーが出ていた。これはes5化されたクラスにおいて、ネイティブクラスであるHTMLElementをnew以外の方法でインスタンス化しようとした際にエラーになっている。

```
Unhandled Runtime Error
TypeError: Failed to construct 'HTMLElement': Please use the 'new' operator, this DOM object constructor cannot be called as a function.
```

index.modern.js ではモダンビルドでes6 classが維持されているため、エラーにならない。

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
