### PR TITLE
chore: prettierignore lerna.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ __snapshots__/
 /storybook-static/
 /coverage/
 .next/
+lerna.json
 
 LICENSE
 /packages/theme/theme.json


### PR DESCRIPTION
## やったこと

lerna.json を .prettierignore に加える。

`yarn lerna version` コマンドを打ったときに自動で lerna.json が変更されるが、その内容が prettier に怒られることがあるため。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] ~~破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した~~
- [ ] ~~追加したコンポーネントが index.ts から再 export されている~~
- [ ] ~~README やドキュメントに影響があることを確認した~~
