### PR TITLE
fix: portalContainerをdocument.bodyに設定

### DIFF
--- a/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
+++ b/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
@@ -60,7 +60,7 @@ export function DropdownPopover({ children, state, ...props }: Props) {
   }, [props.value, state.isOpen])
 
   return (
-    <Overlay>
+    <Overlay portalContainer={document.body}>
       <div {...underlayProps} style={{ position: 'fixed', inset: 0 }} />
       <DropdownPopoverDiv {...popoverProps} ref={ref}>
         <DismissButton onDismiss={() => state.close()} />


### PR DESCRIPTION
## やったこと
- DropdownSelectorのportalContainerをdocument.bodyに設定

## なぜやるか
- Next.jsで正常に動作するようにするため（SSR時にOverlayを開いていないことを想定）