### PR TITLE
GitHub Actionsの各workflowファイル内でnodeのバージョンを書くのをやめた

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.node-version'
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.node-version'
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  NODE_VERSION: 16
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version-file: '.node-version'
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
       - name: Get yarn cache directory path


### PR DESCRIPTION
## やったこと
GitHub Actionsの各workflowファイル内でnodeのバージョンを書いていくとバージョンアップ時に全部書き換える必要があって大変なので `.node-version` から読み込むようにしました。

ref. https://github.com/actions/setup-node/blob/v3.5.1/docs/advanced-usage.md#node-version-file

## 動作確認環境
CIが通ればok

## チェックリスト

