### PR TITLE
fix(icons): newValue is not a name when attr !== 'name'

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -164,7 +164,7 @@ export class PixivIcon extends HTMLElement {
     }
 
     // まだ SVG が読み込めてないなら load
-    this.loadSvg(newValue)
+    this.loadSvg(this.props.name)
   }
 
   render() {


### PR DESCRIPTION
## やったこと

https://github.com/pixiv/charcoal/pull/64

- loadSvg にはつねに name の内容を渡すべきだが、 name 以外の属性が変わった場合は当該属性の値が渡っている

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
