### PR TITLE
Minificationをやめる

### DIFF
--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -14,7 +14,7 @@
   "bin": "./dist/index.cjs",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json --target node",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json --target node",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": true,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json && yarn serialize",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json && yarn serialize",
     "typecheck": "tsc --noEmit --project tsconfig.build.json && yarn typecheck:cli",
     "typecheck:cli": "tsc --noEmit --project cli/tsconfig.build.json",
     "clean": "rimraf dist",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
   "types": "./dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
-    "build": "microbundle -f modern,esm,cjs --tsconfig tsconfig.build.json",
+    "build": "microbundle --compress=false -f modern,esm,cjs --tsconfig tsconfig.build.json",
     "typecheck": "tsc --noEmit --project tsconfig.build.json",
     "clean": "rimraf dist"
   },


### PR DESCRIPTION
 ## やったこと
 
 - ビルド時にminificationしないようにした
   - minifyすると、charcoalを使用するアプリケーションを開発する際にデバッグが難しくなるため
   - minifyはcharcoalを使用するアプリケーションが行うべきであるため