### PR TITLE
複数行テキストインプットの文字数カウントがテキストとかぶるデザインを修正

### DIFF
--- a/packages/react/src/components/TextField/index.story.tsx
+++ b/packages/react/src/components/TextField/index.story.tsx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions'
 import React from 'react'
-import { css } from 'styled-components'
+import styled from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Clickable from '../Clickable'
 import TextField, {
@@ -24,13 +24,13 @@ export default {
   },
 }
 
+const Container = styled.div`
+  display: grid;
+  gap: ${({ theme }) => px(theme.spacing[24])};
+`
+
 const Template: Story<Partial<TextFieldProps>> = (args) => (
-  <div
-    css={css`
-      display: grid;
-      gap: ${({ theme }) => px(theme.spacing[24])};
-    `}
-  >
+  <Container>
     <TextField
       label="Label"
       requiredText="*必須"
@@ -57,7 +57,7 @@ const Template: Story<Partial<TextFieldProps>> = (args) => (
       {...(args as Partial<MultiLineTextFieldProps>)}
       multiline
     />
-  </div>
+  </Container>
 )
 
 export const Default = Template.bind({})

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -391,7 +391,6 @@ const StyledInput = styled.input<{
 `
 
 const StyledTextareaContainer = styled.div<{ rows: number }>`
-  display: grid;
   position: relative;
 
   ${({ rows }) => css`

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -370,8 +370,6 @@ const StyledInput = styled.input<{
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-top: calc(9px / 0.875);
-  padding-bottom: calc(9px / 0.875);
   padding-left: calc((8px + ${(p) => p.extraLeftPadding}px) / 0.875);
   padding-right: calc((8px + ${(p) => p.extraRightPadding}px) / 0.875);
   border-radius: calc(4px / 0.875);

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -292,11 +292,14 @@ const MultiLineTextField = React.forwardRef<
         {...labelProps}
         {...(!showLabel ? visuallyHiddenProps : {})}
       />
-      <StyledTextareaContainer rows={rows}>
+      <StyledTextareaContainer
+        invalid={invalid}
+        rows={showCount ? rows + 1 : rows}
+      >
         <StyledTextarea
           ref={mergeRefs(textareaRef, forwardRef, ariaRef)}
-          invalid={invalid}
           rows={rows}
+          noBottomPadding={showCount}
           {...inputProps}
         />
         {showCount && <MultiLineCounter>{count}</MultiLineCounter>}
@@ -390,17 +393,30 @@ const StyledInput = styled.input<{
   }
 `
 
-const StyledTextareaContainer = styled.div<{ rows: number }>`
+const StyledTextareaContainer = styled.div<{ rows: number; invalid: boolean }>`
   position: relative;
 
+  ${(p) =>
+    theme((o) => [
+      o.bg.surface3.hover,
+      p.invalid && o.outline.assertive,
+      o.font.text2,
+      o.borderRadius(4),
+    ])}
+
+  padding: 0 8px;
+
+  &:focus-within {
+    ${theme((o) => o.outline.default)}
+  }
+
   ${({ rows }) => css`
-    max-height: calc(22px * ${rows} + 18px);
+    height: calc(22px * ${rows} + 18px);
   `};
 `
 
-const StyledTextarea = styled.textarea<{ invalid: boolean }>`
+const StyledTextarea = styled.textarea<{ noBottomPadding: boolean }>`
   border: none;
-  box-sizing: border-box;
   outline: none;
   resize: none;
   font-family: inherit;
@@ -411,23 +427,16 @@ const StyledTextarea = styled.textarea<{ invalid: boolean }>`
   width: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding: calc(9px / 0.875) calc(8px / 0.875);
-  border-radius: calc(4px / 0.875);
+  padding: calc(9px / 0.875) 0 ${(p) => (p.noBottomPadding ? 0 : '')};
 
-  ${({ rows }) => css`
-    height: calc(22px / 0.875 * ${rows} + 18px / 0.875);
+  ${({ rows = 1 }) => css`
+    height: calc(22px / 0.875 * ${rows});
   `};
 
   /* Display box-shadow for iOS Safari */
   appearance: none;
 
-  ${(p) =>
-    theme((o) => [
-      o.bg.surface3.hover,
-      o.outline.default.focus,
-      p.invalid && o.outline.assertive,
-      o.font.text2,
-    ])}
+  background: none;
 
   &::placeholder {
     ${theme((o) => o.font.text3)}


### PR DESCRIPTION
## やったこと

- 文字数カウント分、テキストインプットの高さを大きくして、テキスト入力エリアと文字数カウントがかぶさらないように修正

https://user-images.githubusercontent.com/1888491/179649608-b58f242e-ded5-4afb-a096-583a18155a48.mov

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
