### PR TITLE
svgの最適化による圧縮を行わずに色を置換できるように変更

### DIFF
--- a/misc/icons-cli-denylist
+++ b/misc/icons-cli-denylist
@@ -1,14 +1,2 @@
-32/LikeOff.svg
-32/LikeOn.svg
-32/LikeOnPrivate.svg
 32/Gift.svg
-Inline/BookmarkOff.svg
-Inline/PremiumMulticolor.svg
-Inline/LikeOffMulticolor.svg
-Inline/ViewMulticolor.svg
-24/Discovery.svg
-24/Play.svg
-24/Pause.svg
-24/FrameEffect.svg
-24/Dust.svg
 24/Gift.svg

--- a/packages/icons-cli/src/svg/optimizeSvg.ts
+++ b/packages/icons-cli/src/svg/optimizeSvg.ts
@@ -16,8 +16,25 @@ const svgo = new Svgo({
   ],
 })
 
-export async function optimizeSvg(input: string, convertedColor: string) {
-  const { data } = await svgo.optimize(input)
+/**
+ * SVGを最適化するオプション
+ */
+interface Options {
+  /**
+   * currentColorに置換する色 #ffffff
+   */
+  convertedColor: string
+  /**
+   * svgoによる最適化を行わない
+   */
+  withoutOptimizeBySVGO?: boolean
+}
+
+export async function optimizeSvg(input: string, options: Options) {
+  const { data } =
+    options.withoutOptimizeBySVGO === true
+      ? { data: input }
+      : await svgo.optimize(input)
 
   const { document } = new JSDOM(data).window
   const svg = document.querySelector('svg')
@@ -26,7 +43,7 @@ export async function optimizeSvg(input: string, convertedColor: string) {
   }
 
   addViewboxToRootSvg(svg)
-  convertToCurrentColor(svg, convertedColor)
+  convertToCurrentColor(svg, options.convertedColor)
 
   return svg.outerHTML
 }

--- a/packages/icons-cli/src/svg/optimizeSvgInDirectory.ts
+++ b/packages/icons-cli/src/svg/optimizeSvgInDirectory.ts
@@ -20,7 +20,6 @@ export const optimizeSvgInDirectory = async (
 
   const files = await glob('**/*.svg', {
     cwd: rootDir,
-    ignore: ignorePatterns,
   })
 
   await concurrently(
@@ -29,7 +28,10 @@ export const optimizeSvgInDirectory = async (
       const fullPath = path.join(rootDir, file)
 
       const originalSvg = await fs.readFile(fullPath, 'utf8')
-      const optimizedSvg = await optimizeSvg(originalSvg, replaceColor)
+      const optimizedSvg = await optimizeSvg(originalSvg, {
+        convertedColor: replaceColor,
+        withoutOptimizeBySVGO: ignorePatterns.includes(file),
+      })
       await fs.writeFile(fullPath, optimizedSvg)
     })
   )


### PR DESCRIPTION
## やったこと
- svgの最適化による圧縮を行わずに色を置換できるように変更
- misc/icons-cli-denylistから不必要なアイコンを削除

## なぜやるのか
- Gift.svgのようなアイコンはsvgoによるコンバートで見た目が変わってしまうが、fillの置換だけは行いたいため。
- PremiumMulticolor.svgなどは存在していない。
- Play.svgなどはfillの限定的な置換に対応していなかった時の回避策でリストに追加されていたが、特定の色のみcurrentColorへ置換するようにしたので削除して問題ない。
