### PR TITLE
fix(icons-cli): svg optimize

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Optimize
         env:
           OUTPUT_ROOT_DIR: ${{ secrets.OUTPUT_ROOT_DIR }}
-        run: yarn icons-cli source:generate --ignoreFile ./misc/icons-cli-denylist
+        run: yarn icons-cli svg:optimize --ignoreFile ./misc/icons-cli-denylist
 
       - name: Generate source
         env:


### PR DESCRIPTION
## やったこと
- icons-cliのCIで `svg:optimize` を走らせていなかったので、走らせるように修正した

## 動作確認環境
GitHub Actionsの `icons` を見てください
