### PR TITLE
feat(react): dropdownselector の width を 100% にする

### DIFF
--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -18,16 +18,18 @@ type Props = Omit<
 >
 export const Default: Story<Props> = (props) => {
   return (
-    <DropdownSelector
-      {...props}
-      placeholder={props.placeholder ?? 'Drop Down menu'}
-      onChange={action('change')}
-      onOpenChange={action('open')}
-    >
-      <DropdownSelectorItem key="k:1">選択肢1</DropdownSelectorItem>
-      <DropdownSelectorItem key="k:2">選択肢2</DropdownSelectorItem>
-      <DropdownSelectorItem key="k:3">選択肢3</DropdownSelectorItem>
-    </DropdownSelector>
+    <div style={{ width: 288 }}>
+      <DropdownSelector
+        {...props}
+        placeholder={props.placeholder ?? 'Drop Down menu'}
+        onChange={action('change')}
+        onOpenChange={action('open')}
+      >
+        <DropdownSelectorItem key="k:1">選択肢1</DropdownSelectorItem>
+        <DropdownSelectorItem key="k:2">選択肢2</DropdownSelectorItem>
+        <DropdownSelectorItem key="k:3">選択肢3</DropdownSelectorItem>
+      </DropdownSelector>
+    </div>
   )
 }
 Default.args = {
@@ -52,17 +54,19 @@ export const HasLabel: Story<HasLabelProps> = ({ disabled }) => {
     assertiveText: 'Hint',
   }
   return (
-    <DropdownSelector
-      {...defaultProps}
-      disabled={disabled}
-      placeholder={'Drop Down menu'}
-      onChange={action('change')}
-      onOpenChange={action('open')}
-    >
-      <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
-      <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
-      <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
-    </DropdownSelector>
+    <div style={{ width: 288 }}>
+      <DropdownSelector
+        {...defaultProps}
+        disabled={disabled}
+        placeholder={'Drop Down menu'}
+        onChange={action('change')}
+        onOpenChange={action('open')}
+      >
+        <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
+        <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
+        <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
+      </DropdownSelector>
+    </div>
   )
 }
 
@@ -86,18 +90,20 @@ export const WithSeparator: Story<WithSeparatorProps> = ({
     assertiveText: 'Hint',
   }
   return (
-    <DropdownSelector
-      {...defaultProps}
-      mode={mode}
-      placeholder={'Drop Down menu'}
-      onChange={action('change')}
-      onOpenChange={action('open')}
-      {...props}
-    >
-      <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
-      <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
-      <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
-    </DropdownSelector>
+    <div style={{ width: 288 }}>
+      <DropdownSelector
+        {...defaultProps}
+        mode={mode}
+        placeholder={'Drop Down menu'}
+        onChange={action('change')}
+        onOpenChange={action('open')}
+        {...props}
+      >
+        <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
+        <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
+        <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
+      </DropdownSelector>
+    </div>
   )
 }
 
@@ -115,17 +121,19 @@ export const Invalid: Story<InvalidProps> = ({ disabled }) => {
     invalid: true,
   }
   return (
-    <DropdownSelector
-      {...props}
-      disabled={disabled}
-      placeholder={'Drop Down menu'}
-      onChange={action('change')}
-      onOpenChange={action('open')}
-    >
-      <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
-      <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
-      <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
-    </DropdownSelector>
+    <div style={{ width: 288 }}>
+      <DropdownSelector
+        {...props}
+        disabled={disabled}
+        placeholder={'Drop Down menu'}
+        onChange={action('change')}
+        onOpenChange={action('open')}
+      >
+        <DropdownSelectorItem key="1">選択肢1</DropdownSelectorItem>
+        <DropdownSelectorItem key="2">選択肢2</DropdownSelectorItem>
+        <DropdownSelectorItem key="3">選択肢3</DropdownSelectorItem>
+      </DropdownSelector>
+    </div>
   )
 }
 

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -148,6 +148,7 @@ export const DropdownSelectorItem = Item
 const DropdownSelectorRoot = styled.div`
   position: relative;
   display: inline-block;
+  width: 100%;
 
   ${disabledSelector} {
     cursor: default;
@@ -171,7 +172,7 @@ const DropdownButton = styled.button<{ invalid: boolean }>`
   align-items: center;
 
   height: 40px;
-  width: 288px;
+  width: 100%;
   box-sizing: border-box;
   cursor: pointer;
 


### PR DESCRIPTION
## やったこと

- width: 100% にして wrapper で size 調整できるようにした
- https://github.com/pixiv/charcoal/issues/222

## 動作確認環境
- storybook
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した

## 備考
dropdownselector の overlay がおかしくなるバグに関してはちょっと時間がかかりそうだったので別の PR にします
