### PR TITLE
export OverlayProvider from @charcoal-ui/react

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -36,6 +36,30 @@ export type ModalProps = AriaModalOverlayProps &
 
 const DEFAULT_Z_INDEX = 10
 
+/**
+ * モーダルコンポーネント。
+ *
+ * @example アプリケーションルートで `<OverlayProvider>` で囲った上で利用する
+ * ```tsx
+ * import {
+ *   OverlayProvider,
+ *   Modal,
+ *   ModalHeader,
+ *   ModalBody,
+ *   ModalButtons
+ * } from '@charcoal-ui/react'
+ *
+ * <OverlayProvider>
+ *   <App>
+ *     <Modal isOpen={state.isOpen} onClose={() => state.close()} isDismissable>
+ *       <ModalHeader />
+ *       <ModalBody>...</ModalBody>
+ *       <ModalButtons>...</ModalButtons>
+ *     </Modal>
+ *   </App>
+ * </OverlayProvider>
+ * ```
+ */
 export default function Modal({
   children,
   zIndex = DEFAULT_Z_INDEX,

--- a/packages/react/src/core/OverlayProvider.tsx
+++ b/packages/react/src/core/OverlayProvider.tsx
@@ -1,0 +1,1 @@
+export { OverlayProvider } from '@react-aria/overlays'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export {
   type LinkProps,
 } from './core/ComponentAbstraction'
 export { SSRProvider } from './core/SSRProvider'
+export { OverlayProvider } from './core/OverlayProvider'
 export { default as Button, type ButtonProps } from './components/Button'
 export {
   default as Clickable,


### PR DESCRIPTION
## やったこと

related: #118 #203

- `import { OverlayProvider } from '@charcoal-ui/react'` と書けるようにした
- 内容は `@react-aria/overlays` のものをそのまま
- `charcoal-ui/react` を使うにはついでに `react-aria/*` もインストールしないといけないという暗黙のルールを減らすため

長期的には `<CharcoalProvider>` のようなものを作るべきか悩むが、いったんこれで

## 動作確認環境

Storybook ?

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- ~~README やドキュメントに影響があることを確認した~~
  - とりあえず doc comment に書いた（コンポーネントの個別の説明はいまは書く場所がない）
