### PR TITLE
fix: スタイルが適切に指定されていない箇所を修正

### DIFF
--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -118,5 +118,5 @@ const CheckboxInputOverlay = styled.div<{ checked?: boolean }>`
 `
 
 const InputLabel = styled.div`
-  ${theme((o) => [o.typography(14)])}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `

--- a/packages/react/src/components/DropdownSelector/Listbox.tsx
+++ b/packages/react/src/components/DropdownSelector/Listbox.tsx
@@ -123,5 +123,5 @@ const OptionCheckIcon = styled(Icon)<{ isSelected: boolean }>`
 `
 const OptionText = styled.span`
   display: block;
-  ${theme((o) => [o.typography(14)])}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -121,7 +121,7 @@ const DropdownSelector = <T extends Record<string, unknown>>({
               : props.placeholder}
           </DropdownButtonText>
 
-          <Icon name="16/Menu" />
+          <DropdownButtonIcon name="16/Menu" />
         </DropdownButton>
         {state.isOpen && (
           <DropdownPopover open={state.isOpen} onClose={() => state.close()}>
@@ -196,12 +196,16 @@ const DropdownButtonText = styled.span`
   ${theme((o) => [o.typography(14), o.font.text2])}
 `
 
+const DropdownButtonIcon = styled(Icon)`
+  ${theme((o) => [o.font.text2])}
+`
+
 const AssertiveText = styled.div<{ invalid: boolean }>`
   ${({ invalid }) =>
     theme((o) => [
       o.typography(14),
       o.margin.top(8),
-      invalid && o.font.assertive,
+      invalid ? o.font.assertive : o.font.text2,
     ])}
 `
 

--- a/packages/react/src/components/LoadingSpinner/index.tsx
+++ b/packages/react/src/components/LoadingSpinner/index.tsx
@@ -1,6 +1,6 @@
-import { transparentize } from 'polished'
 import React, { useImperativeHandle, useRef } from 'react'
 import styled, { keyframes } from 'styled-components'
+import { theme } from '../../styled'
 
 export default function LoadingSpinner({
   size = 48,
@@ -25,11 +25,12 @@ const LoadingSpinnerRoot = styled.div.attrs({ role: 'progressbar' })<{
   font-size: ${(props) => props.size}px;
   width: ${(props) => props.size}px;
   height: ${(props) => props.size}px;
-  background-color: ${({ theme, transparent }) =>
-    transparent
-      ? 'transparent'
-      : transparentize(0.32, theme.color.background1)};
-  color: ${({ theme }) => theme.color.text4};
+  opacity: 0.84;
+  ${({ transparent }) =>
+    theme((o) => [
+      o.font.text4,
+      transparent ? o.bg.transparent : o.bg.background1,
+    ])}
 `
 
 const scaleout = keyframes`

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -93,7 +93,7 @@ const MultiSelectRoot = styled.label`
 const MultiSelectLabel = styled.div`
   display: flex;
   align-items: center;
-  ${theme((o) => [o.typography(14), o.font.text1])}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `
 
 const MultiSelectInput = styled.input.attrs({ type: 'checkbox' })<{

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -76,6 +76,7 @@ export const RadioInput = styled.input.attrs({ type: 'radio' })<{
     display: block;
     box-sizing: border-box;
 
+    margin: 0;
     padding: 6px;
 
     width: 20px;
@@ -84,14 +85,14 @@ export const RadioInput = styled.input.attrs({ type: 'radio' })<{
     ${({ hasError = false }) =>
       theme((o) => [
         o.borderRadius('oval'),
-        o.bg.text5.hover.press,
+        o.bg.surface1.hover.press,
         hasError && o.outline.assertive,
       ])};
 
     &:not(:checked) {
       border-width: 2px;
       border-style: solid;
-      border-color: ${({ theme }) => theme.color.text4};
+      border-color: ${({ theme }) => theme.color.text3};
     }
 
     &:checked {
@@ -113,7 +114,7 @@ export const RadioInput = styled.input.attrs({ type: 'radio' })<{
 `
 
 const RadioLabel = styled.div`
-  ${theme((o) => [o.typography(14)])}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `
 
 export type RadioGroupProps = React.PropsWithChildren<{

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -58,6 +58,7 @@ export default function SwitchCheckbox(props: SwitchProps) {
 const Label = styled.label`
   display: inline-grid;
   grid-template-columns: auto 1fr;
+  align-items: center;
   gap: ${({ theme }) => px(theme.spacing[4])};
   cursor: pointer;
   outline: 0;
@@ -70,7 +71,7 @@ const Label = styled.label`
 `
 
 const LabelInner = styled.div`
-  ${theme((o) => o.typography(14))}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `
 
 const SwitchInput = styled.input.attrs({


### PR DESCRIPTION
## やったこと
charcoal-ui/reactのスタイルがFigmaと異なっている箇所を修正しました。

|component|before|after|
|-|-|-|
|Checkbox|<img width="81" alt="image" src="https://user-images.githubusercontent.com/29514424/215407928-954c77db-fe6d-4a90-8c2e-c7a1acd55a2e.png">|<img width="88" alt="image" src="https://user-images.githubusercontent.com/29514424/215405948-197d2624-559a-4602-a99d-ce72e1d4cbd1.png">|
|DropdownSelector|<img width="234" alt="image" src="https://user-images.githubusercontent.com/29514424/215408019-8100c7a0-e131-4678-9043-2dda7b6b8406.png">|<img width="240" alt="image" src="https://user-images.githubusercontent.com/29514424/215406057-cb053fc5-6c0b-464b-9e2b-6af9cb48639b.png">|
|LoadingSpinner|<img width="87" alt="image" src="https://user-images.githubusercontent.com/29514424/215408140-823aa6bc-41ef-4512-bf93-b52e2b696b7a.png">|<img width="78" alt="image" src="https://user-images.githubusercontent.com/29514424/215407713-686a9cbf-e55d-41f0-af1e-1af69386a34a.png">|
|MultiSelect|<img width="80" alt="image" src="https://user-images.githubusercontent.com/29514424/215408301-2f9bc3dc-48a9-46b6-bf5f-24a5c2851620.png">|<img width="78" alt="image" src="https://user-images.githubusercontent.com/29514424/215406166-4dd6a15a-e4af-4230-870d-f15e741050c3.png">|
|Radio|<img width="143" alt="image" src="https://user-images.githubusercontent.com/29514424/215408858-ecec91d6-c0f1-425a-bd1f-c614776290d5.png">|<img width="143" alt="image" src="https://user-images.githubusercontent.com/29514424/215409204-216e1ed6-e2e2-44e4-b9dc-e80229d04b4a.png">|
|Switch|<img width="88" alt="image" src="https://user-images.githubusercontent.com/29514424/215408404-662527a3-a3a9-472d-bcc4-819da79e7adc.png">|<img width="85" alt="image" src="https://user-images.githubusercontent.com/29514424/215407580-a68c5e44-5952-468c-a70b-c0acc74979c8.png">|

## 動作確認環境
storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
