### PR TITLE
ResizeObserver をレンダリングの最中に初期化しない（ SSR のとき困るので ）

### DIFF
--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -162,9 +162,6 @@ export default function Carousel({
     }
   }, [onResize])
 
-  const resizeObserverRef = useRef(new ResizeObserver(handleResize))
-  const resizeObserverInnerRef = useRef(new ResizeObserver(handleResize))
-
   useLayoutEffect(() => {
     const elm = ref.current
     const innerElm = innerRef.current
@@ -178,10 +175,10 @@ export default function Carousel({
       passiveEvents() && { passive: true }
     )
 
-    const resizeObserver = resizeObserverRef.current
+    const resizeObserver = new ResizeObserver(handleResize)
     resizeObserver.observe(elm)
 
-    const resizeObserverInner = resizeObserverInnerRef.current
+    const resizeObserverInner = new ResizeObserver(handleResize)
     resizeObserverInner.observe(innerElm)
 
     return () => {


### PR DESCRIPTION
## やったこと

ref: #71

- ResizeObserver はブラウザ API であり、レンダリングの最中に new すると SSR のときエラーの原因になる
- 素直に useLayoutEffect の中で new したほうが良い

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
