### PR TITLE
tailwind-config が npm v7 以降で peer deps エラーが発生しインストールできないバグを修正

### DIFF
--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "csstype": ">=3.0.0",
     "postcss": ">=7.0.32",
-    "tailwindcss": "^1.4.6"
+    "tailwindcss": ">=1.4.6"
   },
   "files": [
     "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,7 +2153,7 @@ __metadata:
   peerDependencies:
     csstype: ">=3.0.0"
     postcss: ">=7.0.32"
-    tailwindcss: ^1.4.6
+    tailwindcss: ">=1.4.6"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## やったこと

- tailwindcss のバージョン指定を `~1.4.6` から `>=1.4.6` に修正
