### PR TITLE
feat(styled): changed theme initialization

### DIFF
--- a/packages/sample/pages/_app.tsx
+++ b/packages/sample/pages/_app.tsx
@@ -4,14 +4,11 @@ import { ThemeProvider } from 'styled-components'
 import { light, dark } from '@charcoal-ui/theme'
 import {
   TokenInjector,
-  initialThemeSetter,
   useTheme,
   useThemeSetter,
   themeSelector,
   prefersColorScheme,
 } from '@charcoal-ui/styled'
-
-initialThemeSetter()
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [theme] = useTheme()

--- a/packages/sample/pages/_document.tsx
+++ b/packages/sample/pages/_document.tsx
@@ -1,8 +1,28 @@
 import React from 'react'
-import Document, { DocumentContext } from 'next/document'
+import Document, {
+  DocumentContext,
+  Html,
+  Head,
+  Main,
+  NextScript,
+} from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
+import { SetThemeScript } from '@charcoal-ui/styled'
 
 export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head>
+          <SetThemeScript />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
   static async getInitialProps(ctx: DocumentContext) {
     const sheet = new ServerStyleSheet()
     const originalRenderPage = ctx.renderPage

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { DEFAULT_ROOT_ATTRIBUTE, LOCAL_STORAGE_KEY } from './helper'
+
+interface Props {
+  localStorageKey: string
+  rootAttribute: string
+}
+
+/**
+ * 同期的にテーマをローカルストレージから取得してhtmlの属性に設定するスクリプトタグ
+ * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
+ * @returns 
+ */
+export function SetThemeScript(props: Props) {
+  const src = `
+(() => {
+    let currentTheme = localStorage.getItem('${props.localStorageKey}')
+    if (currentTheme) {
+        document.documentElement.dataset['${props.rootAttribute}'] = currentTheme
+    }
+})()
+`
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: src,
+      }}
+    />
+  )
+}
+
+const defaultProps: Props = {
+  localStorageKey: LOCAL_STORAGE_KEY,
+  rootAttribute: DEFAULT_ROOT_ATTRIBUTE,
+}
+
+SetThemeScript.defaultProps = defaultProps

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -12,13 +12,21 @@ interface Props {
  * @returns
  */
 export function SetThemeScript(props: Props) {
-  const src = `
-(() => {
-    let currentTheme = localStorage.getItem('${props.localStorageKey}')
+  if (!/^\w((\w|-)+)$/.test(props.localStorageKey)) {
+    throw new Error(`Unexpected localStorageKey ${props.localStorageKey}. expect /^\\w((\\w|-)+)$/`)
+  }
+  if (!/^\w+$/.test(props.rootAttribute)) {
+    throw new Error(`Unexpected rootAttribute ${props.rootAttribute}. expect /^\\w+$/`)
+  }
+  const src = `'use strict';
+(function () {
+    var localStorageKey = '${props.localStorageKey}'
+    var rootAttribute = '${props.rootAttribute}'
+    var currentTheme = localStorage.getItem(localStorageKey);
     if (currentTheme) {
-        document.documentElement.dataset['${props.rootAttribute}'] = currentTheme
+        document.documentElement.dataset[rootAttribute] = currentTheme;
     }
-})()
+})();
 `
 
   return (

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -13,10 +13,14 @@ interface Props {
  */
 export function SetThemeScript(props: Props) {
   if (!/^\w((\w|-)+)$/.test(props.localStorageKey)) {
-    throw new Error(`Unexpected localStorageKey ${props.localStorageKey}. expect /^\\w((\\w|-)+)$/`)
+    throw new Error(
+      `Unexpected localStorageKey ${props.localStorageKey}. expect /^\\w((\\w|-)+)$/`
+    )
   }
   if (!/^\w+$/.test(props.rootAttribute)) {
-    throw new Error(`Unexpected rootAttribute ${props.rootAttribute}. expect /^\\w+$/`)
+    throw new Error(
+      `Unexpected rootAttribute ${props.rootAttribute}. expect /^\\w+$/`
+    )
   }
   const src = `'use strict';
 (function () {

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -9,7 +9,7 @@ interface Props {
 /**
  * 同期的にテーマをローカルストレージから取得してhtmlの属性に設定するスクリプトタグ
  * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
- * @returns 
+ * @returns
  */
 export function SetThemeScript(props: Props) {
   const src = `

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { DEFAULT_ROOT_ATTRIBUTE, LOCAL_STORAGE_KEY } from './helper'
+import {
+  assertKeyString,
+  DEFAULT_ROOT_ATTRIBUTE,
+  LOCAL_STORAGE_KEY,
+} from './helper'
 
 interface Props {
   localStorageKey: string
@@ -12,16 +16,8 @@ interface Props {
  * @returns
  */
 export function SetThemeScript(props: Props) {
-  if (!/^\w((\w|-)+)$/.test(props.localStorageKey)) {
-    throw new Error(
-      `Unexpected localStorageKey ${props.localStorageKey}. expect /^\\w((\\w|-)+)$/`
-    )
-  }
-  if (!/^\w+$/.test(props.rootAttribute)) {
-    throw new Error(
-      `Unexpected rootAttribute ${props.rootAttribute}. expect /^\\w+$/`
-    )
-  }
+  assertKeyString(props.localStorageKey)
+  assertKeyString(props.rootAttribute)
   const src = `'use strict';
 (function () {
     var localStorageKey = '${props.localStorageKey}'

--- a/packages/styled/src/helper.ts
+++ b/packages/styled/src/helper.ts
@@ -3,12 +3,25 @@ import { useEffect, useMemo, useState } from 'react'
 export const LOCAL_STORAGE_KEY = 'charcoal-theme'
 export const DEFAULT_ROOT_ATTRIBUTE = 'theme'
 
+const keyStringRegExp = new RegExp(/^(\w|-)+$/)
+
+/**
+ * 文字列が英数字_-のみで構成されているか検証する。不正な文字列ならエラーを投げる
+ * @param key 検証するキー
+ */
+export function assertKeyString(key: string) {
+  if (!keyStringRegExp.test(key)) {
+    throw new Error(`Unexpected key :${key}, expect: /^(\\w|-)+$/`)
+  }
+}
+
 /**
  * `<html data-theme="dark">` のような設定を行うデフォルトのセッター
  */
 export const themeSetter =
   (attr: string = DEFAULT_ROOT_ATTRIBUTE) =>
   (theme: string | undefined) => {
+    assertKeyString(attr)
     if (theme !== undefined) {
       document.documentElement.dataset[attr] = theme
     } else {
@@ -65,6 +78,7 @@ export function getThemeSync(key: string = LOCAL_STORAGE_KEY) {
  * `dark` `light` という名前だけは特別扱いされていて、prefers-color-schemeにマッチした場合に返ります
  */
 export const useTheme = (key: string = LOCAL_STORAGE_KEY) => {
+  assertKeyString(key)
   const isDark = useMedia('(prefers-color-scheme: dark)')
   const media = isDark !== undefined ? (isDark ? 'dark' : 'light') : undefined
   const [local, setTheme, ready] = useLocalStorage<string>(key)

--- a/packages/styled/src/helper.ts
+++ b/packages/styled/src/helper.ts
@@ -1,25 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 
-const LOCAL_STORAGE_KEY = 'charcoal-theme'
-const DEFAULT_ROOT_ATTRIBUTE = 'theme'
-
-/**
- * LocalStorageからテーマ情報を取得してページロード前に同期的にテーマをセットするヘルパ
- */
-export function initialThemeSetter({
-  key = LOCAL_STORAGE_KEY,
-  setter = themeSetter(),
-}: { key?: string; setter?: (theme: string) => void } = {}) {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/strict-boolean-expressions
-  if (typeof document !== 'undefined') {
-    document.addEventListener('DOMContentLoaded', () => {
-      const theme = getThemeSync(key)
-      if (theme !== null) {
-        setter(theme)
-      }
-    })
-  }
-}
+export const LOCAL_STORAGE_KEY = 'charcoal-theme'
+export const DEFAULT_ROOT_ATTRIBUTE = 'theme'
 
 /**
  * `<html data-theme="dark">` のような設定を行うデフォルトのセッター

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -36,7 +36,6 @@ export { type Modified, type ModifiedArgumented } from './lib'
 export { default as TokenInjector } from './TokenInjector'
 export {
   getThemeSync,
-  initialThemeSetter,
   themeSetter,
   themeSelector,
   prefersColorScheme,
@@ -45,6 +44,7 @@ export {
   useLocalStorage,
   useMedia,
 } from './helper'
+export * from './SetThemeScript'
 
 const colorProperties = ['bg', 'font'] as const
 type ColorProperty = typeof colorProperties[number]


### PR DESCRIPTION
## やったこと
- テーマの初期化方法を変更
  - Next.jsではscriptがdeferなため、DOMContentLoadedより前に描画が実行されることがある。そのためにテーマの初期変更が描画より後に行われてしまう問題を修正。

## 動作確認環境
なし

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
