### PR TITLE
icon-files/index.cjs は module.exports = してて欲しい

### DIFF
--- a/packages/icon-files/src/index.cjs
+++ b/packages/icon-files/src/index.cjs
@@ -1,6 +1,6 @@
 /** This file is auto generated. DO NOT EDIT BY HAND. */
 
-export default {
+module.exports = {
   '16/Add': () => import('./16/Add.js').then(m => m.default),
   '16/ArrowDown': () => import('./16/ArrowDown.js').then(m => m.default),
   '16/Artwork': () => import('./16/Artwork.js').then(m => m.default),

--- a/packages/icons-cli/src/generateSource.ts
+++ b/packages/icons-cli/src/generateSource.ts
@@ -25,7 +25,7 @@ const generateCjsEntrypoint = (
   icons: string[]
 ) => `/** This file is auto generated. DO NOT EDIT BY HAND. */
 
-export default {
+module.exports = {
 ${icons
   .map((it) => `  '${it}': () => import('./${it}.js').then(m => m.default)`)
   .join(',\n')}


### PR DESCRIPTION
## やったこと

`2.0.0-rc.0` を Next.js で使用したらこのようになった

<img width="740" alt="スクリーンショット_2022-12-15_19_30_53" src="https://user-images.githubusercontent.com/5250706/207836697-5efdeac5-ae77-47aa-b60d-8a02da7f165d.png">

理由は cjs なのに `export default` をしているせい。

最初各アイコンファイル（ `16/Add.js` ）とかも含めて全部 `module.exports = ` にしないとダメかと思ったが、手元で node_modules をいじりながら試した感じ `index.cjs` を直すだけで行けそうな感じだったのでそうしてみた

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
