### PR TITLE
TextFieldのMultiLineでMaxLengthを表示するように修正

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -192,7 +192,7 @@ const SingleLineTextField = React.forwardRef<
           <Affix>{suffix}</Affix>
           {showCount && (
             <SingleLineCounter>
-              {maxLength ? `${count}/${maxLength}` : count}
+              {maxLength !== undefined ? `${count}/${maxLength}` : count}
             </SingleLineCounter>
           )}
         </SuffixContainer>
@@ -310,7 +310,7 @@ const MultiLineTextField = React.forwardRef<
         />
         {showCount && (
           <MultiLineCounter>
-            {maxLength ? `${count}/${maxLength}` : count}
+            {maxLength !== undefined ? `${count}/${maxLength}` : count}
           </MultiLineCounter>
         )}
       </StyledTextareaContainer>

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -318,8 +318,6 @@ const MultiLineTextField = React.forwardRef<
   )
 })
 
-//const Count = React.FC<Prop>
-
 const TextFieldRoot = styled.div<{ isDisabled: boolean }>`
   display: flex;
   flex-direction: column;

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -190,11 +190,7 @@ const SingleLineTextField = React.forwardRef<
         />
         <SuffixContainer ref={suffixRef}>
           <Affix>{suffix}</Affix>
-          {showCount && maxLength && (
-            <SingleLineCounter>
-              {count}/{maxLength}
-            </SingleLineCounter>
-          )}
+          {showCount && <SingleLineCounter>{maxLength ? `${count}/${maxLength}` : count}</SingleLineCounter> }
         </SuffixContainer>
       </StyledInputContainer>
       {assistiveText != null && assistiveText.length !== 0 && (
@@ -308,7 +304,7 @@ const MultiLineTextField = React.forwardRef<
           noBottomPadding={showCount}
           {...inputProps}
         />
-        {showCount && <MultiLineCounter>{count}</MultiLineCounter>}
+        {showCount && <MultiLineCounter>{maxLength ? `${count}/${maxLength}` : count}</MultiLineCounter> }
       </StyledTextareaContainer>
       {assistiveText != null && assistiveText.length !== 0 && (
         <AssistiveText
@@ -321,6 +317,8 @@ const MultiLineTextField = React.forwardRef<
     </TextFieldRoot>
   )
 })
+
+//const Count = React.FC<Prop>
 
 const TextFieldRoot = styled.div<{ isDisabled: boolean }>`
   display: flex;

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -190,7 +190,11 @@ const SingleLineTextField = React.forwardRef<
         />
         <SuffixContainer ref={suffixRef}>
           <Affix>{suffix}</Affix>
-          {showCount && <SingleLineCounter>{maxLength ? `${count}/${maxLength}` : count}</SingleLineCounter> }
+          {showCount && (
+            <SingleLineCounter>
+              {maxLength ? `${count}/${maxLength}` : count}
+            </SingleLineCounter>
+          )}
         </SuffixContainer>
       </StyledInputContainer>
       {assistiveText != null && assistiveText.length !== 0 && (
@@ -304,7 +308,11 @@ const MultiLineTextField = React.forwardRef<
           noBottomPadding={showCount}
           {...inputProps}
         />
-        {showCount && <MultiLineCounter>{maxLength ? `${count}/${maxLength}` : count}</MultiLineCounter> }
+        {showCount && (
+          <MultiLineCounter>
+            {maxLength ? `${count}/${maxLength}` : count}
+          </MultiLineCounter>
+        )}
       </StyledTextareaContainer>
       {assistiveText != null && assistiveText.length !== 0 && (
         <AssistiveText


### PR DESCRIPTION
## やったこと
- TextFieldコンポーネントにて、showCount==trueの場合に文字数を表示するようにし、maxLengthも指定された場合は最大文字数も表示するように修正しました。

## 動作確認環境
node v16.5.0
Macbook Air M1 (macOS 12.3 Monterey)