### PR TITLE
refactor(icons-cli): refactor figma URL parsing

### DIFF
--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -6,30 +6,20 @@ import got from 'got'
 import { match } from 'path-to-regexp'
 import { concurrently } from './concurrently'
 
-const extractor = match<{ file: string; name: string }>('/file/:file/:name')
+const matchPath = match<{ fileId: string; name: string }>('/file/:fileId/:name')
 
-function extractFileId(url: string) {
-  const result = extractor(new URL(url).pathname)
+function extractParams(url: string): { fileId: string; nodeId?: string } {
+  const { pathname, searchParams } = new URL(url)
+
+  const result = matchPath(pathname)
   if (result === false) {
-    throw new Error('no :file in url')
+    throw new Error('No fileId found in url')
   }
 
-  return result.params.file
-}
-
-function extractNodeId(url: string) {
-  if (!url.includes('?')) {
-    return undefined
+  return {
+    fileId: result.params.fileId,
+    nodeId: searchParams.get('node-id') ?? undefined,
   }
-
-  const [, query] = url.split('?')
-  const params = new URLSearchParams(query)
-  const nodeId = params.get('node-id')
-  if (nodeId === null) {
-    return undefined
-  }
-
-  return decodeURIComponent(nodeId)
 }
 
 function filenamify(name: string) {
@@ -86,8 +76,10 @@ export class FigmaFileClient {
       personalAccessToken,
     })
 
-    this.fileId = extractFileId(url)
-    this.nodeId = extractNodeId(url)
+    const { fileId, nodeId } = extractParams(url)
+    this.fileId = fileId
+    this.nodeId = nodeId
+
     this.exportFormat = exportFormat
   }
 


### PR DESCRIPTION
## やったこと

- FigmaのURLをパースする処理を、`fileId`と`nodeId`で別々に行うのではなく同時に行うようにした

## 動作確認環境

icons-cliを実行してdiffが出ないことを確認した