### PR TITLE
@charcoal-ui/styled に簡単なスナップショットテストを追加

### DIFF
--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -19,11 +19,14 @@
   },
   "devDependencies": {
     "@types/react": "^17.0.38",
+    "@types/react-test-renderer": "^17.0.2",
     "@types/styled-components": "^5.1.21",
     "@types/warning": "^3.0.0",
+    "jest-styled-components": "^7.1.1",
     "microbundle": "^0.14.2",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.2",
+    "react-test-renderer": "^17.0.2",
     "rimraf": "^3.0.2",
     "styled-components": "^5.3.3",
     "typescript": "^4.5.5"

--- a/packages/styled/src/__snapshots__/index.test.tsx.snap
+++ b/packages/styled/src/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`theme() <Example /> 1`] = `
+exports[`Story <Example /> 1`] = `
 .c1 {
   background-color: var(--charcoal-surface3);
   color: var(--charcoal-text4);
@@ -753,7 +753,7 @@ exports[`theme() <Example /> 1`] = `
 </div>
 `;
 
-exports[`theme() <TailwindLike /> 1`] = `
+exports[`Story <TailwindLike /> 1`] = `
 <div
   css="
       display: flex;

--- a/packages/styled/src/__snapshots__/index.test.tsx.snap
+++ b/packages/styled/src/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,768 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`theme() <Example /> 1`] = `
+.c1 {
+  background-color: var(--charcoal-surface3);
+  color: var(--charcoal-text4);
+  font-size: 32px;
+  line-height: 40px;
+  font-family: monospace;
+  display: flow-root;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  padding-top: 64px;
+  padding-left: 64px;
+}
+
+.c1::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c1::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c0 {
+  background-color: var(--charcoal-surface2);
+  color: var(--charcoal-text2);
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  padding-top: 36px;
+  padding-bottom: 36px;
+  padding-right: 40px;
+  padding-left: 40px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c2 {
+  background-color: var(--charcoal-surface2);
+  padding-top: 40px;
+  padding-bottom: 40px;
+  padding-right: 40px;
+  padding-left: 40px;
+}
+
+.c3 {
+  background-color: var(--charcoal-surface4);
+  color: var(--charcoal-text5);
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  display: flow-root;
+  height: 40px;
+}
+
+.c3::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c3::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c4 {
+  background-color: var(--charcoal-surface3);
+  color: var(--charcoal-text1);
+  font-size: 16px;
+  line-height: 24px;
+  display: flow-root;
+  width: 392px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c5 {
+  height: 64px;
+}
+
+.c6 {
+  background-color: var(--charcoal-surface4);
+  color: var(--charcoal-text5);
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  margin-top: 64px;
+  margin-bottom: 24px;
+  padding-top: 60px;
+  padding-bottom: 60px;
+  padding-right: 64px;
+  padding-left: 64px;
+  -webkit-transition: 0.2s color,0.2s background-color;
+  transition: 0.2s color,0.2s background-color;
+}
+
+.c6:hover:not(:disabled):not([aria-disabled]),
+.c6:hover[aria-disabled=false] {
+  background-color: var(--charcoal-surface4-hover);
+}
+
+.c6:active:not(:disabled):not([aria-disabled]),
+.c6:active[aria-disabled=false] {
+  background-color: var(--charcoal-surface4-press);
+}
+
+.c6:hover:not(:disabled):not([aria-disabled]),
+.c6:hover[aria-disabled=false] {
+  color: var(--charcoal-text5-hover);
+}
+
+.c6:active:not(:disabled):not([aria-disabled]),
+.c6:active[aria-disabled=false] {
+  color: var(--charcoal-text5-press);
+}
+
+.c8 {
+  background-color: var(--charcoal-surface3);
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: bold;
+  display: flow-root;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-right: 24px;
+  padding-left: 24px;
+}
+
+.c8::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c8::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c7 {
+  background-color: var(--charcoal-surface3);
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: bold;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-right: 24px;
+  padding-left: 24px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c9 {
+  background-color: var(--charcoal-surface3);
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: bold;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-right: 24px;
+  padding-left: 24px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c10 {
+  background-color: var(--charcoal-surface3);
+  color: var(--charcoal-text2);
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  display: flow-root;
+  width: 288px;
+  height: 64px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c10::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c10::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c11 {
+  display: grid;
+  grid-auto-flow: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  gap: 16px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c12 {
+  font: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-style: none;
+  cursor: pointer;
+  background-color: var(--charcoal-brand);
+  color: var(--charcoal-text5);
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: bold;
+  display: flow-root;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  border-radius: 999999px;
+  -webkit-transition: 0.2s color,0.2s background-color,0.2s box-shadow;
+  transition: 0.2s color,0.2s background-color,0.2s box-shadow;
+}
+
+.c12:focus {
+  outline: none;
+}
+
+.c12:hover:not(:disabled):not([aria-disabled]),
+.c12:hover[aria-disabled=false] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c12:active:not(:disabled):not([aria-disabled]),
+.c12:active[aria-disabled=false] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c12:hover:not(:disabled):not([aria-disabled]),
+.c12:hover[aria-disabled=false] {
+  color: var(--charcoal-text5-hover);
+}
+
+.c12:active:not(:disabled):not([aria-disabled]),
+.c12:active[aria-disabled=false] {
+  color: var(--charcoal-text5-press);
+}
+
+.c12::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c12::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c12:disabled,
+.c12[aria-disabled]:not([aria-disabled=false]) {
+  opacity: 0.32;
+}
+
+.c12:not(:disabled):not([aria-disabled]):focus,
+.c12[aria-disabled=false]:focus,
+.c12:not(:disabled):not([aria-disabled]):active,
+.c12[aria-disabled=false]:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c12:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c12[aria-disabled=false]:focus:not(:focus-visible),
+.c12:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
+.c12[aria-disabled=false]:active:not(:focus-visible) {
+  outline: none;
+}
+
+.c12:not(:disabled):not([aria-disabled]):focus-visible,
+.c12[aria-disabled=false]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c12:disabled,
+.c12[aria-disabled]:not([aria-disabled=false]) {
+  cursor: unset;
+}
+
+.c13 {
+  font: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-style: none;
+  height: 40px;
+  width: 184px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-right: 8px;
+  padding-left: 8px;
+  border-radius: 4px;
+  background-color: var(--charcoal-surface3);
+  color: var(--charcoal-text2);
+  font-size: 14px;
+  line-height: 22px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c13:focus {
+  outline: none;
+}
+
+.c13:hover:not(:disabled):not([aria-disabled]),
+.c13:hover[aria-disabled=false] {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c13:disabled,
+.c13[aria-disabled]:not([aria-disabled=false]) {
+  opacity: 0.32;
+}
+
+.c13:not(:disabled):not([aria-disabled]):focus,
+.c13[aria-disabled=false]:focus,
+.c13:not(:disabled):not([aria-disabled]):active,
+.c13[aria-disabled=false]:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c13:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c13[aria-disabled=false]:focus:not(:focus-visible),
+.c13:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
+.c13[aria-disabled=false]:active:not(:focus-visible) {
+  outline: none;
+}
+
+.c13:not(:disabled):not([aria-disabled]):focus-visible,
+.c13[aria-disabled=false]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c14 {
+  font: inherit;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-style: none;
+  height: 40px;
+  width: 184px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  padding-right: 8px;
+  padding-left: 8px;
+  border-radius: 4px;
+  background-color: var(--charcoal-surface3);
+  color: var(--charcoal-text2);
+  font-size: 14px;
+  line-height: 22px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c14:focus {
+  outline: none;
+}
+
+.c14:hover:not(:disabled):not([aria-disabled]),
+.c14:hover[aria-disabled=false] {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c14:disabled,
+.c14[aria-disabled]:not([aria-disabled=false]) {
+  opacity: 0.32;
+}
+
+.c14:not(:disabled):not([aria-disabled]):focus,
+.c14[aria-disabled=false]:focus,
+.c14:not(:disabled):not([aria-disabled]):active,
+.c14[aria-disabled=false]:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c14:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c14[aria-disabled=false]:focus:not(:focus-visible),
+.c14:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
+.c14[aria-disabled=false]:active:not(:focus-visible) {
+  outline: none;
+}
+
+.c14:not(:disabled):not([aria-disabled]):focus-visible,
+.c14[aria-disabled=false]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c14.c14:not(:disabled):not([aria-disabled]),
+.c14.c14[aria-disabled=false] {
+  box-shadow: 0 0 0 4px rgba(255,43,0,0.32);
+}
+
+.c15 {
+  background-color: var(--charcoal-background1);
+  color: var(--charcoal-text2);
+  font-size: 14px;
+  line-height: 22px;
+  width: 392px;
+  margin-top: 40px;
+  margin-bottom: 40px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-right: 24px;
+  padding-left: 24px;
+  border: solid 1px rgba(0,0,0,0.08);
+  border-radius: 8px;
+}
+
+.c16 {
+  position: relative;
+  z-index: 0;
+  overflow: hidden;
+  color: var(--charcoal-text5);
+  width: 184px;
+  padding-top: 36px;
+  padding-bottom: 36px;
+  padding-right: 40px;
+  padding-left: 40px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  border-radius: 8px;
+  -webkit-transition: 0.2s color;
+  transition: 0.2s color;
+  text-align: center;
+}
+
+.c16::before {
+  z-index: -1;
+  content: '';
+  display: block;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  -webkit-transition: 0.2s background-color;
+  transition: 0.2s background-color;
+}
+
+.c16::after {
+  z-index: -2;
+  content: '';
+  display: block;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-color: #d1ff1a;
+  background-image: linear-gradient(to right,#d1ff1a 0%,#1ad1ff 100%);
+}
+
+.c16:hover:not(:disabled):not([aria-disabled])::before,
+.c16:hover[aria-disabled=false]::before {
+  background-color: rgba(0,0,0,0.04);
+}
+
+.c16:active:not(:disabled):not([aria-disabled])::before,
+.c16:active[aria-disabled=false]::before {
+  background-color: rgba(0,0,0,0.16);
+}
+
+.c16:hover:not(:disabled):not([aria-disabled]),
+.c16:hover[aria-disabled=false] {
+  color: var(--charcoal-text5-hover);
+}
+
+.c16:active:not(:disabled):not([aria-disabled]),
+.c16:active[aria-disabled=false] {
+  color: var(--charcoal-text5-press);
+}
+
+.c17 {
+  background-color: #d1ff1a;
+  background-image: linear-gradient(to right,#d1ff1a 0%,#1ad1ff 100%);
+  color: var(--charcoal-text5);
+  width: 184px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  display: flow-root;
+  border-radius: 8px;
+  -webkit-transition: 0.2s color;
+  transition: 0.2s color;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  padding-right: 40px;
+  padding-left: 40px;
+  text-align: center;
+}
+
+.c17:hover:not(:disabled):not([aria-disabled]),
+.c17:hover[aria-disabled=false] {
+  background-color: #c9f519;
+  background-image: linear-gradient(to right,#c9f519 0%,#19c9f5 100%);
+}
+
+.c17:active:not(:disabled):not([aria-disabled]),
+.c17:active[aria-disabled=false] {
+  background-color: #b0d616;
+  background-image: linear-gradient(to right,#b0d616 0%,#16b0d6 100%);
+}
+
+.c17:hover:not(:disabled):not([aria-disabled]),
+.c17:hover[aria-disabled=false] {
+  color: var(--charcoal-text5-hover);
+}
+
+.c17:active:not(:disabled):not([aria-disabled]),
+.c17:active[aria-disabled=false] {
+  color: var(--charcoal-text5-press);
+}
+
+.c17::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c17::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c18 {
+  width: 288px;
+  margin-top: 24px;
+  margin-bottom: 24px;
+}
+
+.c19 {
+  display: inline-block;
+  width: 100%;
+  background-color: var(--charcoal-surface4);
+  color: var(--charcoal-text5);
+  padding-top: 16px;
+  padding-bottom: 16px;
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.c20 {
+  --charcoal-text1: #ffff00;
+  --charcoal-text1-hover: #f5f500;
+  --charcoal-text1-press: #d6d600;
+  background-color: var(--charcoal-surface4);
+  color: var(--charcoal-text1);
+}
+
+<div
+  className=""
+>
+  <div
+    className="c0"
+  >
+    Sample
+  </div>
+  <div
+    className="c1"
+  >
+    Left Top Padding
+  </div>
+  <div
+    className="c2"
+  >
+    <div
+      className="c3"
+    >
+      Nested
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Autem dolores, recusandae quidem mollitia eum non vel architecto possimus repudiandae quis molestias neque facilis rem dolorum voluptatem impedit nemo praesentium voluptas.
+  </div>
+  <div
+    className="c4 c5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Autem dolores, recusandae quidem mollitia eum non vel architecto possimus repudiandae quis molestias neque facilis rem dolorum voluptatem impedit nemo praesentium voluptas.
+  </div>
+  <div
+    className="c6"
+  >
+    With effects
+  </div>
+  <div
+    className="c7"
+  >
+    Without half-leading
+  </div>
+  <div
+    className="c8"
+  >
+    Without half-leading (No optimization)
+  </div>
+  <div
+    className="c9"
+  >
+    With half-leading
+  </div>
+  <div
+    className="c10"
+  >
+    Fixed size box
+  </div>
+  <div
+    className="c11"
+  >
+    <button
+      className="c12"
+    >
+      Button
+    </button>
+    <button
+      className="c12"
+      disabled={true}
+    >
+      Disabled
+    </button>
+  </div>
+  <div
+    className="c11"
+  >
+    <input
+      className="c13"
+      type="text"
+      value="text field"
+    />
+    <input
+      className="c13"
+      disabled={true}
+      type="text"
+      value="disabled"
+    />
+    <input
+      className="c14"
+      type="text"
+      value="invalid"
+    />
+  </div>
+  <div
+    className="c15"
+  >
+    Border
+  </div>
+  <div
+    className="c16"
+  >
+    Gradient
+  </div>
+  <div
+    className="c17"
+  >
+    Gradient (Warning)
+  </div>
+  <div
+    css="
+      display: flex;
+    "
+  >
+    <div
+      css={[Function]}
+    >
+      Tailwind like
+    </div>
+  </div>
+  <div
+    className="c18"
+  >
+    <div
+      className="c19"
+    >
+      Full width
+    </div>
+  </div>
+  <div
+    className="c20"
+  >
+    This is actually text1 !
+  </div>
+</div>
+`;
+
+exports[`theme() <TailwindLike /> 1`] = `
+<div
+  css="
+      display: flex;
+    "
+>
+  <div
+    css={[Function]}
+  >
+    Tailwind like
+  </div>
+</div>
+`;

