### PR TITLE
chore(react-sandbox): カルーセルのスクロール修正

### DIFF
--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -48,6 +48,7 @@ type Props = CarouselAppearanceProps & {
   children: React.ReactNode
   centerItems?: boolean
   onScrollStateChange?: (canScroll: boolean) => void
+  scrollAmountCoef?: number
 }
 
 export interface CarouselHandlerRef {
@@ -64,6 +65,7 @@ export default function Carousel({
   children,
   centerItems,
   onScrollStateChange,
+  scrollAmountCoef = SCROLL_AMOUNT_COEF,
   ...options
 }: Props) {
   // スクロール位置を保存する
@@ -94,24 +96,31 @@ export default function Carousel({
     // スクロール領域を超えないように、アニメーションを開始
     // アニメーション中にアニメーションが開始されたときに、アニメーション終了予定の位置から再度計算するようにする
     const scroll = Math.min(
-      scrollLeft + clientWidth * SCROLL_AMOUNT_COEF,
+      scrollLeft + clientWidth * scrollAmountCoef,
       maxScrollLeft
     )
     setScrollLeft(scroll, true)
     set({ scroll, from: { scroll: scrollLeft }, reset: !animation.current })
     animation.current = true
-  }, [animation, maxScrollLeft, scrollLeft, set, setScrollLeft])
+  }, [
+    animation,
+    maxScrollLeft,
+    scrollLeft,
+    set,
+    scrollAmountCoef,
+    setScrollLeft,
+  ])
 
   const handleLeft = useCallback(() => {
     if (visibleAreaRef.current === null) {
       return
     }
     const { clientWidth } = visibleAreaRef.current
-    const scroll = Math.max(scrollLeft - clientWidth * SCROLL_AMOUNT_COEF, 0)
+    const scroll = Math.max(scrollLeft - clientWidth * scrollAmountCoef, 0)
     setScrollLeft(scroll, true)
     set({ scroll, from: { scroll: scrollLeft }, reset: !animation.current })
     animation.current = true
-  }, [animation, scrollLeft, set, setScrollLeft])
+  }, [animation, scrollLeft, set, scrollAmountCoef, setScrollLeft])
 
   // スクロール可能な場合にボタンを表示する
   // scrollLeftが変化したときに処理する (アニメーション開始時 & 手動スクロール時)
@@ -221,7 +230,7 @@ export default function Carousel({
     const fadeInGradient = options.fadeInGradient ?? false
     const overflowGradient = !fadeInGradient
     return (
-      <Container>
+      <Container ref={visibleAreaRef}>
         <GradientContainer fadeInGradient={fadeInGradient}>
           <RightGradient>
             <LeftGradient show={overflowGradient || scrollLeft > 0}>
@@ -262,7 +271,7 @@ export default function Carousel({
   }
 
   return (
-    <Container>
+    <Container ref={visibleAreaRef}>
       <ScrollArea
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error

--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -83,13 +83,14 @@ export default function Carousel({
   const [styles, set] = useSpring(() => ({ scroll: 0 }))
 
   const ref = useRef<HTMLDivElement>(null)
+  const visibleAreaRef = useRef<HTMLDivElement>(null)
   const innerRef = useRef<HTMLUListElement>(null)
 
   const handleRight = useCallback(() => {
-    if (ref.current === null) {
+    if (visibleAreaRef.current === null) {
       return
     }
-    const { clientWidth } = ref.current
+    const { clientWidth } = visibleAreaRef.current
     // スクロール領域を超えないように、アニメーションを開始
     // アニメーション中にアニメーションが開始されたときに、アニメーション終了予定の位置から再度計算するようにする
     const scroll = Math.min(
@@ -102,10 +103,10 @@ export default function Carousel({
   }, [animation, maxScrollLeft, scrollLeft, set, setScrollLeft])
 
   const handleLeft = useCallback(() => {
-    if (ref.current === null) {
+    if (visibleAreaRef.current === null) {
       return
     }
-    const { clientWidth } = ref.current
+    const { clientWidth } = visibleAreaRef.current
     const scroll = Math.max(scrollLeft - clientWidth * SCROLL_AMOUNT_COEF, 0)
     setScrollLeft(scroll, true)
     set({ scroll, from: { scroll: scrollLeft }, reset: !animation.current })


### PR DESCRIPTION
## やったこと

- カルーセルのスクロール幅の算出基準を画面幅からカルーセルのコンポーネント幅に変更しました。
- スクロール量の割合をpropsで渡せるようにしました。(指定しなかった場合は従来通りの0.75です)

## 動作確認環境

手元で`yarn storybook`を行い確認しました

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
