### PR TITLE
chore(react): add classname to tagitem props

### DIFF
--- a/packages/react/src/components/TagItem/index.story.tsx
+++ b/packages/react/src/components/TagItem/index.story.tsx
@@ -25,6 +25,7 @@ Default.args = {
   href: '',
   rel: '',
   target: '',
+  className: '',
 }
 
 export const Playground: Story<TagItemProps> = ({

--- a/packages/react/src/components/TagItem/index.tsx
+++ b/packages/react/src/components/TagItem/index.tsx
@@ -24,6 +24,7 @@ export type TagItemProps = {
   status?: 'default' | 'active' | 'inactive'
   size?: keyof typeof sizeMap
   disabled?: boolean
+  className?: string
 } & Pick<ComponentPropsWithoutRef<'a'>, 'href' | 'target' | 'rel' | 'onClick'>
 
 const TagItem = forwardRef<HTMLAnchorElement, TagItemProps>(
@@ -36,6 +37,7 @@ const TagItem = forwardRef<HTMLAnchorElement, TagItemProps>(
       size = 'M',
       disabled,
       status = 'default',
+      className,
       ...props
     },
     _ref
@@ -60,6 +62,7 @@ const TagItem = forwardRef<HTMLAnchorElement, TagItemProps>(
         size={hasTranslatedLabel ? 'M' : size}
         status={status}
         {...buttonProps}
+        className={className}
       >
         <Background bgColor={bgColor} bgImage={bgImage} status={status} />
 


### PR DESCRIPTION
## やったこと

- https://github.com/pixiv/charcoal/issues/263
  - これの対応として話題に上がった tagitem にだけ className を付けた
  - これ以外の component にもつける場合には一括でつける。forwardRef に関しては内部のどこの component に ref を張るのかは決めないといけない気がする 

## 動作確認環境
- storybook
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
