### PR TITLE
fix: rc.1 の `<Modal>` コンポーネントへのフィードバックを修正

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,7 @@
     "@react-aria/checkbox": "^3.2.3",
     "@react-aria/dialog": "^3.2.1",
     "@react-aria/focus": "^3.6.1",
-    "@react-aria/overlays": "^3.9.1",
+    "@react-aria/overlays": "3.9.1",
     "@react-aria/radio": "^3.4.0",
     "@react-aria/select": "^3.8.2",
     "@react-aria/ssr": "^3.3.0",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,6 +36,12 @@ export {
 export { default as Icon, type IconProps } from './components/Icon'
 export { default as Modal, type ModalProps } from './components/Modal'
 export {
+  ModalHeader,
+  ModalAlign,
+  ModalBody,
+  ModalButtons,
+} from './components/Modal/ModalPlumbing'
+export {
   default as LoadingSpinner,
   LoadingSpinnerIcon,
 } from './components/LoadingSpinner'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,7 +2059,7 @@ __metadata:
     "@react-aria/checkbox": ^3.2.3
     "@react-aria/dialog": ^3.2.1
     "@react-aria/focus": ^3.6.1
-    "@react-aria/overlays": ^3.9.1
+    "@react-aria/overlays": 3.9.1
     "@react-aria/radio": ^3.4.0
     "@react-aria/select": ^3.8.2
     "@react-aria/ssr": ^3.3.0
@@ -4673,6 +4673,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/overlays@npm:3.9.1":
+  version: 3.9.1
+  resolution: "@react-aria/overlays@npm:3.9.1"
+  dependencies:
+    "@babel/runtime": ^7.6.2
+    "@react-aria/i18n": ^3.4.1
+    "@react-aria/interactions": ^3.9.1
+    "@react-aria/utils": ^3.13.1
+    "@react-aria/visually-hidden": ^3.3.1
+    "@react-stately/overlays": ^3.3.1
+    "@react-types/button": ^3.5.1
+    "@react-types/overlays": ^3.6.1
+    "@react-types/shared": ^3.13.1
+    dom-helpers: ^5.2.1
+    react-transition-group: ^4.4.2
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 6812b68bd17491155b6e57297a1f61b83ca367189d8113042c403341a14eb79a8d5d7ee799861316b24e9414c3b62a59d8d9413ff0b0e174567ed860267c031d
+  languageName: node
+  linkType: hard
+
 "@react-aria/overlays@npm:^3.12.0":
   version: 3.12.0
   resolution: "@react-aria/overlays@npm:3.12.0"
@@ -4692,28 +4714,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: e76d41b272b245d2cfbea99fe96dcfca34ffd245c5635a04ea82fa186ca35f6f2e49bf105aeba2ac5fecfe2d840098d63587d46cbed566494e7375ae0f74013c
-  languageName: node
-  linkType: hard
-
-"@react-aria/overlays@npm:^3.9.1":
-  version: 3.9.1
-  resolution: "@react-aria/overlays@npm:3.9.1"
-  dependencies:
-    "@babel/runtime": ^7.6.2
-    "@react-aria/i18n": ^3.4.1
-    "@react-aria/interactions": ^3.9.1
-    "@react-aria/utils": ^3.13.1
-    "@react-aria/visually-hidden": ^3.3.1
-    "@react-stately/overlays": ^3.3.1
-    "@react-types/button": ^3.5.1
-    "@react-types/overlays": ^3.6.1
-    "@react-types/shared": ^3.13.1
-    dom-helpers: ^5.2.1
-    react-transition-group: ^4.4.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: 6812b68bd17491155b6e57297a1f61b83ca367189d8113042c403341a14eb79a8d5d7ee799861316b24e9414c3b62a59d8d9413ff0b0e174567ed860267c031d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## やったこと

thx @motoki317 

1.  (エラー報告) ModalのpropにisOpenを渡そうとすると、そんなpropは:naiyo: と怒られました。どうやらcharcoalを使う側で `@react-aria/overlays` の最新バージョン3.12.0がインストールされてしまうのが原因らしく、package.jsonのresolutionsで、charcoalで使っている3.9.1を指定してあげるとエラーが消えました。こちらは `@react-aria/overlays` の破壊的変更が原因でしょうか...？
2. ModalPlumbingからexportされているModalAlign等の要素を使いたかったのですが、exportされていないようです。こちらは意図的ですか？

1 については実際 react-aria で useOverlay の代わりに useModalOverlay の利用が推奨されるようになった？とかで OverlayProps の想定される使い方が変わってしまってそう（ see: https://github.com/adobe/react-spectrum/pull/3561 https://github.com/adobe/react-spectrum/pull/3347 ）

2 についてはそのとおりなので、Modal.tsx 以外からも export する

## 動作確認環境

Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] ~~破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した~~
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
