### PR TITLE
fix: charcoal-ui/react から Modal が export されていない

### DIFF
--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Story } from '../../_lib/compat'
-import Modal, { ModalDismissButton, Props } from '.'
+import Modal, { ModalDismissButton, ModalProps } from '.'
 import { OverlayProvider } from '@react-aria/overlays'
 import { useOverlayTriggerState } from 'react-stately'
 import Button from '../Button'
@@ -37,7 +37,7 @@ export default {
   },
 }
 
-const DefaultStory = (args: Props) => {
+const DefaultStory = (args: ModalProps) => {
   const state = useOverlayTriggerState({})
   return (
     // Application must be wrapped in an OverlayProvider so that it can be
@@ -98,9 +98,9 @@ const StyledModalText = styled(ModalAlign)`
   ${theme((o) => [o.font.text2, o.typography(14)])}
 `
 
-export const Default: Story<Props> = DefaultStory.bind({})
+export const Default: Story<ModalProps> = DefaultStory.bind({})
 
-const FullBottomSheetStory = (args: Props) => {
+const FullBottomSheetStory = (args: ModalProps) => {
   const state = useOverlayTriggerState({})
   return (
     // Application must be wrapped in an OverlayProvider so that it can be
@@ -153,9 +153,9 @@ const FullBottomSheetStory = (args: Props) => {
   )
 }
 
-export const FullBottomSheet: Story<Props> = FullBottomSheetStory.bind({})
+export const FullBottomSheet: Story<ModalProps> = FullBottomSheetStory.bind({})
 
-const BottomSheetStory = (args: Props) => {
+const BottomSheetStory = (args: ModalProps) => {
   const state = useOverlayTriggerState({})
   return (
     // Application must be wrapped in an OverlayProvider so that it can be
@@ -192,4 +192,4 @@ const BottomSheetStory = (args: Props) => {
   )
 }
 
-export const BottomSheet: Story<Props> = BottomSheetStory.bind({})
+export const BottomSheet: Story<ModalProps> = BottomSheetStory.bind({})

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -19,7 +19,7 @@ import { animated, useTransition, easings } from 'react-spring'
 import Button, { ButtonProps } from '../Button'
 import IconButton from '../IconButton'
 
-export type Props = OverlayProps &
+export type ModalProps = OverlayProps &
   AriaDialogProps & {
     children: React.ReactNode
     zIndex?: number
@@ -39,7 +39,7 @@ export default function Modal({
   zIndex = DEFAULT_Z_INDEX,
   portalContainer,
   ...props
-}: Props) {
+}: ModalProps) {
   const {
     title,
     size = 'M',

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,6 +34,7 @@ export {
   type MultiLineTextFieldProps,
 } from './components/TextField'
 export { default as Icon, type IconProps } from './components/Icon'
+export { default as Modal, type ModalProps } from './components/Modal'
 export {
   default as LoadingSpinner,
   LoadingSpinnerIcon,


### PR DESCRIPTION
## やったこと

#90 の際、index.ts からの再 export を忘れていたと思われる

これ系 CI で根本対応したい…

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
