### PR TITLE
https://github.com/pixiv/charcoal/pull/269 の CI が通らない件調査

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.5"
+    "typescript": "4.6"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "5.0"
+    "typescript": "^5.0.2"
   },
   "resolutions": {
     "@charcoal-ui/foundation": "../packages/foundation",

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.8"
+    "typescript": "4.9"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.6.3"
+    "typescript": "4.5"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,5 +28,18 @@
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
     "typescript": "5.0"
+  },
+  "resolutions": {
+    "@charcoal-ui/foundation": "../packages/foundation",
+    "@charcoal-ui/icon-files": "../packages/icon-files",
+    "@charcoal-ui/icons": "../packages/icons",
+    "@charcoal-ui/icons-cli": "../packages/icons-cli",
+    "@charcoal-ui/react": "../packages/react",
+    "@charcoal-ui/react-sandbox": "../packages/react-sandbox",
+    "@charcoal-ui/styled": "../packages/styled",
+    "@charcoal-ui/tailwind-config": "../packages/tailwind-config",
+    "@charcoal-ui/tailwind-diff": "../packages/tailwind-diff",
+    "@charcoal-ui/theme": "../packages/theme",
+    "@charcoal-ui/utils": "../packages/utils"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.6"
+    "typescript": "4.7"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.7"
+    "typescript": "4.8"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,6 +27,6 @@
     "@types/styled-components": "^5.1.26",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
-    "typescript": "4.9"
+    "typescript": "5.0"
   }
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.9
+    typescript: 5.0
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:5.0":
+  version: 5.0.2
+  resolution: "typescript@npm:5.0.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: bef1dcd166acfc6934b2ec4d72f93edb8961a5fab36b8dd2aaf6f4f4cd5c0210f2e0850aef4724f3b4913d5aef203a94a28ded731b370880c8bcff7e4ff91fc1
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.9#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ddd1e8"
+"typescript@patch:typescript@5.0#~builtin<compat/typescript>":
+  version: 5.0.2
+  resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
+  checksum: bdbf3d0aac0d6cf010fbe0536753dc19f278eb4aba88140dcd25487dfe1c56ca8b33abc0dcd42078790a939b08ebc4046f3e9bb961d77d3d2c3cfa9829da4d53
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.6.3
+    typescript: 4.5
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.6.3":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:4.5":
+  version: 4.5.5
+  resolution: "typescript@npm:4.5.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
+  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.6.3#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=ddd1e8"
+"typescript@patch:typescript@4.5#~builtin<compat/typescript>":
+  version: 4.5.5
+  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: fe6bdc1afb2f145ddb7b0a3a31f96352209f6a5704d97f038414ea22ff9d8dd42f32cfb6652e30458d7d958d2d4e85de2df11c574899c6f750a6b3c0e90a3a76
+  checksum: 9cdde4aae20b2904431f3f2ca8acaf3b0cc52faddf68aa88b288c9d0520221817da43783a756fce7ab9360033ada0371c3ff93dfc4bdb4b13f6e9bac64e1658d
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -161,17 +161,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@charcoal-ui/foundation@npm:^2.5.0":
+"@charcoal-ui/foundation@file:../packages/foundation::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/foundation@npm:2.5.0"
-  checksum: 932e1c82e53cefd6f730a3181bdafadc354b27813f817873996ceabba3aeb6a9ea899c8da3a840e54a22fde5af22d07aae11f887f8672fe972a1c2743efe35cd
+  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=b3ff33&locator=charcoal-web-docs%40workspace%3A."
+  checksum: 65cb07e948892b17ea4535599541eb72d293ebe5a333d017370a562d803728f4d44b1af2d76e372057cfe6467d6ff5948b391bdeeec418229faca4e1d4b533ea
   languageName: node
   linkType: hard
 
-"@charcoal-ui/icon-files@npm:^2.5.0":
+"@charcoal-ui/icon-files@file:../packages/icon-files::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/icon-files@npm:2.5.0"
-  checksum: 7a42a4a80ea2f878984e87cc19f4dd25b0afb9454be1081768f54dd1bd010f3e4dbd576e6c3e939326078a5c514dc0b1f5c08a640726b4bdf16f65df0970b641
+  resolution: "@charcoal-ui/icon-files@file:../packages/icon-files#../packages/icon-files::hash=828292&locator=charcoal-web-docs%40workspace%3A."
+  checksum: 0d9c634aed62bdafb207b7bde6846fe92ea2162eb4f5828197fabf4fc766492f9652fc9f39ae3bcdf06509f89099512cd07f13b43056bdb7fe1c8c0b8080d941
   languageName: node
   linkType: hard
 
