### PR TITLE
Auto upgrade action version with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'


### PR DESCRIPTION
## やったこと
GitHub Actionsのworkflowは一度設定するとactionsのバージョンアップを忘れがちなので、Dependabotでバージョンアップするようにしました。

c.f. [Keeping your actions up to date with Dependabot \- GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)

## 動作確認環境
主な個人リポジトリには全部入れて動作確認しましたが、`v1.2.3` のようなバージョンだけでなく `v1` のようなメジャーバージョンのtagに対してもバージョンアップのPRが作られることを確認しました。

* 設定を入れた時のPR: https://github.com/sue445/terraform-gcp-template/pull/78
* Dependabotで実際に作られたPR: https://github.com/sue445/terraform-gcp-template/pull/79

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
