### PR TITLE
dropdwonselector 使用時に下の要素が見えてしまう問題を修正

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.21",
+    "@types/use-sync-external-store": "^0.0.3",
     "@types/warning": "^3.0.0",
     "jest-axe": "^5.0.1",
     "jest-styled-components": "^7.0.8",
@@ -68,6 +69,7 @@
     "polished": "^4.1.4",
     "react-spring": "^9.0.0",
     "react-stately": "^3.19.0",
+    "use-sync-external-store": "^1.2.0",
     "warning": "^4.0.3"
   },
   "peerDependencies": {

--- a/packages/react/src/components/DropdownSelector/Popover.tsx
+++ b/packages/react/src/components/DropdownSelector/Popover.tsx
@@ -1,45 +1,37 @@
-import { FocusScope } from '@react-aria/focus'
-import { DismissButton, useOverlay } from '@react-aria/overlays'
+import { DismissButton, Overlay, usePopover } from '@react-aria/overlays'
 import React, {
   FC,
   useRef,
   useMemo,
   PropsWithChildren,
   memo,
-  CSSProperties,
+  RefObject,
 } from 'react'
-import { mergeProps } from '@react-aria/utils'
+import type { OverlayTriggerState } from 'react-stately'
 
 type Props = PropsWithChildren<{
-  open?: boolean
-  onClose?: () => void
-  style?: CSSProperties
   className?: string
+  triggerRef: RefObject<Element>
+  state: OverlayTriggerState
 }>
 
-const Popover: FC<Props> = ({ open, onClose, children, ...props }) => {
+const Popover: FC<Props> = ({ children, state, triggerRef, className }) => {
   const ref = useRef<HTMLDivElement>(null)
 
-  const { overlayProps } = useOverlay(
-    useMemo(
-      () => ({
-        isOpen: open,
-        onClose,
-        shouldCloseOnBlur: true,
-        isDismissable: true,
-      }),
-      [onClose, open]
-    ),
-    ref
+  const { popoverProps, underlayProps } = usePopover(
+    useMemo(() => ({ triggerRef, popoverRef: ref }), [triggerRef]),
+    state
   )
 
   return (
-    <FocusScope restoreFocus>
-      <div {...mergeProps(overlayProps, props)} ref={ref}>
+    <Overlay>
+      <div {...underlayProps} style={{ position: 'fixed', inset: 0 }} />
+      <div {...popoverProps} ref={ref} className={className}>
+        <DismissButton onDismiss={() => state.close()} />
         {children}
-        <DismissButton onDismiss={onClose} />
+        <DismissButton onDismiss={() => state.close()} />
       </div>
-    </FocusScope>
+    </Overlay>
   )
 }
 

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -18,16 +18,33 @@ type Props = Omit<
 >
 export const Default: Story<Props> = (props) => {
   return (
-    <DropdownSelector
-      {...props}
-      placeholder={props.placeholder ?? 'Drop Down menu'}
-      onChange={action('change')}
-      onOpenChange={action('open')}
-    >
-      <DropdownSelectorItem key="k:1">選択肢1</DropdownSelectorItem>
-      <DropdownSelectorItem key="k:2">選択肢2</DropdownSelectorItem>
-      <DropdownSelectorItem key="k:3">選択肢3</DropdownSelectorItem>
-    </DropdownSelector>
+    <>
+      <div style={{ marginBottom: '1em', width: 500 }}>
+        <DropdownSelector
+          {...props}
+          placeholder={props.placeholder ?? 'Drop Down menu'}
+          onChange={action('change')}
+          onOpenChange={action('open')}
+        >
+          <DropdownSelectorItem key="k:1">選択肢1</DropdownSelectorItem>
+          <DropdownSelectorItem key="k:2">選択肢2</DropdownSelectorItem>
+          <DropdownSelectorItem key="k:3">選択肢3</DropdownSelectorItem>
+        </DropdownSelector>
+      </div>
+
+      <div style={{ width: 288 }}>
+        <DropdownSelector
+          {...props}
+          placeholder={props.placeholder ?? 'Drop Down menu'}
+          onChange={action('change')}
+          onOpenChange={action('open')}
+        >
+          <DropdownSelectorItem key="k:1">選択肢1</DropdownSelectorItem>
+          <DropdownSelectorItem key="k:2">選択肢2</DropdownSelectorItem>
+          <DropdownSelectorItem key="k:3">選択肢3</DropdownSelectorItem>
+        </DropdownSelector>
+      </div>
+    </>
   )
 }
 Default.args = {

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -19,7 +19,7 @@ type Props = Omit<
 export const Default: Story<Props> = (props) => {
   return (
     <>
-      <div style={{ marginBottom: '1em', width: "100%" }}>
+      <div style={{ marginBottom: '1em', width: '100%' }}>
         <DropdownSelector
           {...props}
           placeholder={props.placeholder ?? 'Drop Down menu'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,6 +2083,7 @@ __metadata:
     "@types/react-dom": ^17.0.11
     "@types/react-router-dom": ^5.3.3
     "@types/styled-components": ^5.1.21
+    "@types/use-sync-external-store": ^0.0.3
     "@types/warning": ^3.0.0
     jest-axe: ^5.0.1
     jest-styled-components: ^7.0.8
@@ -2097,6 +2098,7 @@ __metadata:
     styled-components: ^5.3.3
     tsup: ^6.5.0
     typescript: ^4.5.5
+    use-sync-external-store: ^1.2.0
     warning: ^4.0.3
   peerDependencies:
     react: ">=16.13.1"
@@ -8252,6 +8254,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/unist@npm:2.0.3"
   checksum: 4427306b094561da28164e7e5250c4e6b382cb8eac40bf7e6bb0ff1e6e00c13e47aaf32e4a08fc8ba54602d07f79a39fb9ba304cc9dc886b1e3caf824649edbd
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/use-sync-external-store@npm:0.0.3"
+  checksum: 161ddb8eec5dbe7279ac971531217e9af6b99f7783213566d2b502e2e2378ea19cf5e5ea4595039d730aa79d3d35c6567d48599f69773a02ffcff1776ec2a44e
   languageName: node
   linkType: hard
 
@@ -25628,7 +25637,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:1.2.0":
+"use-sync-external-store@npm:1.2.0, use-sync-external-store@npm:^1.2.0":
   version: 1.2.0
   resolution: "use-sync-external-store@npm:1.2.0"
   peerDependencies:


### PR DESCRIPTION
## やったこと

- popover のコンポーネントを react-aria に現在乗っているものに修正
  - https://react-spectrum.adobe.com/react-aria/useSelect.html#popover
- それにあたって portal を使って selector item が rendering されるようになり width が inner item の長さ依存になったので button の width を同期するようにした

## 動作確認環境
storybook

|before|after|
|---|---|
|<img width="609" alt="スクリーンショット 2023-02-08 22 53 34" src="https://user-images.githubusercontent.com/32933709/217608375-ec00649f-3448-40c4-abd3-c10522a0a326.png">|<img width="725" alt="スクリーンショット 2023-02-09 2 33 31" src="https://user-images.githubusercontent.com/32933709/217608432-94f9e21b-2e6a-434d-ba1e-8b61bf868408.png">|

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した

## 備考
- use-sync-external-store を入れた
  - dom の resize 検知をするために入れたが普通に useEffect でもいいなぁと思っている
  - dom の state も react から見ると external store になるので use-sync-external-store のほうが適切だと思いこちらを使用した