### PR TITLE
icons: 同一のnameのsvgがロード中の場合にアイコンが描画されないケースの修正

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -199,10 +199,6 @@ export class PixivIcon extends HTMLElement {
   private loadSvg(name: string) {
     const loader = UrlLoader.find(name) ?? FileLoader.findOrRegister(name)
 
-    if (loader.isLoading()) {
-      return
-    }
-
     void this.waitUntilVisible().then(async () => {
       this.svgContent = await loader.fetch()
       this.render()


### PR DESCRIPTION
## やったこと

- 同一のsvgをロードするpromiseが既に存在する場合に描画が走らない問題を修正

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
