### PR TITLE
fix: ModalをStrictModeに対応 + Modalの表示でスクロールできないバグ修正

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -4,7 +4,6 @@ import {
   Overlay,
   useModalOverlay,
   useOverlay,
-  usePreventScroll,
 } from '@react-aria/overlays'
 import styled, { css, useTheme } from 'styled-components'
 import { theme } from '../../styled'

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -29,8 +29,10 @@ export type ModalProps = AriaModalOverlayProps &
     isOpen: boolean
     onClose: () => void
 
-    // NOTICE: デフォルト値を与えてはならない
-    // （たとえば document.body をデフォルト値にすると SSR できなくなる）
+    /**
+     * https://github.com/adobe/react-spectrum/issues/3787
+     * Next.jsで使用する際に発生するエラーの一時的な回避策でdocument.bodyを指定する必要がある
+     */
     portalContainer?: HTMLElement
   }
 
@@ -126,7 +128,7 @@ export default function Modal({
   return transition(
     ({ backgroundColor, transform }, item) =>
       item && (
-        <Overlay>
+        <Overlay portalContainer={portalContainer}>
           <ModalBackground
             zIndex={zIndex}
             {...underlayProps}

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -80,7 +80,6 @@ export default function Modal({
   const ref = useRef<HTMLDivElement>(null)
   const { overlayProps, underlayProps } = useOverlay(props, ref)
 
-  usePreventScroll()
   const { modalProps } = useModalOverlay(
     props,
     {


### PR DESCRIPTION
## やったこと
- ModalをStrictModeに対応
  - document.bodyをportalContainerに指定することで回避することができる
- Modalの表示でスクロールできないバグ修正
  - Modalを開かなくてもレンダリングするだけで画面のスクロールができなくなるバグを修正

## 動作確認環境
Storybook
