### PR TITLE
docs: add npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ This is the monorepo for the `@charcoal-ui` packages by pixiv.
 
 See our [documentation](https://pixiv.github.io/charcoal/docs), or README of each package in `/packages`.
 
+## NPM Packages
+
+| package                      | version                                                                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| @charcoal-ui/foundation      | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/foundation)](https://www.npmjs.com/package/@charcoal-ui/foundation)           |
+| @charcoal-ui/icons           | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/icons)](https://www.npmjs.com/package/@charcoal-ui/icons)                     |
+| @charcoal-ui/icons-cli       | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/icons-cli)](https://www.npmjs.com/package/@charcoal-ui/icons-cli)             |
+| @charcoal-ui/react           | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/react)](https://www.npmjs.com/package/@charcoal-ui/react)                     |
+| @charcoal-ui/react-sandbox   | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/react-sandbox)](https://www.npmjs.com/package/@charcoal-ui/react-sandbox)     |
+| @charcoal-ui/styled          | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/styled)](https://www.npmjs.com/package/@charcoal-ui/styled)                   |
+| @charcoal-ui/tailwind-config | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/tailwind-config)](https://www.npmjs.com/package/@charcoal-ui/tailwind-config) |
+| @charcoal-ui/tailwind-diff   | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/tailwind-diff)](https://www.npmjs.com/package/@charcoal-ui/tailwind-diff)     |
+| @charcoal-ui/theme           | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/theme)](https://www.npmjs.com/package/@charcoal-ui/theme)                     |
+| @charcoal-ui/utils           | [![styled npm version](https://img.shields.io/npm/v/@charcoal-ui/utils)](https://www.npmjs.com/package/@charcoal-ui/utils)                     |
+
 ## Contribution
 
 ### Setup


### PR DESCRIPTION
## やったこと
npmパッケージのバッジを追加．パッケージが多いためテーブルにした．

## なぜやるのか
各パッケージのnpmへのリンクがREADME.mdにないため．