### PR TITLE
CIの並列化

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,23 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: yarn
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -19,23 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: yarn
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 on:
   push:
     branches:
@@ -9,7 +9,19 @@ on:
       - main
 
 jobs:
-  test:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn build
+
+  build-storybook:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,22 +31,72 @@ jobs:
           node-version-file: '.node-version'
           cache: yarn
 
-      - name: Prepare deps
-        run: |
-          yarn install --immutable --inline-builds
-          yarn build
+      - run: yarn install --immutable --inline-builds
+      - run: yarn build
+      - run: yarn build-storybook
 
-      # TODO: jobを分けてビルド結果をキャッシュして並列化
-      - name: Test
-        run: |
-          yarn test
-          yarn lint
-          yarn typecheck:config
-          yarn typecheck
+  build-storybook-vite:
+    runs-on: ubuntu-latest
 
-      - name: Check if Storybook builds
-        # storybook の vite build が OOM で落ちることがある
-        # これだけ違う job に分離して強い runner で動かすと良いかも？
-        run: |
-          yarn build-storybook
-          NODE_OPTIONS=--max_old_space_size=6144 USE_VITE=1 yarn build-storybook
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn build
+      - run: yarn build-storybook
+        env:
+          NODE_OPTIONS: --max_old_space_size=6144
+          USE_VITE: '1'
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn build
+      - run: yarn typecheck
+
+  typecheck-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - run: yarn install --immutable --inline-builds
+      - run: yarn typecheck:config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: yarn
 
       - name: Prepare deps
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -18,23 +18,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn-2
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: yarn
 
       - name: Prepare deps
         run: |


### PR DESCRIPTION
## やったこと

- これまでyarn dependenciesのキャッシュに`actions/cache`を使っていたが、`actions/node`を使うと短く書けるのでそちらに置き換えた
- これまでbuild, lint,testなどを単一のjobで実行していたが、複数のjobに分割して並列で実行されるようにした
  - 利点: CIが高速になる
  - 欠点: ビルドを複数のjobで重複して行う必要があるため、全体としてはリソースの無駄が増える
