### PR TITLE
fix: Skip docs-hosting-pr workflow when PullRequest from forked repo

### DIFF
--- a/.github/workflows/docs-hosting-pr.yml
+++ b/.github/workflows/docs-hosting-pr.yml
@@ -19,6 +19,10 @@ jobs:
   build_and_preview:
     runs-on: ubuntu-latest
 
+    # NOTE: forkされたリポジトリからのPullRequestだと権限の関係でOIDCによる認証が利用できないためスキップする
+    # c.f. https://github.com/pixiv/charcoal/issues/277
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+
     environment:
       name: preview-channel
       url: ${{ steps.preview_deploy.outputs.details_url }}


### PR DESCRIPTION
## やったこと

#277 の修正

## 原因
https://github.com/pixiv/charcoal/blob/773269152abdd0c2574c8f5a416df19b1a3465ac/.github/workflows/docs-hosting-pr.yml#L47-L52 での認証には https://github.com/pixiv/charcoal/blob/564fef976cf3f213a951b493b51aadb3224ae49c/.github/workflows/docs-hosting-pr.yml#L11 の設定が必要なのですが、 https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token によるとforkされたリポジトリのPRだと `id-token` は最大でも `read` しか付与できないのが原因だと思われます。

## 対応方法
`pull_request_target` にすることでおそらく回避できるとは思うのですが、それだとGitHub ActionsのSecurityを犠牲にして好ましくないためpixiv org外からのPullRequestでWorkflowを実行させないようにしています 😢 

ref. https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

## 動作確認環境
GitHub Actions

## チェックリスト

- [x] 「Deploy to Preview Channel」workflowが実行されないこと

Close #277