@@ -183,17 +183,6 @@ __metadata:
     dompurify: ^2.3.6
     warning: ^4.0.3
   checksum: becb70fa12f0a291e720b75acb0ecb2987a56ac3c85e35d650608373d4824362a82b1def7deb731e7a8b734a50edbde3af43f4f39722be4153a8bcf88ade63f0
-  languageName: node
-  linkType: hard
-
-"@charcoal-ui/icons@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@charcoal-ui/icons@npm:2.5.0"
-  dependencies:
-    "@charcoal-ui/icon-files": ^2.5.0
-    dompurify: ^2.3.6
-    warning: ^4.0.3
-  checksum: 16f2bc8be4f2f5dee8aaf4984204f9ad64e9cc972bb959888b7ae0519965193acc211db879d5ce298d54e5d08b4b0a80b5e7565de5c94a1bb746254da0c6f806
   languageName: node
   linkType: hard
 
@@ -245,21 +234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@charcoal-ui/styled@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@charcoal-ui/styled@npm:2.5.0"
-  dependencies:
-    "@charcoal-ui/foundation": ^2.5.0
-    "@charcoal-ui/theme": ^2.5.0
-    "@charcoal-ui/utils": ^2.5.0
-    warning: ^4.0.3
-  peerDependencies:
-    react: ">=16.13.1"
-    styled-components: ">=5.1.1"
-  checksum: f13a1655258dd17d211d8aba41025b857086381eedf7a22f8dc14ce536948d5324aa7ce7277694694632f417a482f999b4c3749e3955b3bccf82eb612a47a7fa
-  languageName: node
-  linkType: hard
-
 "@charcoal-ui/theme@file:../packages/theme::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
   resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=a0967d&locator=charcoal-web-docs%40workspace%3A."
@@ -271,17 +245,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@charcoal-ui/theme@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@charcoal-ui/theme@npm:2.5.0"
-  dependencies:
-    "@charcoal-ui/foundation": ^2.5.0
-    "@charcoal-ui/utils": ^2.5.0
-    polished: ^4.1.4
-  checksum: 304a07afed17798f1fb01a070e9cb4e5faff1b850cef128f303cef73bdf6001684f7f9e325878369ceed96c5108b8aed81b93c5a56b2bcb2ff82f903d9f30974
-  languageName: node
-  linkType: hard
-
 "@charcoal-ui/utils@file:../packages/utils::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
   resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=d6e255&locator=charcoal-web-docs%40workspace%3A."
@@ -289,16 +252,6 @@ __metadata:
     "@charcoal-ui/foundation": ^2.5.0
     polished: ^4.1.4
   checksum: b263945797146243508e912b13a5461995d81e6c0ddbdca645be884a631789ee3be8e499970cc76e80858ec814195b3ee7b8e8cf59e09c4d97e43b22cae42488
