### PR TITLE
fix(react): fix wrong styles

### DIFF
--- a/packages/react/src/components/DropdownSelector/Listbox.tsx
+++ b/packages/react/src/components/DropdownSelector/Listbox.tsx
@@ -114,6 +114,7 @@ const OptionRoot = styled.li<{ mode?: ListMode }>`
 `
 const OptionCheckIcon = styled(Icon)<{ isSelected: boolean }>`
   visibility: hidden;
+  ${theme((o) => [o.font.text2])}
 
   ${({ isSelected }) =>
     isSelected &&


### PR DESCRIPTION
## やったこと

- dropdownselector の icon color に style があたってないのを修正

## 動作確認環境
- storybook 
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
