### PR TITLE
bundle size を PR ごとに計測する仕組みを入れてみる

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,13 @@
+name: Bundle Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: './packages/**/dist/*.{ts,cjs,js,map}'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: './packages/**/dist/*.{ts,cjs,js,map}'
+          pattern: './packages/**/dist/*'
+          exclude: '**/*.map' # sourcemap は見ない

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,5 +10,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: './packages/**/dist/*'
-          exclude: '**/*.map' # sourcemap は見ない
+          pattern: './packages/**/dist/**/*.{ts,js,cjs}' # sourcemap は見ない

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -10,4 +10,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: preactjs/compressed-size-action@v2
         with:
-          pattern: './packages/**/dist/**/*.{ts,js,cjs}' # sourcemap は見ない
+          build-script: 'build'
+          clean-script: 'clean'
+
+          # パフォーマンス面の計測よりも、誤って変なものを bundle したことを検知したいので圧縮前で比較する
+          compression: 'none'
+
+          # sourcemap は見ない
+          # d.ts はたまに異常な数の union 型が展開されるとかは検知したいが見なくて良いかもしれない
+          pattern: './packages/**/dist/**/*.{ts,js,cjs}'


### PR DESCRIPTION
## やったこと

bundle size を PR ごとに計測する仕組みを入れてみる（ preact 公式の作った Action ）

https://github.com/preactjs/compressed-size-action

純粋にライブラリの重さを意識できるし、また https://github.com/pixiv/charcoal/pull/226 のような「間違って dist に依存の依存が含まれてしまった」といったミスに気づくチャンスも増えるという期待もある。

いまだと 1 バイトでも増えたら報告の対象になるっぽいのでここは要調整かも。

あとデフォルトでは gzip した状態を比較するっぽい（圧縮前で比較したほうが良い？）

## 動作確認環境

この PR にちゃんとしたコメントが来れば良い（ アクセストークンは特にセットアップしなくても動くはず ）。

push ごとのほうが良いか？と思ったが `on: [pull_request]` はふつうに PR 更新時にも発火するらしいので OK

https://zenn.dev/snowcait/articles/dc1851e421e600#pr-%E3%81%8C%E6%9B%B4%E6%96%B0%E3%81%95%E3%82%8C%E3%81%9F%E3%81%A8%E3%81%8D%E3%81%AB%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
