### PR TITLE
fix(icons): たとえ this.svgContent があったとしても name が変わったら必ず load

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -151,17 +151,19 @@ export class PixivIcon extends BaseElement {
     _oldValue: string | null,
     newValue: string
   ) {
-    if (attr !== 'name') {
-      this.render()
+    // name が変更された場合必ず再読み込みを試みる
+    if (attr === 'name') {
+      this.loadSvg(newValue)
       return
     }
 
+    // SVG が読み込み済み && scale などの変更だけならそこだけ反映すればいい
     if (this.svgContent !== undefined) {
       this.render()
       return
     }
 
-    // name が変わったときかつまだ取得したことないアイコン名だったときは load する
+    // まだ SVG が読み込めてないなら load
     this.loadSvg(newValue)
   }
 


### PR DESCRIPTION
## やったこと

https://github.com/pixiv/charcoal/pull/57

- icons の中身が一度読み込み済になったあとで name を変更した場合に、中身が変更されてなさそう

## 動作確認環境

そろそろ pixiv-icon のテストを復活させたい…

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