-  languageName: node
-  linkType: hard
-
-"@charcoal-ui/utils@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "@charcoal-ui/utils@npm:2.5.0"
-  dependencies:
-    "@charcoal-ui/foundation": ^2.5.0
-    polished: ^4.1.4
-  checksum: f3307019f068440d2a90ffb09d567d70cdac4607c06c304c3c71736379c84a693ef76554b35bdf82265dda9dadbafedf4f817195ec03584cf49ce8a21689d455
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.5
+    typescript: 4.6
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.5":
-  version: 4.5.5
-  resolution: "typescript@npm:4.5.5"
+"typescript@npm:4.6":
+  version: 4.6.4
+  resolution: "typescript@npm:4.6.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 506f4c919dc8aeaafa92068c997f1d213b9df4d9756d0fae1a1e7ab66b585ab3498050e236113a1c9e57ee08c21ec6814ca7a7f61378c058d79af50a4b1f5a5e
+  checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.5#~builtin<compat/typescript>":
-  version: 4.5.5
-  resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=ddd1e8"
+"typescript@patch:typescript@4.6#~builtin<compat/typescript>":
+  version: 4.6.4
+  resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 9cdde4aae20b2904431f3f2ca8acaf3b0cc52faddf68aa88b288c9d0520221817da43783a756fce7ab9360033ada0371c3ff93dfc4bdb4b13f6e9bac64e1658d
+  checksum: 8cff08bf66d9ecfbf9fcc5edde04a5a7923e6cac3b21d99b4e9a06973bf5bd7f9a83ec7eed24129c1b9e13fd861de8c1070110d4b9ce9f18ab57c6999e9c9a6f
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.6
+    typescript: 4.7
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.6":
-  version: 4.6.4
-  resolution: "typescript@npm:4.6.4"
+"typescript@npm:4.7":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: e7bfcc39cd4571a63a54e5ea21f16b8445268b9900bf55aee0e02ad981be576acc140eba24f1af5e3c1457767c96cea6d12861768fb386cf3ffb34013718631a
+  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.6#~builtin<compat/typescript>":
-  version: 4.6.4
-  resolution: "typescript@patch:typescript@npm%3A4.6.4#~builtin<compat/typescript>::version=4.6.4&hash=ddd1e8"
+"typescript@patch:typescript@4.7#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 8cff08bf66d9ecfbf9fcc5edde04a5a7923e6cac3b21d99b4e9a06973bf5bd7f9a83ec7eed24129c1b9e13fd861de8c1070110d4b9ce9f18ab57c6999e9c9a6f
+  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.8
+    typescript: 4.9
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8":
-  version: 4.8.4
-  resolution: "typescript@npm:4.8.4"
+"typescript@npm:4.9":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.8#~builtin<compat/typescript>":
-  version: 4.8.4
-  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=ddd1e8"
+"typescript@patch:typescript@4.9#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
+  checksum: 2eee5c37cad4390385db5db5a8e81470e42e8f1401b0358d7390095d6f681b410f2c4a0c496c6ff9ebd775423c7785cdace7bcdad76c7bee283df3d9718c0f20
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2432,7 +2432,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 4.7
+    typescript: 4.8
   languageName: unknown
   linkType: soft
 
@@ -4754,23 +4754,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.7":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:4.8":
+  version: 4.8.4
+  resolution: "typescript@npm:4.8.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
+  checksum: 3e4f061658e0c8f36c820802fa809e0fd812b85687a9a2f5430bc3d0368e37d1c9605c3ce9b39df9a05af2ece67b1d844f9f6ea8ff42819f13bcb80f85629af0
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.7#~builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=ddd1e8"
+"typescript@patch:typescript@4.8#~builtin<compat/typescript>":
+  version: 4.8.4
+  resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=ddd1e8"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 96d3030cb01143570567cb4f3a616b10df65f658f0e74e853e77a089a6a954e35c800be7db8b9bfe9a1ae05d9c2897e281359f65e4caa1caf266368e1c4febd3
+  checksum: 563a0ef47abae6df27a9a3ab38f75fc681f633ccf1a3502b1108e252e187787893de689220f4544aaf95a371a4eb3141e4a337deb9895de5ac3c1ca76430e5f0
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -177,12 +177,12 @@ __metadata:
 
 "@charcoal-ui/icons@file:../packages/icons::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=1e530c&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=0d3d75&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icon-files": ^2.5.0
     dompurify: ^2.3.6
     warning: ^4.0.3
-  checksum: f7b6d92845171a90f1e2fa59719ae27e048ec2db7cda1e174a22a0fad133be8eb347c69cefc904c37e9b2fd62c6bd0d3ac2993cae25e57615d287282e794b3b8
+  checksum: becb70fa12f0a291e720b75acb0ecb2987a56ac3c85e35d650608373d4824362a82b1def7deb731e7a8b734a50edbde3af43f4f39722be4153a8bcf88ade63f0
   languageName: node
   linkType: hard
 
@@ -199,7 +199,7 @@ __metadata:
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=ba95c8&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=417ef1&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icons": ^2.5.0
     "@charcoal-ui/styled": ^2.5.0
