### PR TITLE
icons-cli の実行を週一にする

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -2,7 +2,6 @@ name: icons
 
 on:
   schedule:
-    # only on weekday, at 1:00 UTC ( 10:00 JST )
     - cron: '0 1 * * 1'
 
   workflow_dispatch:

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -3,7 +3,7 @@ name: icons
 on:
   schedule:
     # only on weekday, at 1:00 UTC ( 10:00 JST )
-    - cron: '0 1 * * 1-5'
+    - cron: '0 1 * * 1'
 
   workflow_dispatch:
 


### PR DESCRIPTION
## やったこと

icons-cli は Figma に変更があったらいま毎日 PR を送ってくる。

現状のリリース頻度的にこれは週一でも良い（ そうでないと同じ内容の PR が何度も作られてしまいがち ）。

週に１回リリースをする際にこれをレビューするみたいな運用でも良いかも

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
