### PR TITLE
storybook の vite build が OOM で落ちることがあるので何とかする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
           yarn typecheck
 
       - name: Check if Storybook builds
+        # storybook の vite build が OOM で落ちることがある
+        # これだけ違う job に分離して強い runner で動かすと良いかも？
         run: |
           yarn build-storybook
           NODE_OPTIONS=--max_old_space_size=8192 yarn cross-env USE_VITE=1 yarn build-storybook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Check if Storybook builds
         run: |
           yarn build-storybook
-          yarn cross-env USE_VITE=1 yarn build-storybook
+          NODE_OPTIONS=--max_old_space_size=8192 yarn cross-env USE_VITE=1 yarn build-storybook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,4 @@ jobs:
         # これだけ違う job に分離して強い runner で動かすと良いかも？
         run: |
           yarn build-storybook
-          NODE_OPTIONS=--max_old_space_size=8192 yarn cross-env USE_VITE=1 yarn build-storybook
+          NODE_OPTIONS=--max_old_space_size=6144 yarn cross-env USE_VITE=1 yarn build-storybook


### PR DESCRIPTION
## やったこと

- ときどき GitHub Actions の test ジョブが落ちる
- storybook の vite build が OOM で落ちるせいっぽいので何とかする
- max_old_space_size を引き上げるみたいな方法と runs_on を変えるみたいな方法がそれぞれ思いつくがどうするか（考え中）

## 動作確認環境

CI

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
