### PR TITLE
fix(react-sandbox): Next.js環境化で使えるようにisEdgeを関数に

### DIFF
--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -216,7 +216,7 @@ export default function Carousel({
   }, [onScroll])
 
   // NOTE: Edgeではmaskを使うと要素のレンダリングがバグる（場合によっては画像が表示されない）のでグラデーションを無効にする
-  if (!isEdge && options.hasGradient === true) {
+  if (!isEdge() && options.hasGradient === true) {
     const fadeInGradient = options.fadeInGradient ?? false
     const overflowGradient = !fadeInGradient
     return (

--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -215,8 +215,16 @@ export default function Carousel({
     }
   }, [onScroll])
 
+  const [disableGradient, setDisableGradient] = useState(false)
+
+  useLayoutEffect(() => {
+    if (isEdge()) {
+      setDisableGradient(true)
+    }
+  }, [])
+
   // NOTE: Edgeではmaskを使うと要素のレンダリングがバグる（場合によっては画像が表示されない）のでグラデーションを無効にする
-  if (!isEdge() && options.hasGradient === true) {
+  if (!disableGradient && options.hasGradient === true) {
     const fadeInGradient = options.fadeInGradient ?? false
     const overflowGradient = !fadeInGradient
     return (

--- a/packages/react-sandbox/src/foundation/support.ts
+++ b/packages/react-sandbox/src/foundation/support.ts
@@ -26,4 +26,4 @@ export function passiveEvents(): boolean {
   }
 }
 
-export const isEdge = navigator.userAgent.includes('Edge/')
+export const isEdge = () => navigator.userAgent.includes('Edge/')


### PR DESCRIPTION
## やったこと

文脈: Next.js環境化で`@charcoal-ui/recat-sandbox`を使おうとすると`isEdge`を評価しようとして`ReferenceError: navigator is not defined`というエラーが出ていた。

- `isEdge`を関数にして評価を遅延させるように
- CarouselコンポーネントをSSRできるように`useLayoutEffect`の中で`isEdge`を使用
    - ただし`useLayoutEffect`を使うことのwarningは出る
    - 追記: どうやら[これだけではSSRはできない](https://github.com/pixiv/charcoal/pull/71#issuecomment-1156263806)のでSSRする場合さらなる修正が必要

## 動作確認環境

- `yarn build`が通る (WSL2)
- ビルドしたものを該当Next.jsプロジェクトに持っていってエラーが消えることを確認

## チェックリスト

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した

質問: この変更は破壊的変更に含まれますでしょうか？
