### PR TITLE
postpublish で tag を push する

### DIFF
--- a/misc/postpublish.sh
+++ b/misc/postpublish.sh
@@ -17,6 +17,8 @@ if [[ $default_branch = `git symbolic-ref --short HEAD` ]]; then
   else
     echo 'No diff found after yarn install'
   fi
+
+  git push origin --tags
 else
   echo 'Not in default branch'
 fi


### PR DESCRIPTION
## やったこと

yarn lerna version した際にタグが打たれるが、yarn lerna publish 後に tag が push されていなかった。

`misc/postpublish.sh` で `git tag origin --push` を呼ぶようにする。

## 動作確認環境

次リリース時ににある

## チェックリスト

不要なチェック項目は消して構いません