--- a/packages/styled/src/index.story.tsx
+++ b/packages/styled/src/index.story.tsx
@@ -21,7 +21,7 @@ type MyTheme = CharcoalTheme & {
   }
 }
 
-function myTheme(theme: CharcoalTheme): MyTheme {
+export function myTheme(theme: CharcoalTheme): MyTheme {
   return {
     ...theme,
     color: {

--- a/packages/styled/src/index.test.tsx
+++ b/packages/styled/src/index.test.tsx
@@ -12,7 +12,8 @@ function render(children: JSX.Element) {
     .toJSON()
 }
 
-describe('theme()', () => {
+// TODO: もう少し theme() 関数に対する丁寧なユニットテストが欲しい
+describe('Story', () => {
   test('<Example />', () => {
     expect(render(<Example />)).toMatchSnapshot()
   })

--- a/packages/styled/src/index.test.tsx
+++ b/packages/styled/src/index.test.tsx
@@ -1,0 +1,23 @@
+import { light } from '@charcoal-ui/theme'
+import 'jest-styled-components'
+
+import React from 'react'
+import renderder from 'react-test-renderer'
+import { ThemeProvider } from 'styled-components'
+import { Example, myTheme, TailwindLike } from './index.story'
+
+function render(children: JSX.Element) {
+  return renderder
+    .create(<ThemeProvider theme={myTheme(light)}>{children}</ThemeProvider>)
+    .toJSON()
+}
+
+describe('theme()', () => {
+  test('<Example />', () => {
+    expect(render(<Example />)).toMatchSnapshot()
+  })
+
+  test('<TailwindLike />', () => {
+    expect(render(<TailwindLike />)).toMatchSnapshot()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 5
   cacheKey: 8
 
+"@adobe/css-tools@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@adobe/css-tools@npm:4.2.0"
+  checksum: dc5cc92ba3d562e7ffddb79d6d222c7e00b65f255fd2725b3d71490ff268844be322f917415d8c4ab39eca646343b632058db8bd5b1d646193fcc94d1d3e420b
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -1791,11 +1798,14 @@ __metadata:
     "@charcoal-ui/theme": ^2.4.0
     "@charcoal-ui/utils": ^2.4.0
     "@types/react": ^17.0.38
+    "@types/react-test-renderer": ^17.0.2
     "@types/styled-components": ^5.1.21
     "@types/warning": ^3.0.0
+    jest-styled-components: ^7.1.1
     microbundle: ^0.14.2
     npm-run-all: ^4.1.5
     react: ^17.0.2
+    react-test-renderer: ^17.0.2
     rimraf: ^3.0.2
     styled-components: ^5.3.3
     typescript: ^4.5.5
@@ -7327,14 +7337,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^17.0.38":
-  version: 17.0.38
-  resolution: "@types/react@npm:17.0.38"
+"@types/react-test-renderer@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "@types/react-test-renderer@npm:17.0.2"
+  dependencies:
+    "@types/react": ^17
+  checksum: 0be325798b6b38cc31fbb11f2f1e1a5578cc3b23eddf1ddd1ab58ccf50966e8f779383084d8bc3a7db3108ad815af8fbae5c0f54329a88d52200e01547d85c33
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:*, @types/react@npm:^17, @types/react@npm:^17.0.38":
+  version: 17.0.53
+  resolution: "@types/react@npm:17.0.53"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 4079f4f959cd4a4bfaeda8b89fe8a1b1f8bdc9d87acfdc5f74a0b39cec9ec6a470724357c62778c0f063180b360c250e920c5a142f1dbcda67d9cc25a6d43a85
+  checksum: dacfde02c260fd98bed2eb775ed0c7ce1397be4c0844f907a50763b081a4008f81f57071889a16eb1350ddcf0927f3cf1a6541702c8ad03de3c70383ef931e3f
   languageName: node
   linkType: hard
 
@@ -16405,14 +16424,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jest-styled-components@npm:^7.0.8":
-  version: 7.0.8
-  resolution: "jest-styled-components@npm:7.0.8"
+"jest-styled-components@npm:^7.0.8, jest-styled-components@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "jest-styled-components@npm:7.1.1"
   dependencies:
-    css: ^3.0.0
+    "@adobe/css-tools": ^4.0.1
   peerDependencies:
     styled-components: ">= 5"
-  checksum: 0fc3a71c54ece55b8fd4c8304a9db283acac97cdfd8350ff27ff3b0c3da8e798dca87c7ee5fc004b1b0577d632dec44ebea31750238b82395152c0f8a471ea7c
+  checksum: 1376d1211855c459e59e6b030af7294519cd2dd78169a2cb0df185ff4390fff417ab51be3dd520f1e975d2f391f50ff266e803c168ff9f03f3ff7ebbb823d2d7
   languageName: node
   linkType: hard
 
@@ -20704,6 +20723,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0":
+  version: 18.2.0
+  resolution: "react-is@npm:18.2.0"
+  checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -20802,6 +20828,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-shallow-renderer@npm:^16.13.1":
+  version: 16.15.0
+  resolution: "react-shallow-renderer@npm:16.15.0"
+  dependencies:
+    object-assign: ^4.1.1
+    react-is: ^16.12.0 || ^17.0.0 || ^18.0.0
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 6052c7e3e9627485120ebd8257f128aad8f56386fe8d42374b7743eac1be457c33506d153c7886b4e32923c0c352d402ab805ef9ca02dbcd8393b2bdeb6e5af8
+  languageName: node
+  linkType: hard
+
 "react-sizeme@npm:^3.0.1":
   version: 3.0.1
   resolution: "react-sizeme@npm:3.0.1"
@@ -20878,6 +20916,20 @@ fsevents@^1.2.7:
   peerDependencies:
     react: ">= 0.14.0"
   checksum: fa03880a887bc0c79c0be25fc35924980d75f684f8d05620272bdfcbb9f119f45bb7f8ddd92b9e944103964a4e094b99750d0b19c992fd86f2ce0b70266e89c3
+  languageName: node
+  linkType: hard
+
+"react-test-renderer@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react-test-renderer@npm:17.0.2"
+  dependencies:
+    object-assign: ^4.1.1
+    react-is: ^17.0.2
+    react-shallow-renderer: ^16.13.1
+    scheduler: ^0.20.2
+  peerDependencies:
+    react: 17.0.2
+  checksum: e6b5c6ed2a0bde2c34f1ab9523ff9bc4c141a271daf730d6b852374e83acc0155d58ab71a318251e953ebfa65b8bebb9c5dce3eba1ccfcbef7cc4e1e8261c401
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## やったこと

ref: https://github.com/pixiv/charcoal/issues/256

styled のメンテナビリティをあげたいのでリファクタリングをしたいが、現状の挙動がテストされてない。

あんまり丁寧なテストはないが、とりあえず storybook のレンダリング結果をスナップショットテストして回帰テストとして使う

## 動作確認環境

CI が通るかどうか

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
