### PR TITLE
fix: PixivIconLoadErrorのエラー名とprototypeを修正

### DIFF
--- a/packages/icons/src/loaders/CustomIconLoader.ts
+++ b/packages/icons/src/loaders/CustomIconLoader.ts
@@ -37,6 +37,9 @@ export class CustomIconLoader implements Loadable {
         return this._resultSvg
       })
       .catch((e) => {
+        if (e instanceof PixivIconLoadError) {
+          throw e
+        }
         throw new PixivIconLoadError(this._name, e)
       })
       .finally(() => {

--- a/packages/icons/src/loaders/PixivIconLoadError.ts
+++ b/packages/icons/src/loaders/PixivIconLoadError.ts
@@ -4,7 +4,8 @@ export class PixivIconLoadError extends Error {
 
     // TODO: TypeScript 4.6+ になるとここに `{ cause }` が渡せる
     super(message)
-    Object.setPrototypeOf(this, new.target)
+    this.name = 'PixivIconLoadError'
+    Object.setPrototypeOf(this, new.target.prototype)
   }
 }
 


### PR DESCRIPTION
## やったこと
- minifyされるとエラー名がおかしくなるのを修正
- instanceofがうまく動かない問題を修正
- PixivIconLoadErrorが2重にならないように修正

## 動作確認環境
- storybookで、ネットワークをオフライン状態にして確認

