### PR TITLE
fix: remove extra margins from `Switch`

### DIFF
--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -4,7 +4,7 @@ import React, { useRef, useMemo } from 'react'
 import { useToggleState } from 'react-stately'
 import styled from 'styled-components'
 import { theme } from '../../styled'
-import { disabledSelector, px } from '@charcoal-ui/utils'
+import { disabledSelector } from '@charcoal-ui/utils'
 
 export type SwitchProps = {
   name: string
@@ -59,7 +59,6 @@ const Label = styled.label`
   display: inline-grid;
   grid-template-columns: auto 1fr;
   align-items: center;
-  gap: ${({ theme }) => px(theme.spacing[4])};
   cursor: pointer;
   outline: 0;
 
@@ -71,7 +70,11 @@ const Label = styled.label`
 `
 
 const LabelInner = styled.div`
-  ${theme((o) => [o.typography(14), o.font.text2])}
+  ${theme((o) => [
+    o.typography(14).preserveHalfLeading,
+    o.font.text2,
+    o.margin.left(4),
+  ])}
 `
 
 const SwitchInput = styled.input.attrs({
@@ -91,6 +94,7 @@ const SwitchInput = styled.input.attrs({
       o.height.px(16),
       o.bg.text4.hover.press,
       o.outline.default.focus,
+      o.margin.all(0),
     ])}
 
     &::after {


### PR DESCRIPTION
## やったこと
- `Switch`コンポーネントで用いられている`<input>`についているuser agent stylesheetのmarginを上書きして取り除く
- `grid-template-columns: auto 1fr`と`gap`の併用により、unlabeledな場合に必ず右端部に余白がついてしまうのを取り除く

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] README やドキュメントに影響があることを確認した
