### PR TITLE
TextField の autoHeight で rows が initialRows に戻らないバグを修正

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -243,7 +243,7 @@ const MultiLineTextField = React.forwardRef<
       const rows = `${textarea.value}\n`.match(/\n/gu)?.length ?? 1
       setRows((prevRows) => {
         if (initialRows <= rows) return rows
-        if (initialRows <= prevRows) return initialRows
+        if (initialRows < prevRows) return initialRows
         return prevRows
       })
     },

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -241,9 +241,11 @@ const MultiLineTextField = React.forwardRef<
   const syncHeight = useCallback(
     (textarea: HTMLTextAreaElement) => {
       const rows = `${textarea.value}\n`.match(/\n/gu)?.length ?? 1
-      if (initialRows <= rows) {
-        setRows(rows)
-      }
+      setRows((prevRows) => {
+        if (initialRows <= rows) return rows
+        if (initialRows <= prevRows) return initialRows
+        return prevRows
+      })
     },
     [initialRows]
   )

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -240,7 +240,7 @@ const MultiLineTextField = React.forwardRef<
 
   const syncHeight = useCallback(
     (textarea: HTMLTextAreaElement) => {
-      const rows = (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
+      const rows = (textarea.value.match(/\n/gu)?.length ?? 0) || 1
       setRows(initialRows <= rows ? rows : initialRows)
     },
     [initialRows]

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -240,7 +240,7 @@ const MultiLineTextField = React.forwardRef<
 
   const syncHeight = useCallback(
     (textarea: HTMLTextAreaElement) => {
-      const rows = (textarea.value.match(/\n/gu)?.length ?? 0) || 1
+      const rows = (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
       setRows(initialRows <= rows ? rows : initialRows)
     },
     [initialRows]

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -240,12 +240,8 @@ const MultiLineTextField = React.forwardRef<
 
   const syncHeight = useCallback(
     (textarea: HTMLTextAreaElement) => {
-      const rows = `${textarea.value}\n`.match(/\n/gu)?.length ?? 1
-      setRows((prevRows) => {
-        if (initialRows <= rows) return rows
-        if (initialRows < prevRows) return initialRows
-        return prevRows
-      })
+      const rows = (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
+      setRows(initialRows <= rows ? rows : initialRows)
     },
     [initialRows]
   )


### PR DESCRIPTION
## やったこと

-  autoHeight を有効にした TextField でテキストをまとめて消すと rows が initialRows に戻らないバグを修正

## 動作確認環境

Storybook で動画のバグが修正されていることを確認してください。

https://user-images.githubusercontent.com/38908416/182281727-a1560e4f-1ebc-40c3-a6d1-b46d70d335f1.mov

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
