### PR TITLE
<SSRProvider>を追加

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -15,3 +15,17 @@ yarn
 ```
 yarn add @charcoal-ui/react
 ```
+
+## Server Side Renderingを行う場合の注意点
+
+SSRを行う場合はアプリケーション全体を`<SSRProvider>`で囲む必要があります。
+
+```jsx
+import { SSRProvider } from '@charcoal-ui/react'
+
+<SSRProvider>
+  <App />
+</SSRProvider>
+```
+
+既知の不具合として、Reactの[strict mode](https://reactjs.org/docs/strict-mode.html)が有効化されているとhydration errorが発生します。`@charcoal-ui/react`が依存している`react-aria`の不具合 (adobe/react-spectrum#2231, adobe/react-spectrum#779) によるものです。

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,16 +16,18 @@ yarn
 yarn add @charcoal-ui/react
 ```
 
-## Server Side Renderingを行う場合の注意点
+## Server Side Rendering を行う場合の注意点
 
-SSRを行う場合はアプリケーション全体を`<SSRProvider>`で囲む必要があります。
+SSR を行う場合はアプリケーション全体を`<SSRProvider>`で囲む必要があります。
 
 ```jsx
 import { SSRProvider } from '@charcoal-ui/react'
 
-<SSRProvider>
-  <App />
-</SSRProvider>
+const App = () => (
+  <SSRProvider>
+    <Page />
+  </SSRProvider>
+)
 ```
 
-既知の不具合として、Reactの[strict mode](https://reactjs.org/docs/strict-mode.html)が有効化されているとhydration errorが発生します。`@charcoal-ui/react`が依存している`react-aria`の不具合 (adobe/react-spectrum#2231, adobe/react-spectrum#779) によるものです。
+既知の不具合として、React の[strict mode](https://reactjs.org/docs/strict-mode.html)が有効化されていると hydration error が発生します。`@charcoal-ui/react`が依存している`react-aria`の不具合 (adobe/react-spectrum#2231, adobe/react-spectrum#779) によるものです。

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,6 +56,7 @@
     "@react-aria/dialog": "^3.2.1",
     "@react-aria/focus": "^3.6.1",
     "@react-aria/overlays": "^3.9.1",
+    "@react-aria/ssr": "^3.3.0",
     "@react-aria/switch": "^3.1.3",
     "@react-aria/textfield": "^3.5.0",
     "@react-aria/visually-hidden": "^3.2.3",

--- a/packages/react/src/core/SSRProvider.tsx
+++ b/packages/react/src/core/SSRProvider.tsx
@@ -1,0 +1,1 @@
+export { SSRProvider } from '@react-aria/ssr'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ export {
   useComponentAbstraction,
   type LinkProps,
 } from './core/ComponentAbstraction'
+export { SSRProvider } from './core/SSRProvider'
 export { default as Button, type ButtonProps } from './components/Button'
 export {
   default as Clickable,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2051,6 +2051,7 @@ __metadata:
     "@react-aria/dialog": ^3.2.1
     "@react-aria/focus": ^3.6.1
     "@react-aria/overlays": ^3.9.1
+    "@react-aria/ssr": ^3.3.0
     "@react-aria/switch": ^3.1.3
     "@react-aria/textfield": ^3.5.0
     "@react-aria/visually-hidden": ^3.2.3
@@ -4564,25 +4565,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/ssr@npm:^3.0.3, @react-aria/ssr@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@react-aria/ssr@npm:3.1.0"
-  dependencies:
-    "@babel/runtime": ^7.6.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1
-  checksum: ae376d45dbd19e990891353a2eee10c13f3b54dbd807a2e528928983741c0ea9dbfefcc132c46c685e53440a53f7be82bd36a5c61bdfaec3c3518f02ae444e7f
-  languageName: node
-  linkType: hard
-
-"@react-aria/ssr@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@react-aria/ssr@npm:3.2.0"
+"@react-aria/ssr@npm:^3.0.3, @react-aria/ssr@npm:^3.1.0, @react-aria/ssr@npm:^3.2.0, @react-aria/ssr@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@react-aria/ssr@npm:3.3.0"
   dependencies:
     "@babel/runtime": ^7.6.2
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 30468b436f9d56636eb3fb89cbbbf861c55ad841e255e529d225a0efd9c23628badaee72c42ab3870b5f17a9d5b5163564a64e9b928565230a090cb4f7de23bf
+  checksum: 0b7677ef521c65452460601dce3c264b67baa75ef7c99e9755ea55913765054156b6157c9c42e3d56aba86d1704b8b2aeb7672e4084f2f375fe1ec481e33c8c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 ## やったこと
 
 - `<SSRProvider>`コンポーネントを追加した
   - react-ariaを使用するとき、SSRを行う場合はアプリケーション全体を`<SSRProvider>`で囲む必要がある
   - 現在はcharcoalを使用するアプリケーションがreact-ariaから`SSRProvider`をimportしなければいけない
   - これは変なので、charcoalから`<SSRProvider>`を再exportするようにした