### PR TITLE
feat(react): fix checkbox check icon position

### DIFF
--- a/packages/react/src/components/Checkbox/index.story.tsx
+++ b/packages/react/src/components/Checkbox/index.story.tsx
@@ -18,17 +18,35 @@ type Props = {
 export const Labelled: Story<Props> = (props) => {
   return (
     <div>
-      <Checkbox
-        {...props}
-        name="labelled"
-        label="label"
-        onBlur={action('blur')}
-        onClick={action('click')}
-        onChange={action('change')}
-        onFocus={action('focus')}
-      >
-        同意する
-      </Checkbox>
+      <div style={{ marginBottom: '1em' }}>
+        <Checkbox
+          {...props}
+          name="labelled"
+          label="label"
+          onBlur={action('blur')}
+          onClick={action('click')}
+          onChange={action('change')}
+          onFocus={action('focus')}
+        >
+          同意する
+        </Checkbox>
+      </div>
+
+      <div>
+        <Checkbox
+          {...props}
+          name="labelled"
+          label="label"
+          onBlur={action('blur')}
+          onClick={action('click')}
+          onChange={action('change')}
+          onFocus={action('focus')}
+        >
+          <span style={{ width: 200, display: 'block' }}>
+            同意する同意する同意する同意する同意する同意する同意する同意する同意する同意する同意する同意する同意する
+          </span>
+        </Checkbox>
+      </div>
     </div>
   )
 }

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -127,5 +127,6 @@ const InputLabel = styled.div`
   ${theme((o) => [o.font.text2])}
 
   font-size: 14px;
+  /** checkbox の height が 20px なのでcheckbox と text が揃っているように見せるために行ボックスの高さを 20px にしている */
   line-height: 20px;
 `

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -53,10 +53,12 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     return (
       <InputRoot aria-disabled={isDisabled}>
-        <CheckboxInput type="checkbox" {...inputProps} />
-        <CheckboxInputOverlay aria-hidden={true} checked={inputProps.checked}>
-          <Icon name="24/Check" unsafeNonGuidelineScale={2 / 3} />
-        </CheckboxInputOverlay>
+        <CheckboxRoot>
+          <CheckboxInput type="checkbox" {...inputProps} />
+          <CheckboxInputOverlay aria-hidden={true} checked={inputProps.checked}>
+            <Icon name="24/Check" unsafeNonGuidelineScale={2 / 3} />
+          </CheckboxInputOverlay>
+        </CheckboxRoot>
 
         {'children' in props && <InputLabel>{props.children}</InputLabel>}
       </InputRoot>
@@ -73,7 +75,7 @@ const hiddenCss = css`
 const InputRoot = styled.label`
   position: relative;
   display: flex;
-  align-items: center;
+
   cursor: pointer;
   ${disabledSelector} {
     cursor: default;
@@ -81,6 +83,10 @@ const InputRoot = styled.label`
 
   gap: ${({ theme }) => px(theme.spacing[4])};
   ${theme((o) => [o.disabled])}
+`
+
+const CheckboxRoot = styled.div`
+  position: relative;
 `
 
 const CheckboxInput = styled.input`
@@ -118,5 +124,8 @@ const CheckboxInputOverlay = styled.div<{ checked?: boolean }>`
 `
 
 const InputLabel = styled.div`
-  ${theme((o) => [o.typography(14), o.font.text2])}
+  ${theme((o) => [o.font.text2])}
+
+  font-size: 14px;
+  line-height: 20px;
 `


### PR DESCRIPTION
## やったこと

- https://github.com/pixiv/charcoal/issues/221

## 動作確認環境

- storybook で確認
 
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した

- `theme(o => o.typograpy(14))` を使うのをやめた
  - negative margin を使用して line-height を打ち消している部分が 1 行のとき checkbox と高さを合わせる見た目の弊害になったため
- 実装は mantine の checkbox を参照した
  - https://mantine.dev/core/checkbox/
 
<img width="339" alt="スクリーンショット 2023-02-09 1 22 25" src="https://user-images.githubusercontent.com/32933709/217589423-f3c1dcc2-29d3-4920-a34f-b168e30a3281.png">

