### PR TITLE
<CharcoalProvider> を作る

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -39,7 +39,7 @@ const DEFAULT_Z_INDEX = 10
 /**
  * モーダルコンポーネント。
  *
- * @example アプリケーションルートで `<OverlayProvider>` で囲った上で利用する
+ * @example アプリケーションルートで `<OverlayProvider>` ないし `<CharcoalProvider>` で囲った上で利用する
  * ```tsx
  * import {
  *   OverlayProvider,

--- a/packages/react/src/core/CharcoalProvider.tsx
+++ b/packages/react/src/core/CharcoalProvider.tsx
@@ -23,13 +23,13 @@ export function CharcoalProvider({
   children,
 }: React.PropsWithChildren<Props>) {
   return (
-    <ThemeProvider theme={defaultTheme}>
-      {injectTokens && <TokenInjector theme={themeMap} />}
-      <SSRProvider>
+    <SSRProvider>
+      <ThemeProvider theme={defaultTheme}>
+        {injectTokens && <TokenInjector theme={themeMap} />}
         <ComponentAbstraction components={components}>
           <OverlayProvider>{children}</OverlayProvider>
         </ComponentAbstraction>
-      </SSRProvider>
-    </ThemeProvider>
+      </ThemeProvider>
+    </SSRProvider>
   )
 }

--- a/packages/react/src/core/CharcoalProvider.tsx
+++ b/packages/react/src/core/CharcoalProvider.tsx
@@ -8,12 +8,12 @@ import { CharcoalTheme } from '@charcoal-ui/theme'
 import { OverlayProvider } from './OverlayProvider'
 import { SSRProvider } from './SSRProvider'
 
-interface Props {
+export type CharcoalProviderProps = React.PropsWithChildren<{
   themeMap: ThemeMap<CharcoalTheme>
   defaultTheme?: CharcoalTheme
   injectTokens?: boolean
   components?: Partial<Components>
-}
+}>
 
 export function CharcoalProvider({
   themeMap,
@@ -21,7 +21,7 @@ export function CharcoalProvider({
   components = {},
   injectTokens = true,
   children,
-}: React.PropsWithChildren<Props>) {
+}: CharcoalProviderProps) {
   return (
     <SSRProvider>
       <ThemeProvider theme={defaultTheme}>

--- a/packages/react/src/core/CharcoalProvider.tsx
+++ b/packages/react/src/core/CharcoalProvider.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { ThemeProvider } from 'styled-components'
+import ComponentAbstraction, { Components } from './ComponentAbstraction'
+import { TokenInjector } from '@charcoal-ui/styled'
+import { ThemeMap } from '@charcoal-ui/styled/src/TokenInjector'
+import { CharcoalTheme } from '@charcoal-ui/theme'
+
+import { OverlayProvider } from '@react-aria/overlays'
+import { SSRProvider } from '@react-aria/ssr'
+
+interface Props {
+  themeMap: ThemeMap<CharcoalTheme>
+  defaultTheme?: CharcoalTheme
+  injectTokens?: boolean
+  components?: Partial<Components>
+}
+
+export function CharcoalProvider({
+  themeMap,
+  defaultTheme = themeMap[':root'],
+  components = {},
+  injectTokens = true,
+  children,
+}: React.PropsWithChildren<Props>) {
+  return (
+    <ThemeProvider theme={defaultTheme}>
+      {injectTokens && <TokenInjector theme={themeMap} />}
+      <SSRProvider>
+        <ComponentAbstraction components={components}>
+          <OverlayProvider>{children}</OverlayProvider>
+        </ComponentAbstraction>
+      </SSRProvider>
+    </ThemeProvider>
+  )
+}

--- a/packages/react/src/core/CharcoalProvider.tsx
+++ b/packages/react/src/core/CharcoalProvider.tsx
@@ -5,8 +5,8 @@ import { TokenInjector } from '@charcoal-ui/styled'
 import { ThemeMap } from '@charcoal-ui/styled/src/TokenInjector'
 import { CharcoalTheme } from '@charcoal-ui/theme'
 
-import { OverlayProvider } from '@react-aria/overlays'
-import { SSRProvider } from '@react-aria/ssr'
+import { OverlayProvider } from './OverlayProvider'
+import { SSRProvider } from './SSRProvider'
 
 interface Props {
   themeMap: ThemeMap<CharcoalTheme>

--- a/packages/react/src/core/ComponentAbstraction.tsx
+++ b/packages/react/src/core/ComponentAbstraction.tsx
@@ -17,7 +17,7 @@ export const DefaultLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
   }
 )
 
-interface Components {
+export interface Components {
   Link: React.ComponentType<React.ComponentPropsWithRef<typeof DefaultLink>>
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,10 @@ export {
 } from './core/ComponentAbstraction'
 export { SSRProvider } from './core/SSRProvider'
 export { OverlayProvider } from './core/OverlayProvider'
+export {
+  CharcoalProvider,
+  type CharcoalProviderProps,
+} from './core/CharcoalProvider'
 export { default as Button, type ButtonProps } from './components/Button'
 export {
   default as Clickable,


### PR DESCRIPTION
## やったこと

特に tailwind を使うプロジェクトにおいて、`@charcoal-ui/react` を入れるには追加で styled のセットアップをしなければならないというのが導入の障壁になりがち。

そうでなくても、特定のコンポーネントを使うために `@react-aria/*` を各自で入れなければならない状況があって（ SSRProvider を export することで解決できてるとは言え ）ダルい。

`<CharcoalProvider>` というコンポーネントを作り、これで囲っておけばなんとなく `@charcoal-ui/react` を動かすのに必要な Context が提供されるようにする。

デメリットとして、使いもしない Context も bundle される（ SSR しないプロダクトも一旦 SSRProvider を読む ）とかが起こるというのはある

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
