### PR TITLE
icons-cliの修正

### DIFF
--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -24,22 +24,21 @@ export async function* getChangedFiles(dir = targetDir) {
 }
 
 async function collectGitStatus() {
-  const map = new Map<string, string | null>()
-  /**
-   * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
-   */
-  const gitStatus = await execp(`git status --porcelain`)
-  gitStatus.split('\n').forEach((s) => {
-    map.set(
-      s.slice(3),
-      s.startsWith(' M')
-        ? 'modified'
-        : s.startsWith('??')
-        ? 'untracked'
-        : s.startsWith(' D')
-        ? 'deleted'
-        : null
-    )
-  })
-  return map
+  return new Map(
+    /**
+     * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
+     */
+    (await execp(`git status --porcelain`)).split('\n').map((s) => {
+      return [
+        s.slice(3),
+        s.startsWith(' M')
+          ? 'modified'
+          : s.startsWith('??')
+          ? 'untracked'
+          : s.startsWith(' D')
+          ? 'deleted'
+          : null,
+      ] as const
+    })
+  )
 }

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -8,37 +8,15 @@ export const targetDir = path.resolve(process.cwd(), 'packages', 'icons')
  * dir 内で変更があったファイル情報を for await で回せるようにするやつ
  */
 export async function* getChangedFiles(dir = targetDir) {
-  const directories = await fs.readdir(dir)
   const gitStatus = await collectGitStatus()
-
-  for (const dir of directories) {
-    const directory = path.resolve(targetDir, dir)
-
-    // eslint-disable-next-line no-await-in-loop
-    const stat = await fs.stat(directory)
-    if (!stat.isDirectory()) {
+  const map = new Map(Object.entries(gitStatus))
+  for (const [relativePath, status] of map) {
+    const fullpath = path.resolve(process.cwd(), relativePath)
+    if (!`${fullpath}`.startsWith(`${dir}/`)) {
       continue
     }
-
-    // eslint-disable-next-line no-await-in-loop
-    const files = await fs.readdir(directory)
-
-    for (const file of files) {
-      const fullpath = path.resolve(targetDir, dir, file)
-      const relativePath = path.relative(process.cwd(), fullpath)
-
-      const status = gitStatus[relativePath]
-      console.log(`${fullpath}: ${status ?? 'null'}`)
-      if (status == null) {
-        // Already up-to-date
-        continue
-      }
-
-      // eslint-disable-next-line no-await-in-loop
-      const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
-
-      yield { relativePath, content, status }
-    }
+    const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
+    yield { relativePath, content, status }
   }
 }
 
@@ -47,20 +25,17 @@ async function collectGitStatus() {
     /**
      * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
      */
-    (await execp(`git status --porcelain`))
-      .split('\n')
-      .map(
-        (s) =>
-          [
-            s.slice(3),
-            s.startsWith(' M')
-              ? 'modified'
-              : s.startsWith('??')
-              ? 'untracked'
-              : s.startsWith(' D')
-              ? 'deleted'
-              : null,
-          ] as const
-      )
+    (await execp(`git status --porcelain`)).split('\n').map((s) => {
+      return [
+        s.slice(3),
+        s.startsWith(' M')
+          ? 'modified'
+          : s.startsWith('??')
+          ? 'untracked'
+          : s.startsWith(' D')
+          ? 'deleted'
+          : null,
+      ] as const
+    })
   )
 }

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -9,7 +9,7 @@ export const targetDir = path.resolve(process.cwd(), 'packages', 'icons')
  */
 export async function* getChangedFiles(dir = targetDir) {
   if (!existsSync(dir))
-    throw new Error(`icons-cli: target directory not found (${targetDir})`)
+    throw new Error(`icons-cli: target directory not found (${dir})`)
   const gitStatus = await collectGitStatus()
   for (const [relativePath, status] of gitStatus) {
     const fullpath = path.resolve(process.cwd(), relativePath)

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -28,6 +28,7 @@ export async function* getChangedFiles(dir = targetDir) {
       const relativePath = path.relative(process.cwd(), fullpath)
 
       const status = gitStatus[relativePath]
+      console.log(`${fullpath}: ${status ?? 'null'}`)
       if (status == null) {
         // Already up-to-date
         continue

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs'
+import { promises as fs, existsSync } from 'fs'
 import path from 'path'
 import { execp } from './utils'
 
@@ -8,13 +8,17 @@ export const targetDir = path.resolve(process.cwd(), 'packages', 'icons')
  * dir 内で変更があったファイル情報を for await で回せるようにするやつ
  */
 export async function* getChangedFiles(dir = targetDir) {
+  if (!existsSync(dir))
+    throw new Error(`icons-cli: target directory not found (${dir})`)
   const gitStatus = await collectGitStatus()
   const map = new Map(Object.entries(gitStatus))
   for (const [relativePath, status] of map) {
     const fullpath = path.resolve(process.cwd(), relativePath)
-    if (!`${fullpath}`.startsWith(`${dir}/`)) {
+    if (!fullpath.startsWith(`${dir}/`)) {
       continue
     }
+    if (!existsSync(fullpath))
+      throw new Error(`icons-cli: could not load svg (${fullpath})`)
     const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
     yield { relativePath, content, status }
   }


### PR DESCRIPTION
## やったこと
- icons-cliが`packages/icons/svg/‘配下が展開されず、PRにファイルの変更が含まれなかった問題を修正しました。
    - ディレクトリの中のファイルを取る処理が1段分しかなく、`svg/16/hoge.svg`のようなファイルの差分を検出できていなかった
    - gitによって変更が検出されたファイルの中でパスの前方が指定ディレクトリと一致するファイルのみをリストする処理に変更しました

## 動作確認環境
手元で確認するか、試しにCIを実行する

### テストで作成したPR
https://github.com/pixiv/charcoal/pull/107