### PR TITLE
chore: fix surface9(light) color

### DIFF
--- a/packages/theme/src/default.ts
+++ b/packages/theme/src/default.ts
@@ -98,7 +98,7 @@ export const light: CharcoalTheme = {
     surface6: rgba('#000000', 0.88),
     surface7: rgba('#000000', 0.02),
     surface8: rgba('#000000', 0.88),
-    surface9: rgba('#ffffff', 0.84),
+    surface9: '#ffffff',
     surface10: rgba('#000000', 0.16),
     text1: '#1f1f1f',
     text2: '#474747',


### PR DESCRIPTION
## やったこと

- surface9のlightテーマの色が間違っていたので修正

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
