### PR TITLE
ダークテーマのリンクの色を修正

### DIFF
--- a/packages/theme/src/default.ts
+++ b/packages/theme/src/default.ts
@@ -136,7 +136,7 @@ export const dark: CharcoalTheme = {
     background1: '#1f1f1f',
     background2: '#000000',
     icon6: light.color.icon6,
-    link1: light.color.link1,
+    link1: '#669FC2',
     link2: light.color.link2,
     surface1: '#1f1f1f',
     surface2: rgba('#000000', 0.16),


### PR DESCRIPTION
## やったこと
ダークテーマのリンクの色を修正 

closes: #91 

## 動作確認環境
<img width="872" alt="スクリーンショット 2022-09-06 15 11 31" src="https://user-images.githubusercontent.com/35446607/188559988-cd7e8ba4-8895-4a0f-8920-30a173fdb63f.png">
