### PR TITLE
fix: cjsをNext.js環境で使用できるように修正

### DIFF
--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -7,36 +7,13 @@ export default defineConfig({
   target: 'esnext',
   sourcemap: true,
   onSuccess: () => {
-    {
-      let src = readFileSync('./dist/index.cjs').toString()
-      src = src.replace(
-        /__toESM\(require\("styled-components"\), 1\);/g,
-        `require("styled-components");`
-      )
-      writeFileSync('./dist/index.cjs', src)
-    }
-    {
-      let src = readFileSync('./dist/index.js').toString()
-      const namedImportRegexp =
-        /import \{[\n\s]+([a-zA-Z0-9$, \n]*?)[\n\s]*?\} from "@react-aria\/(.*)";/
-      let match = src.match(namedImportRegexp)
-      const pkgNameMap: Record<string, number> = {}
-      while (match) {
-        const namedExportGroup = match[1].replace(/ as /g, ': ')
-        const pkgGroup = match[2] ?? ''
-        let pkgName = pkgGroup.replace(/-/, '_') + 'Pkg'
-        if (pkgNameMap[pkgName] === undefined) {
-          pkgNameMap[pkgName] = 0
-        }
-        pkgName = pkgName + (pkgNameMap[pkgName]++).toString()
-        src = src.replace(
-          namedImportRegexp,
-          () => `import ${pkgName} from "@react-aria/${pkgGroup}";
-const { ${namedExportGroup} } = ${pkgName};`
-        )
-        match = src.match(namedImportRegexp)
-      }
-      writeFileSync('./dist/index.js', src)
-    }
+    const cjsDistFile = './dist/index.cjs'
+    let src = readFileSync(cjsDistFile).toString()
+    src = src.replace(
+      /__toESM\(require\("styled-components"\), 1\);/g,
+      `require("styled-components");`
+    )
+    writeFileSync(cjsDistFile, src)
+    return Promise.resolve()
   },
 })

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from 'fs'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
@@ -5,4 +6,37 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'esnext',
   sourcemap: true,
+  onSuccess: () => {
+    {
+      let src = readFileSync('./dist/index.cjs').toString()
+      src = src.replace(
+        /__toESM\(require\("styled-components"\), 1\);/g,
+        `require("styled-components");`
+      )
+      writeFileSync('./dist/index.cjs', src)
+    }
+    {
+      let src = readFileSync('./dist/index.js').toString()
+      const namedImportRegexp =
+        /import \{[\n\s]+([a-zA-Z0-9$, \n]*?)[\n\s]*?\} from "@react-aria\/(.*)";/
+      let match = src.match(namedImportRegexp)
+      const pkgNameMap: Record<string, number> = {}
+      while (match) {
+        const namedExportGroup = match[1].replace(/ as /g, ': ')
+        const pkgGroup = match[2] ?? ''
+        let pkgName = pkgGroup.replace(/-/, '_') + 'Pkg'
+        if (pkgNameMap[pkgName] === undefined) {
+          pkgNameMap[pkgName] = 0
+        }
+        pkgName = pkgName + (pkgNameMap[pkgName]++).toString()
+        src = src.replace(
+          namedImportRegexp,
+          () => `import ${pkgName} from "@react-aria/${pkgGroup}";
+const { ${namedExportGroup} } = ${pkgName};`
+        )
+        match = src.match(namedImportRegexp)
+      }
+      writeFileSync('./dist/index.js', src)
+    }
+  },
 })

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -6,10 +6,13 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'esnext',
   sourcemap: true,
+  // Next.jsでcjsを使うときにエラーになるので回避策としてstyled-componentsのrequireを書き換える
+  // TypeError: import_styled_components2.default.button is not a function
   onSuccess: () => {
     const cjsDistFile = './dist/index.cjs'
     let src = readFileSync(cjsDistFile).toString()
     src = src.replace(
+      // NOTE: この正規表現は出力結果を見て作成した
       /__toESM\(require\("styled-components"\), 1\);/g,
       `require("styled-components");`
     )


### PR DESCRIPTION
## やったこと

Next.js環境で下記エラーが出るので回避策としてビルド後に変換を追加
```
TypeError: import_styled_components2.default.button is not a function
    at Object.<anonymous> (/path/pixiv-web/node_modules/@charcoal-ui/react/dist/index.cjs:137:54)
```

関連: https://github.com/evanw/esbuild/issues/2581
