### PR TITLE
chore: prefer node-version-file always

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: '.node-version'
           cache: yarn
 
       - run: yarn install --immutable --inline-builds


### PR DESCRIPTION
## やったこと

CI 上でリポジトリの node-version と異なるバージョンの Node.js が意図せず使われているケースがある。

これのせいでビルドに失敗したのを見たので直したい

例: https://github.com/pixiv/charcoal/actions/runs/4220752310/jobs/7327328447

```
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
```

とりあえず Node.js のバージョン指定に常に .node-version を使うように変える

## 動作確認環境

CI が通るか

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