@@ -226,13 +226,13 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: 695b8dac43462eaaf28081358ee535277e7929dbed719e65f8b9cff48540e55febf9a1456ec9e4b232922c887ffba4b5b22411d886cccf4c1dd353dbb1e83df8
+  checksum: f649d579fbbb348959bd090a426e6c7d555d279e31546a1c9fa6d0c03e58c063ce80b1d69bb2f4f4e60d0d0b1047f32ca903b1f9ed0cea8e975a52a706c0aebb
   languageName: node
   linkType: hard
 
 "@charcoal-ui/styled@file:../packages/styled::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=965c1f&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=38b9f4&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^2.5.0
     "@charcoal-ui/theme": ^2.5.0
@@ -241,7 +241,7 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: 24268d6d6ec14f3775fb2b94b65392f3677533ba92f7feeab6c81c6dd9aa275a87e6e5652b3c7b2d0c22f331237906ee0128c9c37ca4d92494fd2d04dfaa2fc4
+  checksum: e790516ad16bbc99bfd879f56cc890503cbf5c0d956af5e743004419d5a57300c2a8d01149d9f0fc9dc0513bdab9f22e5b6c2dfc0dd61266371c5b5d78fdf427
   languageName: node
   linkType: hard
 
@@ -262,12 +262,12 @@ __metadata:
 
 "@charcoal-ui/theme@file:../packages/theme::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=6ecf96&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=a0967d&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^2.5.0
     "@charcoal-ui/utils": ^2.5.0
     polished: ^4.1.4
-  checksum: f41ba096ea59a267f3ac53f5b95c25378f18f81ca58c6f1eca35282409c840ebd82dfd0d81f10c49ef5a0f932b5b61e5168dee70a9b65df6be6780cfe56c983f
+  checksum: c1d0e85f4d120f074583ed1de30a0aa334532ef6bbcc96d8258d74e66e2a55c2e6b53ec573950f0e3a0410dedcfc3bfd61ea086b30ae7b0acbc6fc9e32ae0550
   languageName: node
   linkType: hard
 
@@ -284,11 +284,11 @@ __metadata:
 
 "@charcoal-ui/utils@file:../packages/utils::locator=charcoal-web-docs%40workspace%3A.":
   version: 2.5.0
-  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=0523f5&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=d6e255&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^2.5.0
     polished: ^4.1.4
-  checksum: e19aece139691f729757ef4d56883594d2e68d2fb9041c214279dc6a50cce9c17d2eaccab3e25d4c54471eac4042799d945b3f73301caab70458b7ff1d6adb25
+  checksum: b263945797146243508e912b13a5461995d81e6c0ddbdca645be884a631789ee3be8e499970cc76e80858ec814195b3ee7b8e8cf59e09c4d97e43b22cae42488
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2385,7 +2385,7 @@ __metadata:
     react: ^18.2.0
     react-dom: 18.2.0
     styled-components: ^5.3.6
-    typescript: 5.0
+    typescript: ^5.0.2
   languageName: unknown
   linkType: soft
 
@@ -4707,7 +4707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.0":
+"typescript@npm:^5.0.2":
   version: 5.0.2
   resolution: "typescript@npm:5.0.2"
   bin:
@@ -4717,7 +4717,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@5.0#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.0.2
   resolution: "typescript@patch:typescript@npm%3A5.0.2#~builtin<compat/typescript>::version=5.0.2&hash=ddd1e8"
   bin:


### PR DESCRIPTION
## やったこと

https://github.com/pixiv/charcoal/pull/269

```
Failed to compile.

./node_modules/@charcoal-ui/styled/src/util.ts:97:22
Type error: No overload matches this call.
  Overload 1 of 2, '(o: {}): string[]', gave the following error.
    Argument of type '_' is not assignable to parameter of type '{}'.
      Type 'T' is not assignable to type '{}'.
  Overload 2 of 2, '(o: object): string[]', gave the following error.
    Argument of type '_' is not assignable to parameter of type 'object'.
      Type 'T' is not assignable to type 'object'.

   95 |   _ extends T = T
   96 | >(obj: _) {
>  97 |   return Object.keys(obj) as unknown as (keyof T & string)[]
      |                      ^
   98 | }
   99 | 
  100 | export interface ReadonlyArrayConstructor {
Error: Process completed with exit code 1.
```

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
