### PR TITLE
feat: add makeSetThemeScriptCode

### DIFF
--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -9,9 +9,9 @@
   "dependencies": {
     "@charcoal-ui/react": "^2.0.0-alpha.22",
     "@charcoal-ui/react-sandbox": "^2.0.0-alpha.11",
-    "@charcoal-ui/styled": "^2.0.0-alpha.5",
+    "@charcoal-ui/styled": "../styled",
     "@charcoal-ui/theme": "^2.0.0-alpha.7",
-    "next": "^12.1.6",
+    "next": "12.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "styled-components": "^5.3.3"

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -11,7 +11,7 @@
     "@charcoal-ui/react-sandbox": "^2.0.0-alpha.11",
     "@charcoal-ui/styled": "workspace:^",
     "@charcoal-ui/theme": "^2.0.0-alpha.7",
-    "next": "12.3.2",
+    "next": "^12.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "styled-components": "^5.3.3"

--- a/packages/sample/package.json
+++ b/packages/sample/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@charcoal-ui/react": "^2.0.0-alpha.22",
     "@charcoal-ui/react-sandbox": "^2.0.0-alpha.11",
-    "@charcoal-ui/styled": "../styled",
+    "@charcoal-ui/styled": "workspace:^",
     "@charcoal-ui/theme": "^2.0.0-alpha.7",
     "next": "12.3.2",
     "react": "^17.0.2",

--- a/packages/sample/pages/_document.tsx
+++ b/packages/sample/pages/_document.tsx
@@ -7,14 +7,18 @@ import Document, {
   NextScript,
 } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
-import { SetThemeScript } from '@charcoal-ui/styled'
+import Script from 'next/script'
+import { makeSetThemeScriptCode } from '@charcoal-ui/styled'
 
 export default class MyDocument extends Document {
   render() {
+    const setThemeScript = makeSetThemeScriptCode()
     return (
       <Html>
         <Head>
-          <SetThemeScript />
+          <Script id="set-theme-script" strategy="beforeInteractive">
+            {setThemeScript}
+          </Script>
         </Head>
         <body>
           <Main />

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -11,14 +11,14 @@ interface Props {
 }
 
 /**
- * 同期的にテーマをローカルストレージから取得してhtmlの属性に設定するスクリプトタグ
+ * 同期的にテーマをローカルストレージから取得してhtmlの属性に設定するコードを取得する
  * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
- * @returns
+ * @returns ソースコードの文字列
  */
-export function SetThemeScript(props: Props) {
+export function makeSetThemeScriptCode(props: Props) {
   assertKeyString(props.localStorageKey)
   assertKeyString(props.rootAttribute)
-  const src = `'use strict';
+  return `'use strict';
 (function () {
     var localStorageKey = '${props.localStorageKey}'
     var rootAttribute = '${props.rootAttribute}'
@@ -28,7 +28,15 @@ export function SetThemeScript(props: Props) {
     }
 })();
 `
+}
 
+/**
+ * 同期的にテーマをローカルストレージから取得してhtmlの属性に設定するスクリプトタグ
+ * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
+ * @returns
+ */
+export function SetThemeScript(props: Props) {
+  const src = makeSetThemeScriptCode(props)
   return (
     <script
       dangerouslySetInnerHTML={{

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -15,13 +15,16 @@ interface Props {
  * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
  * @returns ソースコードの文字列
  */
-export function makeSetThemeScriptCode(props: Props = defaultProps) {
-  assertKeyString(props.localStorageKey)
-  assertKeyString(props.rootAttribute)
+export function makeSetThemeScriptCode({
+  localStorageKey = defaultProps.localStorageKey,
+  rootAttribute = defaultProps.rootAttribute,
+}: Partial<Props> = defaultProps) {
+  assertKeyString(localStorageKey)
+  assertKeyString(rootAttribute)
   return `'use strict';
 (function () {
-    var localStorageKey = '${props.localStorageKey}'
-    var rootAttribute = '${props.rootAttribute}'
+    var localStorageKey = '${localStorageKey}'
+    var rootAttribute = '${rootAttribute}'
     var currentTheme = localStorage.getItem(localStorageKey);
     if (currentTheme) {
         document.documentElement.dataset[rootAttribute] = currentTheme;

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -15,7 +15,7 @@ interface Props {
  * @param props localStorageのキー、htmlのdataになる属性のキーを含むオブジェクト
  * @returns ソースコードの文字列
  */
-export function makeSetThemeScriptCode(props: Props) {
+export function makeSetThemeScriptCode(props: Props = defaultProps) {
   assertKeyString(props.localStorageKey)
   assertKeyString(props.rootAttribute)
   return `'use strict';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,7 +2105,7 @@ __metadata:
   dependencies:
     "@charcoal-ui/react": ^2.0.0-alpha.22
     "@charcoal-ui/react-sandbox": ^2.0.0-alpha.11
-    "@charcoal-ui/styled": ../styled
+    "@charcoal-ui/styled": "workspace:^"
     "@charcoal-ui/theme": ^2.0.0-alpha.7
     "@types/node": ^18.0.0
     "@types/react": ^17.0.38
@@ -2120,7 +2120,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/styled@^2.0.0-alpha.5, @charcoal-ui/styled@workspace:packages/styled":
+"@charcoal-ui/styled@^2.0.0-alpha.5, @charcoal-ui/styled@workspace:^, @charcoal-ui/styled@workspace:packages/styled":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/styled@workspace:packages/styled"
   dependencies:
@@ -2142,21 +2142,6 @@ __metadata:
     styled-components: ">=5.1.1"
   languageName: unknown
   linkType: soft
-
-"@charcoal-ui/styled@file:../styled::locator=%40charcoal-ui%2Fsample%40workspace%3Apackages%2Fsample":
-  version: 2.0.0-alpha.5
-  resolution: "@charcoal-ui/styled@file:../styled#../styled::hash=3ad892&locator=%40charcoal-ui%2Fsample%40workspace%3Apackages%2Fsample"
-  dependencies:
-    "@charcoal-ui/foundation": ^1.0.1-alpha.1
-    "@charcoal-ui/theme": ^2.0.0-alpha.7
-    "@charcoal-ui/utils": ^1.1.0-alpha.2
-    warning: ^4.0.3
-  peerDependencies:
-    react: ">=16.13.1"
-    styled-components: ">=5.1.1"
-  checksum: cc177df462aa498165b3a1e616c49c00ca440682f0d5dee8c613d2049e33e51a3db832de937f6a99b71561f467cd0b311d2f1db2b5f0c34c87dac9964819629a
-  languageName: node
-  linkType: hard
 
 "@charcoal-ui/tailwind-config@workspace:packages/tailwind-config":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,14 +2105,14 @@ __metadata:
   dependencies:
     "@charcoal-ui/react": ^2.0.0-alpha.22
     "@charcoal-ui/react-sandbox": ^2.0.0-alpha.11
-    "@charcoal-ui/styled": ^2.0.0-alpha.5
+    "@charcoal-ui/styled": ../styled
     "@charcoal-ui/theme": ^2.0.0-alpha.7
     "@types/node": ^18.0.0
     "@types/react": ^17.0.38
     "@types/react-dom": ^17.0.11
     "@types/styled-components": ^5.1.21
     babel-plugin-styled-components: ^2.0.7
-    next: ^12.1.6
+    next: 12.3.2
     react: ^17.0.2
     react-dom: ^17.0.2
     styled-components: ^5.3.3
@@ -2142,6 +2142,21 @@ __metadata:
     styled-components: ">=5.1.1"
   languageName: unknown
   linkType: soft
+
+"@charcoal-ui/styled@file:../styled::locator=%40charcoal-ui%2Fsample%40workspace%3Apackages%2Fsample":
+  version: 2.0.0-alpha.5
+  resolution: "@charcoal-ui/styled@file:../styled#../styled::hash=3ad892&locator=%40charcoal-ui%2Fsample%40workspace%3Apackages%2Fsample"
+  dependencies:
+    "@charcoal-ui/foundation": ^1.0.1-alpha.1
+    "@charcoal-ui/theme": ^2.0.0-alpha.7
+    "@charcoal-ui/utils": ^1.1.0-alpha.2
+    warning: ^4.0.3
+  peerDependencies:
+    react: ">=16.13.1"
+    styled-components: ">=5.1.1"
+  checksum: cc177df462aa498165b3a1e616c49c00ca440682f0d5dee8c613d2049e33e51a3db832de937f6a99b71561f467cd0b311d2f1db2b5f0c34c87dac9964819629a
+  languageName: node
+  linkType: hard
 
 "@charcoal-ui/tailwind-config@workspace:packages/tailwind-config":
   version: 0.0.0-use.local
@@ -4005,93 +4020,100 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/env@npm:12.1.6"
-  checksum: e6a4f189f0d653d13dc7ad510f6c9d2cf690bfd9e07c554bd501b840f8dabc3da5adcab874b0bc01aab86c3647cff4fb84692e3c3b28125af26f0b05cd4c7fcf
+"@next/env@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/env@npm:12.3.2"
+  checksum: 668aba397427dd5d19563844274ae7425c99db890e36d2262b9d107122a85500634518fdb916562b3c8a298de983183e241717b535d975df4c997baaa4730ddf
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm-eabi@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-android-arm-eabi@npm:12.1.6"
+"@next/swc-android-arm-eabi@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-android-arm-eabi@npm:12.3.2"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-android-arm64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-android-arm64@npm:12.1.6"
+"@next/swc-android-arm64@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-android-arm64@npm:12.3.2"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-darwin-arm64@npm:12.1.6"
+"@next/swc-darwin-arm64@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-darwin-arm64@npm:12.3.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-darwin-x64@npm:12.1.6"
+"@next/swc-darwin-x64@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-darwin-x64@npm:12.3.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm-gnueabihf@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.1.6"
+"@next/swc-freebsd-x64@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-freebsd-x64@npm:12.3.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm-gnueabihf@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-linux-arm-gnueabihf@npm:12.3.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm64-gnu@npm:12.1.6"
+"@next/swc-linux-arm64-gnu@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-linux-arm64-gnu@npm:12.3.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-arm64-musl@npm:12.1.6"
+"@next/swc-linux-arm64-musl@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-linux-arm64-musl@npm:12.3.2"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-x64-gnu@npm:12.1.6"
+"@next/swc-linux-x64-gnu@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-linux-x64-gnu@npm:12.3.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-linux-x64-musl@npm:12.1.6"
+"@next/swc-linux-x64-musl@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-linux-x64-musl@npm:12.3.2"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-arm64-msvc@npm:12.1.6"
+"@next/swc-win32-arm64-msvc@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-win32-arm64-msvc@npm:12.3.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-ia32-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-ia32-msvc@npm:12.1.6"
+"@next/swc-win32-ia32-msvc@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-win32-ia32-msvc@npm:12.3.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:12.1.6":
-  version: 12.1.6
-  resolution: "@next/swc-win32-x64-msvc@npm:12.1.6"
+"@next/swc-win32-x64-msvc@npm:12.3.2":
+  version: 12.3.2
+  resolution: "@next/swc-win32-x64-msvc@npm:12.3.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7035,6 +7057,15 @@ __metadata:
     magic-string: ^0.25.0
     string.prototype.matchall: ^4.0.6
   checksum: 2c021349442e2e2cec96bb50fd82ec8bf8514d909bc73594f6cfc89b3b68f2feed909a8161d7d307d9455585c97e6b66853ce334db432626c7596836d4549c0c
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.4.11":
+  version: 0.4.11
+  resolution: "@swc/helpers@npm:0.4.11"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 736857d524b41a8a4db81094e9b027f554004e0fa3e86325d85bdb38f7e6459ce022db079edb6c61ba0f46fe8583b3e663e95f7acbd13e51b8da6c34e45bba2e
   languageName: node
   linkType: hard
 
@@ -10116,17 +10147,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001332":
-  version: 1.0.30001359
-  resolution: "caniuse-lite@npm:1.0.30001359"
-  checksum: e15dbf4ea445367e998ad525c54620275ae382446d0bc289d14bf014a159074a2207881b46406b011a72676686f8a734457ea8e8d4856dc3f700c3391e89b43e
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001370":
   version: 1.0.30001378
   resolution: "caniuse-lite@npm:1.0.30001378"
   checksum: 19f1774da1f62d393ddde55dc091eb3e4f5c5b0ce43f9a9d20e75307a0f329cf8591c836a35a9f6f9fd7c27db7a75e0682245a194acec2e2ba1bc25ef1c3300c
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001406":
+  version: 1.0.30001430
+  resolution: "caniuse-lite@npm:1.0.30001430"
+  checksum: 15200fe2658871807341a451b01e3d6ae2bf5e0e30b60af86e1e8d9e1655a5f5011bb23fdc3d6b696019d63d3e60ad6864b15c40c80c538c4500ac5098b9701b
   languageName: node
   linkType: hard
 
@@ -18533,26 +18564,29 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"next@npm:^12.1.6":
-  version: 12.1.6
-  resolution: "next@npm:12.1.6"
+"next@npm:12.3.2":
+  version: 12.3.2
+  resolution: "next@npm:12.3.2"
   dependencies:
-    "@next/env": 12.1.6
-    "@next/swc-android-arm-eabi": 12.1.6
-    "@next/swc-android-arm64": 12.1.6
-    "@next/swc-darwin-arm64": 12.1.6
-    "@next/swc-darwin-x64": 12.1.6
-    "@next/swc-linux-arm-gnueabihf": 12.1.6
-    "@next/swc-linux-arm64-gnu": 12.1.6
-    "@next/swc-linux-arm64-musl": 12.1.6
-    "@next/swc-linux-x64-gnu": 12.1.6
-    "@next/swc-linux-x64-musl": 12.1.6
-    "@next/swc-win32-arm64-msvc": 12.1.6
-    "@next/swc-win32-ia32-msvc": 12.1.6
-    "@next/swc-win32-x64-msvc": 12.1.6
-    caniuse-lite: ^1.0.30001332
-    postcss: 8.4.5
-    styled-jsx: 5.0.2
+    "@next/env": 12.3.2
+    "@next/swc-android-arm-eabi": 12.3.2
+    "@next/swc-android-arm64": 12.3.2
+    "@next/swc-darwin-arm64": 12.3.2
+    "@next/swc-darwin-x64": 12.3.2
+    "@next/swc-freebsd-x64": 12.3.2
+    "@next/swc-linux-arm-gnueabihf": 12.3.2
+    "@next/swc-linux-arm64-gnu": 12.3.2
+    "@next/swc-linux-arm64-musl": 12.3.2
+    "@next/swc-linux-x64-gnu": 12.3.2
+    "@next/swc-linux-x64-musl": 12.3.2
+    "@next/swc-win32-arm64-msvc": 12.3.2
+    "@next/swc-win32-ia32-msvc": 12.3.2
+    "@next/swc-win32-x64-msvc": 12.3.2
+    "@swc/helpers": 0.4.11
+    caniuse-lite: ^1.0.30001406
+    postcss: 8.4.14
+    styled-jsx: 5.0.7
+    use-sync-external-store: 1.2.0
   peerDependencies:
     fibers: ">= 3.1.0"
     node-sass: ^6.0.0 || ^7.0.0
@@ -18567,6 +18601,8 @@ fsevents@^1.2.7:
     "@next/swc-darwin-arm64":
       optional: true
     "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-freebsd-x64":
       optional: true
     "@next/swc-linux-arm-gnueabihf":
       optional: true
@@ -18593,7 +18629,7 @@ fsevents@^1.2.7:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 670d544fd47670c29681d10824e6da625e9d4a048e564c8d9cb80d37f33c9ff9b5ca0a53e6d84d8d618b1fe7c9bb4e6b45040cb7e57a5c46b232a8f914425dc1
+  checksum: fa2372c3dfaa8c3910ad443a6489ea2578c141e8c819544eb98da6ed6a6c960b2496ac8e9baa4f919bc55c60fd072b85eca5fd2a7073a521364f3247ec09dfa2
   languageName: node
   linkType: hard
 
@@ -20444,14 +20480,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.5, postcss@npm:^8.2.1, postcss@npm:^8.4.5":
-  version: 8.4.5
-  resolution: "postcss@npm:8.4.5"
+"postcss@npm:8.4.14":
+  version: 8.4.14
+  resolution: "postcss@npm:8.4.14"
   dependencies:
-    nanoid: ^3.1.30
+    nanoid: ^3.3.4
     picocolors: ^1.0.0
-    source-map-js: ^1.0.1
-  checksum: b78abdd89c10f7b48f4bdcd376104a19d6e9c7495ab521729bdb3df315af6c211360e9f06887ad3bc0ab0f61a04b91d68ea11462997c79cced58b9ccd66fac07
+    source-map-js: ^1.0.2
+  checksum: fe58766ff32e4becf65a7d57678995cfd239df6deed2fe0557f038b47c94e4132e7e5f68b5aa820c13adfec32e523b693efaeb65798efb995ce49ccd83953816
   languageName: node
   linkType: hard
 
@@ -20462,6 +20498,17 @@ fsevents@^1.2.7:
     picocolors: ^0.2.1
     source-map: ^0.6.1
   checksum: 4ac793f506c23259189064bdc921260d869a115a82b5e713973c5af8e94fbb5721a5cc3e1e26840500d7e1f1fa42a209747c5b1a151918a9bc11f0d7ed9048e3
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.2.1, postcss@npm:^8.4.5":
+  version: 8.4.5
+  resolution: "postcss@npm:8.4.5"
+  dependencies:
+    nanoid: ^3.1.30
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.1
+  checksum: b78abdd89c10f7b48f4bdcd376104a19d6e9c7495ab521729bdb3df315af6c211360e9f06887ad3bc0ab0f61a04b91d68ea11462997c79cced58b9ccd66fac07
   languageName: node
   linkType: hard
 
@@ -23273,9 +23320,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"styled-jsx@npm:5.0.2":
-  version: 5.0.2
-  resolution: "styled-jsx@npm:5.0.2"
+"styled-jsx@npm:5.0.7":
+  version: 5.0.7
+  resolution: "styled-jsx@npm:5.0.7"
   peerDependencies:
     react: ">= 16.8.0 || 17.x.x || ^18.0.0-0"
   peerDependenciesMeta:
@@ -23283,7 +23330,7 @@ fsevents@^1.2.7:
       optional: true
     babel-plugin-macros:
       optional: true
-  checksum: 86d55819ebeabd283a574d2f44f7d3f8fa6b8c28fa41687ece161bf1e910e04965611618921d8f5cd33dc6dae1033b926a70421ae5ea045440a9861edc3e0d87
+  checksum: 61959993915f4b1662a682dbbefb3512de9399cf6901969bcadd26ba5441d2b5ca5c1021b233bbd573da2541b41efb45d56c6f618dbc8d88a381ebc62461fefe
   languageName: node
   linkType: hard
 
@@ -24135,6 +24182,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.4.0":
+  version: 2.4.1
+  resolution: "tslib@npm:2.4.1"
+  checksum: 19480d6e0313292bd6505d4efe096a6b31c70e21cf08b5febf4da62e95c265c8f571f7b36fcc3d1a17e068032f59c269fab3459d6cd3ed6949eafecf64315fca
+  languageName: node
+  linkType: hard
+
 "tsutils@npm:^3.21.0":
   version: 3.21.0
   resolution: "tsutils@npm:3.21.0"
@@ -24669,6 +24723,15 @@ fsevents@^1.2.7:
     "@types/react":
       optional: true
   checksum: d865c59cca002d53ebb16da4ca6198c5e40d513fb65816449a9507b70753b31b436bf90afab5ac55f3ffc65671d23a0bd48d1f4bcc35f6866313c1f9360c1f21
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,7 +2112,7 @@ __metadata:
     "@types/react-dom": ^17.0.11
     "@types/styled-components": ^5.1.21
     babel-plugin-styled-components: ^2.0.7
-    next: 12.3.2
+    next: ^12.3.2
     react: ^17.0.2
     react-dom: ^17.0.2
     styled-components: ^5.3.3
@@ -18549,7 +18549,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"next@npm:12.3.2":
+"next@npm:^12.3.2":
   version: 12.3.2
   resolution: "next@npm:12.3.2"
   dependencies:


### PR DESCRIPTION
## やったこと
- `SetThemeScript`のsrcを文字列として取得できる関数を追加
- 12.1.6だとbeforeInteractiveでinlineが使えなかったのでsampleのnextのバージョンを上げた
