### PR TITLE
fix: add w-fit to width class name

### DIFF
--- a/packages/tailwind-config/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwind-config/src/__snapshots__/index.test.ts.snap
@@ -634,6 +634,7 @@ Array [
   "w-full",
   "w-screen",
   "w-auto",
+  "w-fit",
   "w-col-span-1",
   "w-col-span-2",
   "w-col-span-3",

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -69,6 +69,7 @@ export function createTailwindConfig({
         full: '100%',
         screen: '100vw',
         auto: 'auto',
+        fit: 'fit-content',
 
         /**
          * generates classes like "w-col-span-1"


### PR DESCRIPTION
## やったこと
- tailwind/widthのclassNameに`w-fit`を追加

## なぜやるのか
- `w-fit(width: fit-content)`をclassNameから指定できないため

## 動作確認環境
- Macbook Pro Intel系/google chrome
- storybook内で確認。


## チェックリスト
以下3つのチェックリストに対して影響はないと思われる。

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した


