### PR TITLE
refactor(icons-cli): optimize regexp for icon name

### DIFF
--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -36,8 +36,7 @@ function filenamify(name: string) {
   return camelCase(name, { pascalCase: true }).replace(' ', '')
 }
 
-// eslint-disable-next-line prefer-named-capture-group
-const iconName = /^(\d|Inline)+\s*\/\s*/u
+const iconName = /^(?:\d+|Inline)\s*\//u
 
 function isIconNode(node: Figma.Node) {
   return iconName.test(node.name)


### PR DESCRIPTION
## やったこと

- アイコン名（`Inline/Add`, `16/Check`など）にマッチする正規表現を調整した
  - `(\d|Inline)+`を `(\d+|Inline)`に変更
  - non-capturing groupに変更
  - 末尾の`\s*`は無意味なので削除

## 動作確認環境

`icons-cli`を実行してdiffが出ないことを確認した
