### PR TITLE
[icons-cli] Pull Request作成サブコマンドでOUTPUT_ROOT_DIRを使う

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -69,4 +69,5 @@ jobs:
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: main
+          OUTPUT_ROOT_DIR: packages/icon-files/
         run: yarn icons-cli github:pr

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -7,6 +7,9 @@ on:
 
   workflow_dispatch:
 
+env:
+  OUTPUT_ROOT_DIR: packages/icon-files/
+
 jobs:
   icons:
     runs-on: ubuntu-latest
@@ -43,17 +46,12 @@ jobs:
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-          OUTPUT_ROOT_DIR: packages/icon-files/
         run: yarn icons-cli figma:export
 
       - name: Optimize
-        env:
-          OUTPUT_ROOT_DIR: packages/icon-files/
         run: yarn icons-cli svg:optimize --ignoreFile ./misc/icons-cli-denylist
 
       - name: Generate source
-        env:
-          OUTPUT_ROOT_DIR: packages/icon-files/
         run: yarn icons-cli files:generate
 
       - name: Generate github token
@@ -69,5 +67,4 @@ jobs:
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: main
-          OUTPUT_ROOT_DIR: packages/icon-files/
         run: yarn icons-cli github:pr

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -2,12 +2,10 @@ import { promises as fs, existsSync } from 'fs'
 import path from 'path'
 import { execp } from './utils'
 
-export const targetDir = path.resolve(process.cwd(), 'packages', 'icons')
-
 /**
  * dir 内で変更があったファイル情報を for await で回せるようにするやつ
  */
-export async function* getChangedFiles(dir = targetDir) {
+export async function* getChangedFiles(dir: string) {
   if (!existsSync(dir))
     throw new Error(`icons-cli: target directory not found (${dir})`)
   const gitStatus = await collectGitStatus()

--- a/packages/icons-cli/src/index.ts
+++ b/packages/icons-cli/src/index.ts
@@ -99,12 +99,14 @@ void yargs
     async () => {
       mustBeDefined(GITLAB_PROJECT_ID, 'GITLAB_PROJECT_ID')
       mustBeDefined(GITLAB_ACCESS_TOKEN, 'GITLAB_ACCESS_TOKEN')
+      mustBeDefined(OUTPUT_ROOT_DIR, 'OUTPUT_ROOT_DIR')
 
       await GitlabClient.runFromCli(
         GITLAB_HOST ?? 'https://gitlab.com',
         Number(GITLAB_PROJECT_ID),
         GITLAB_ACCESS_TOKEN,
-        GITLAB_DEFAULT_BRANCH ?? 'main'
+        GITLAB_DEFAULT_BRANCH ?? 'main',
+        OUTPUT_ROOT_DIR
       )
     }
   )
@@ -114,12 +116,14 @@ void yargs
     {},
     async () => {
       mustBeDefined(GITHUB_ACCESS_TOKEN, 'GITHUB_ACCESS_TOKEN')
+      mustBeDefined(OUTPUT_ROOT_DIR, 'OUTPUT_ROOT_DIR')
 
       await GithubClient.runFromCli(
         GITHUB_REPO_OWNER ?? 'pixiv',
         GITHUB_REPO_NAME ?? 'charcoal',
         GITHUB_ACCESS_TOKEN,
-        GITHUB_DEFAULT_BRANCH ?? 'main'
+        GITHUB_DEFAULT_BRANCH ?? 'main',
+        OUTPUT_ROOT_DIR
       )
     }
   )


### PR DESCRIPTION
## やったこと
- `OUTPUT_ROOT_DIR` をみて差分をとるディレクトリを決めるように変更
    - `OUTPUT_ROOT_DIR` が与えられなかったときは処理をそこでやめる

## 動作確認環境
手元で動かして動作確認をしました

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
