### PR TITLE
TextField を TextField と TextArea に分ける

### DIFF
--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -57,11 +57,12 @@ const reactList: ListItem[] = [
     'SegmentedControl',
     'Switch',
     'TagItem',
+    'TextArea',
     'TextField',
-  ].map((o) => {
+  ].map((component) => {
     return {
-      text: o,
-      href: `/@charcoal-ui/react/${o}`,
+      text: component,
+      href: `/@charcoal-ui/react/${component}`,
     }
   }),
 ]

--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -45,6 +45,11 @@ export const apiData: Omit<
     description: '入力必須化',
     type: 'boolean',
   },
+  autoFocus: {
+    default: 'false',
+    description: 'オートフォーカスをするか',
+    type: 'boolean',
+  },
   requiredText: {
     default: '',
     description: '必須を示すのテキスト',

--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -27,7 +27,7 @@ export const apiData: Omit<
   },
   excludeFromTabOrder: {
     default: 'false',
-    description: '(非推奨）',
+    description: 'Tabキーを押したときにフォーカスの対象から除く',
     type: 'boolean',
   },
   invalid: {

--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -26,11 +26,6 @@ export const apiData: Omit<
     description: '高さを自動で変える',
     type: 'boolean',
   },
-  excludeFromTabOrder: {
-    default: 'false',
-    description: 'Tabキーを押したときにフォーカスの対象から除く',
-    type: 'boolean',
-  },
   invalid: {
     default: 'false',
     description: '入力が不正か',

--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -32,7 +32,7 @@ export const apiData: Omit<
   },
   invalid: {
     default: 'false',
-    description: '入力の不正化',
+    description: '入力が不正か',
     type: 'boolean',
   },
   maxLength: {
@@ -42,7 +42,7 @@ export const apiData: Omit<
   },
   required: {
     default: 'false',
-    description: '入力必須化',
+    description: '入力必須か',
     type: 'boolean',
   },
   autoFocus: {

--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -1,8 +1,8 @@
-import { TextFieldProps } from '@charcoal-ui/react'
+import { TextAreaProps } from '@charcoal-ui/react'
 import { ApiTableData } from '../_components/ApiTable'
 
 export const apiData: Omit<
-  ApiTableData<TextFieldProps, HTMLInputElement>,
+  ApiTableData<TextAreaProps, HTMLInputElement>,
   'type' | 'value'
 > = {
   label: {
@@ -14,6 +14,11 @@ export const apiData: Omit<
   assistiveText: {
     description: 'エラーのテキスト',
     type: 'string',
+  },
+  autoHeight: {
+    default: 'false',
+    description: '高さを自動で変える',
+    type: 'boolean',
   },
   disabled: {
     default: 'false',
@@ -45,6 +50,11 @@ export const apiData: Omit<
     description: '必須を示すのテキスト',
     type: 'string',
   },
+  rows: {
+    default: '',
+    description: '表示する行数、multilineのみ有効',
+    type: 'number',
+  },
   showCount: {
     default: 'false',
     description: '入力文字数の表示',
@@ -58,9 +68,5 @@ export const apiData: Omit<
   subLabel: {
     description: '右側に表示されるラベル',
     type: 'string',
-  },
-  suffix: {
-    description: 'フィールドの末尾の要素、multilineでは無効',
-    type: 'ReactNode',
   },
 }

--- a/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { TextField } from '@charcoal-ui/react'
+import { TextArea } from '@charcoal-ui/react'
 import { sections } from './sections'
 import { apiData } from './apiData'
 import { InlineCode } from '../../../../components/InlineCode'
@@ -8,21 +8,21 @@ import { SSRHighlight } from '../../../../components/SSRHighlight'
 import { ContentRoot } from '../../../../components/ContentRoot'
 import { ApiTable } from '../_components/ApiTable'
 import { PreviewsList } from '../_components/PreviewsList'
-import styled from 'styled-components'
 import { theme } from '../../../../utils/theme'
+import styled from 'styled-components'
 
-const TextFieldPage: FC = () => {
+const TextAreaPage: FC = () => {
   return (
     <ContentRoot>
-      <h1>Textfield</h1>
+      <h1>TextArea</h1>
       <p>ユーザのテキスト入力を扱うコンポーネント</p>
 
       <h2>BASIC</h2>
       <PreviewDivColumn>
-        <TextField label="textfield" />
+        <TextArea label="TextArea" />
         <SSRHighlight
           lang="typescript"
-          code={`<TextField label="textfield" />`}
+          code={`<TextArea label="TextArea" />`}
         />
       </PreviewDivColumn>
 
@@ -31,7 +31,7 @@ const TextFieldPage: FC = () => {
         renderer={(meta, i) => {
           return (
             <Inner>
-              <TextField key={i} {...meta.props} />
+              <TextArea key={i} {...meta.props} />
             </Inner>
           )
         }}
@@ -55,4 +55,4 @@ const TextFieldPage: FC = () => {
 
 const Inner = styled.div(theme((o) => o.width.full))
 
-export default TextFieldPage
+export default TextAreaPage

--- a/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
@@ -43,12 +43,6 @@ const TextAreaPage: FC = () => {
         <InlineCode>props</InlineCode>
         を継承しています。
       </p>
-      <p>
-        <InlineCode>multiline</InlineCode>
-        の時は<InlineCode>&lt;textarea&gt;</InlineCode>の
-        <InlineCode>props</InlineCode>
-        を継承しています。
-      </p>
       <ApiTable data={apiData} />
     </ContentRoot>
   )

--- a/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
@@ -3,7 +3,8 @@ import { PreviewSection } from '../_components/Previews'
 
 export const sections: PreviewSection<TextAreaProps>[] = [
   {
-    title: 'showLabel, subLabel, requiredText, assistiveText',
+    // autoFocus は先頭の1個だけで有効にする
+    title: 'autoFocus, showLabel, subLabel, requiredText, assistiveText',
     previewMetas: [
       {
         children: undefined,
@@ -15,6 +16,7 @@ export const sections: PreviewSection<TextAreaProps>[] = [
           required: true,
           requiredText: 'requiredText',
           assistiveText: 'assistiveText',
+          autoFocus: true,
         },
       },
     ],

--- a/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
@@ -1,17 +1,7 @@
-import { Icon, TextFieldProps } from '@charcoal-ui/react'
-import styled from 'styled-components'
-import { theme } from '../../../../utils/theme'
+import { TextAreaProps } from '@charcoal-ui/react'
 import { PreviewSection } from '../_components/Previews'
 
-const StyledDiv = styled.div`
-  display: flex;
-  ${theme((o) => o.font.text4)}
-  > pixiv-icon {
-    margin: auto;
-  }
-`
-
-export const sections: PreviewSection<TextFieldProps>[] = [
+export const sections: PreviewSection<TextAreaProps>[] = [
   {
     title: 'showLabel, subLabel, requiredText, assistiveText',
     previewMetas: [
@@ -46,7 +36,7 @@ export const sections: PreviewSection<TextFieldProps>[] = [
           label: 'Label',
           placeholder: 'placeholder',
           showCount: true,
-          maxLength: 16,
+          maxLength: 140,
         },
       },
     ],
@@ -80,35 +70,15 @@ export const sections: PreviewSection<TextFieldProps>[] = [
     ],
   },
   {
-    title: 'prefix',
+    title: 'autoHeight',
     previewMetas: [
       {
         children: undefined,
         props: {
-          label: 'Label',
+          label: 'autoHeight',
           placeholder: 'placeholder',
-          prefix: (
-            <StyledDiv>
-              <Icon name="24/Search" />
-            </StyledDiv>
-          ),
-        },
-      },
-    ],
-  },
-  {
-    title: 'suffix',
-    previewMetas: [
-      {
-        children: undefined,
-        props: {
-          label: 'Label',
-          placeholder: 'placeholder',
-          suffix: (
-            <StyledDiv>
-              <Icon name="24/Search" />
-            </StyledDiv>
-          ),
+          showLabel: true,
+          autoHeight: true,
         },
       },
     ],

--- a/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/sections.tsx
@@ -3,8 +3,7 @@ import { PreviewSection } from '../_components/Previews'
 
 export const sections: PreviewSection<TextAreaProps>[] = [
   {
-    // autoFocus は先頭の1個だけで有効にする
-    title: 'autoFocus, showLabel, subLabel, requiredText, assistiveText',
+    title: 'showLabel, subLabel, requiredText, assistiveText',
     previewMetas: [
       {
         children: undefined,
@@ -16,7 +15,6 @@ export const sections: PreviewSection<TextAreaProps>[] = [
           required: true,
           requiredText: 'requiredText',
           assistiveText: 'assistiveText',
-          autoFocus: true,
         },
       },
     ],

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -21,11 +21,6 @@ export const apiData: Omit<
     description: 'エラーのテキスト',
     type: 'string',
   },
-  excludeFromTabOrder: {
-    default: 'false',
-    description: 'Tabキーを押したときにフォーカスの対象から除く',
-    type: 'boolean',
-  },
   invalid: {
     default: 'false',
     description: '入力が不正か',

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -37,7 +37,12 @@ export const apiData: Omit<
   },
   required: {
     default: 'false',
-    description: '入力必須化',
+    description: '入力必須か',
+    type: 'boolean',
+  },
+  autoFocus: {
+    default: 'false',
+    description: 'オートフォーカスをするか',
     type: 'boolean',
   },
   requiredText: {

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -27,7 +27,7 @@ export const apiData: Omit<
   },
   invalid: {
     default: 'false',
-    description: '入力の不正化',
+    description: '入力が不正化',
     type: 'boolean',
   },
   maxLength: {

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -22,12 +22,12 @@ export const apiData: Omit<
   },
   excludeFromTabOrder: {
     default: 'false',
-    description: '(非推奨）',
+    description: 'Tabキーを押したときにフォーカスの対象から除く',
     type: 'boolean',
   },
   invalid: {
     default: 'false',
-    description: '入力が不正化',
+    description: '入力が不正か',
     type: 'boolean',
   },
   maxLength: {

--- a/docs/src/pages/@charcoal-ui/react/TextField/index.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/index.page.tsx
@@ -42,12 +42,6 @@ const TextFieldPage: FC = () => {
         <InlineCode>&lt;input&gt;</InlineCode>の<InlineCode>props</InlineCode>
         を継承しています。
       </p>
-      <p>
-        <InlineCode>multiline</InlineCode>
-        の時は<InlineCode>&lt;textarea&gt;</InlineCode>の
-        <InlineCode>props</InlineCode>
-        を継承しています。
-      </p>
       <ApiTable data={apiData} />
     </ContentRoot>
   )

--- a/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
@@ -13,7 +13,8 @@ const StyledDiv = styled.div`
 
 export const sections: PreviewSection<TextFieldProps>[] = [
   {
-    title: 'showLabel, subLabel, requiredText, assistiveText',
+    // autoFocus は先頭の1個だけで有効にする
+    title: 'autoFocus, showLabel, subLabel, requiredText, assistiveText',
     previewMetas: [
       {
         children: undefined,
@@ -25,6 +26,7 @@ export const sections: PreviewSection<TextFieldProps>[] = [
           required: true,
           requiredText: 'requiredText',
           assistiveText: 'assistiveText',
+          autoFocus: true,
         },
       },
     ],

--- a/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
@@ -13,8 +13,7 @@ const StyledDiv = styled.div`
 
 export const sections: PreviewSection<TextFieldProps>[] = [
   {
-    // autoFocus は先頭の1個だけで有効にする
-    title: 'autoFocus, showLabel, subLabel, requiredText, assistiveText',
+    title: 'showLabel, subLabel, requiredText, assistiveText',
     previewMetas: [
       {
         children: undefined,
@@ -26,7 +25,6 @@ export const sections: PreviewSection<TextFieldProps>[] = [
           required: true,
           requiredText: 'requiredText',
           assistiveText: 'assistiveText',
-          autoFocus: true,
         },
       },
     ],

--- a/docs/src/pages/v3.0.0-guide.page.tsx
+++ b/docs/src/pages/v3.0.0-guide.page.tsx
@@ -56,6 +56,11 @@ export default function V2toV3GuidePage() {
         <li>onOpenChange の削除</li>
         <li>mode の削除</li>
       </ul>
+      <h4>TextField</h4>
+      <p>
+        multiline
+        propsによって指定していた複数行入力をTextAreaコンポーネントに分離しました。
+      </p>
     </ContentRoot>
   )
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -163,8 +163,8 @@ __metadata:
 
 "@charcoal-ui/foundation@file:../packages/foundation::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=ff0c82&locator=charcoal-web-docs%40workspace%3A."
-  checksum: 07c07dd9af22314a65d225493d2067cbbf1465414f075b187165300c9c815b2cdb8c9d38732032ab42f5cd90bd380937ef30c1644c424103ab94a325d496827d
+  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=2cbe23&locator=charcoal-web-docs%40workspace%3A."
+  checksum: bb54dd9e78a4a8c3aae9e625094599a1038acd162f4b4ea3c3b8fb90a890ddfeb62307801dea606e5e649a0b0c1ef43b8d2b8ab1e312ab54bd25318a591409e8
   languageName: node
   linkType: hard
 
@@ -177,18 +177,18 @@ __metadata:
 
 "@charcoal-ui/icons@file:../packages/icons::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=dc741c&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=a70ff4&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icon-files": ^3.0.0-beta.3
     dompurify: ^2.3.6
     warning: ^4.0.3
-  checksum: 742d47ed5644b7a81bc5c813ebeeacb23ba3b08fad0569288d3b60ea88a1dd378df85c7ad8f97e1f60ecd6eeb54f76bd2e18f8f38c33f32ffd5f291fd29ccf47
+  checksum: f1fd62de94e230dd0139ba0b42f13b030e928ac8230fddacc4f2fa6278568f3616d712d8484f3ef2873405d535bca519385c7d0d8bb63e04ab9dbbb8cc8a6fb2
   languageName: node
   linkType: hard
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=daacd9&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=7820f6&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icons": ^3.0.0-beta.3
     "@charcoal-ui/styled": ^3.0.0-beta.3
@@ -215,13 +215,13 @@ __metadata:
   peerDependencies:
     react: ">=17.0.0"
     styled-components: ">=5.1.1"
-  checksum: 3ec7d8d25a834415d1b18d70821e05836f09f6f7daf6063708b24ac24459fc8b826ee879af38f1bceba7718594757eb29c391d67633e911211c36fc6d44be76a
+  checksum: 82fda41fc8ec093433274237db07eae1f9dbdde314695d1b893d16cfcf90f3cea80874135d0a62527be3d32df1435421b09022ca0d49ec975116419e2032b502
   languageName: node
   linkType: hard
 
 "@charcoal-ui/styled@file:../packages/styled::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=121bfc&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=7b1f9f&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.3
     "@charcoal-ui/theme": ^3.0.0-beta.3
@@ -230,28 +230,28 @@ __metadata:
   peerDependencies:
     react: ">=17.0.0"
     styled-components: ">=5.1.1"
-  checksum: bfd3e8e2fccaad4aae87f26126e996192d233d727c801efca4776be47861084a0d21406c3497c169cdf6a707ba0f1d354c97b80f79c0f793067529a44df8d245
+  checksum: 8d407762358b3e7972b2c618168abae8385bdd46d81ca5a74ffd56199c2f1cefaec091b77a09241a302c523abb309584ee010cbb96b9b02bb0fcd1edc97b0083
   languageName: node
   linkType: hard
 
 "@charcoal-ui/theme@file:../packages/theme::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=ffc6fd&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=9f3538&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.3
     "@charcoal-ui/utils": ^3.0.0-beta.3
     polished: ^4.1.4
-  checksum: 9f9f60a5afc2a21d8ae15823d09b7cd1146603886ee4158c562e412a270559ed45df7c1bbeaa20876f4cef98888d06a24f2fca42bbcec7d299f3da1ec5c3f137
+  checksum: 8f4459e2acfff56911bf8a5c14292193e6abdcc359213118a20d7840ed89bd9ee0453dcc8d3fd2ca9653563b5250ff7268db7a729744a5a15dbd71cfaf6db715
   languageName: node
   linkType: hard
 
 "@charcoal-ui/utils@file:../packages/utils::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.3
-  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=8e41c6&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=c1575b&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.3
     polished: ^4.1.4
-  checksum: 53cd1109b7027ff4b9661c0804e3a2c6e9ecd76a4c7bbdc7af99f2c9c6e41f887bc5df7a0a0f109a610b9c384a98064310deff1f90130f86c1e88cbd9627432a
+  checksum: 9000da83d11040396af0f012fa976eebc0b64b36f72ff947cdc8761a961742a7700ca46dffa1adfa023fb0c2858263e21541060dc0323b1eb75a419688fa9d8c
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -188,7 +188,7 @@ __metadata:
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=8ad007&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=57b4da&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icons": ^3.0.0-beta.2
     "@charcoal-ui/styled": ^3.0.0-beta.2
@@ -215,13 +215,13 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: 56b1e6d77bbfafbfa0f6d756a45384b7a50790db59fcd38ce5a6d17b83093281619650ccf9a12e0e1c689a905eb844cc8b534fca8af00f0a33e56d0c5ebd401a
+  checksum: 4079c47cc0c93c492b3d2ba657436c7ba1794f57c952bb53f44ca2fe484764c84280de811fab9a8a4c5efb977275264d7e58953f9d9af4a9d3e5ff02c46ad178
   languageName: node
   linkType: hard
 
 "@charcoal-ui/styled@file:../packages/styled::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=324a0e&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=b4635f&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.2
     "@charcoal-ui/theme": ^3.0.0-beta.2
@@ -230,7 +230,7 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: f3838e631f10da0f59fb98b6ba64c2ec6077105fa2f568e714d0b7a98f94a0e85e2da596d4fd785b86695198fb10b48f374d52f1dbee8471596e9771fe66c71a
+  checksum: e372896c8a5e1b451b8f621cdd17f8ca17cd7ab427dcf0b3629e5c40b9ec4b0f3f539a1524cf44057f0f302044f3db778dc6e399845d79418ce28a424d925743
   languageName: node
   linkType: hard
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -163,8 +163,8 @@ __metadata:
 
 "@charcoal-ui/foundation@file:../packages/foundation::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=1cac55&locator=charcoal-web-docs%40workspace%3A."
-  checksum: 0e22c02312794a828aace7f83498b62e889246705af380a995db7f5dbbadc8d0daae90f8aa09ed017cf519995c9bd18a46a6f1d30f7206b785c06b15a1c68b28
+  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=e4104f&locator=charcoal-web-docs%40workspace%3A."
+  checksum: 9d52f42960b2a53dda87fbe8dc44bef6ce2427ff45d6791431243d29cdd8da975a74dd1de2b562dbd7d0ab28768924dcb85febe85005fb8aa54747bb33f1ecb0
   languageName: node
   linkType: hard
 
@@ -177,18 +177,18 @@ __metadata:
 
 "@charcoal-ui/icons@file:../packages/icons::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=2c585a&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=457d84&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icon-files": ^3.0.0-beta.2
     dompurify: ^2.3.6
     warning: ^4.0.3
-  checksum: e0306ec1d475ec3fa3cebef564e226783ef49a9f4ac9371e2cd30b3c5e2fdeb211a61e62e44bef419c274b5e2f00223736cc1112f540df98705f14df158a8a81
+  checksum: 49497616c05d3bf062bf4626c15d49bb3c9ce486868678e0fc7477b3feec908a2556a28e8144fb383495a869459d538e0093f68fcfd38d73987cc8a406de4773
   languageName: node
   linkType: hard
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=0e8378&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=8ad007&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icons": ^3.0.0-beta.2
     "@charcoal-ui/styled": ^3.0.0-beta.2
@@ -215,13 +215,13 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: eb8d32d9561be99a8ca300514d2690c2d1993736c4453cf238f20ec8c83be58e721d561032e3fa3501c7470c39dc3bd813de00ee22bc08f63b35ef25e7da9e32
+  checksum: 56b1e6d77bbfafbfa0f6d756a45384b7a50790db59fcd38ce5a6d17b83093281619650ccf9a12e0e1c689a905eb844cc8b534fca8af00f0a33e56d0c5ebd401a
   languageName: node
   linkType: hard
 
 "@charcoal-ui/styled@file:../packages/styled::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=0b9143&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=324a0e&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.2
     "@charcoal-ui/theme": ^3.0.0-beta.2
@@ -230,28 +230,28 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: 9a752b3be279dcdf8a19b92ced3ee9b90ee4cf6f1ff808d0a897b63d2825982afce08b13fbe50ecb661150ded2b626c0024f660d62ae515a01d7b02963601897
+  checksum: f3838e631f10da0f59fb98b6ba64c2ec6077105fa2f568e714d0b7a98f94a0e85e2da596d4fd785b86695198fb10b48f374d52f1dbee8471596e9771fe66c71a
   languageName: node
   linkType: hard
 
 "@charcoal-ui/theme@file:../packages/theme::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=448b36&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=7c5106&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.2
     "@charcoal-ui/utils": ^3.0.0-beta.2
     polished: ^4.1.4
-  checksum: e8750ed8ca6f6a4e20f85e01468e43d847fc4c6d90554137bf5352fbc4a89cdb60ffe089146dcf012b5a20577a4fe812ac33644ff7c59b0103dbf85f44e20ee0
+  checksum: af063379efc733d1477f52e6094458d438bef3bc56d698c8c056417547a278e685d4fd8933c158568076eac07d6f6550aafec61cdc4d5b3580780f1276076289
   languageName: node
   linkType: hard
 
 "@charcoal-ui/utils@file:../packages/utils::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=1151e0&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=323b9f&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^3.0.0-beta.2
     polished: ^4.1.4
-  checksum: 2602c7dad04c19d30303b2bd4c969bc44a5099a6db27cb7f22c71b60c1fc497fe45c468c61989afcaa0d81917a14188277383df382527c28de6f0139474a1645
+  checksum: 99626b5ca6e853d79c9925c56d008c6c1ba5b336f4a2d732c4934d0be535213b22ff59db3352f0aa6be4bdf4306e2840ff0ec902085d0a202f1e40ff2f0470e4
   languageName: node
   linkType: hard
 

--- a/packages/react/src/_lib/index.ts
+++ b/packages/react/src/_lib/index.ts
@@ -33,3 +33,26 @@ export function unreachable(value?: never): never {
       : `unreachable (${JSON.stringify(value)})`
   )
 }
+
+/**
+ * 複数のrefをマージする。
+ *
+ * forwardRefで受け取ったrefと、コンポーネント内で定義したrefを同じ要素につけたいケースなどで使う
+ */
+export function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
+  return (value) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        ref(value)
+      } else if (ref !== null) {
+        ;(ref as React.MutableRefObject<T | null>).current = value
+      }
+    }
+  }
+}
+
+export function countCodePointsInString(string: string) {
+  // [...string] とするとproduction buildで動かなくなる
+  // cf. https://twitter.com/f_subal/status/1497214727511891972
+  return Array.from(string).length
+}

--- a/packages/react/src/components/DropdownSelector/ListItem/index.tsx
+++ b/packages/react/src/components/DropdownSelector/ListItem/index.tsx
@@ -28,9 +28,7 @@ export default function ListItem<T extends CustomJSXElement = 'div'>(
   const { children, ...rest } = props
   return (
     <StyledLi role="option">
-      <ItemDiv {...rest}>
-        {props.children}
-      </ItemDiv>
+      <ItemDiv {...rest}>{props.children}</ItemDiv>
     </StyledLi>
   )
 }

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -17,7 +17,6 @@ export default {
     disabled: false,
     required: false,
     invalid: false,
-    autoFocus: false,
   },
 }
 

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -17,6 +17,7 @@ export default {
     disabled: false,
     required: false,
     invalid: false,
+    autoFocus: false,
   },
 }
 

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -1,0 +1,62 @@
+import { action } from '@storybook/addon-actions'
+import React from 'react'
+import styled from 'styled-components'
+import { Story } from '../../_lib/compat'
+import Clickable from '../Clickable'
+import TextArea, { TextAreaProps } from '.'
+import { px } from '@charcoal-ui/utils'
+
+export default {
+  title: 'TextArea',
+  component: TextArea,
+  argTypes: {},
+  args: {
+    showLabel: false,
+    label: 'Label',
+    assistiveText: '',
+    disabled: false,
+    required: false,
+    invalid: false,
+  },
+}
+
+const Container = styled.div`
+  display: grid;
+  gap: ${({ theme }) => px(theme.spacing[24])};
+`
+
+const Template: Story<Partial<TextAreaProps>> = (args) => (
+  <Container>
+    <TextArea
+      label="Label"
+      requiredText="*必須"
+      subLabel={
+        <Clickable onClick={action('label-click')}>Text Link</Clickable>
+      }
+      placeholder="Text Area"
+      {...args}
+    />
+  </Container>
+)
+
+export const Default = Template.bind({})
+
+export const HasLabel = Template.bind({})
+HasLabel.args = {
+  showLabel: true,
+  assistiveText: 'Assistive text',
+  required: true,
+}
+
+export const HasCount = Template.bind({})
+HasCount.args = {
+  showCount: true,
+  maxLength: 100,
+}
+
+export const AutoHeight: Story<Partial<TextAreaProps>> = (args) => (
+  <TextArea label="Label" placeholder="TextArea" {...args} />
+)
+AutoHeight.args = {
+  autoHeight: true,
+}

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -27,6 +27,7 @@ export interface TextAreaProps
   readonly required?: boolean
   readonly invalid?: boolean
   readonly maxLength?: number
+  readonly autoFocus?: boolean
   /**
    * tab-indexがｰ1かどうか
    */

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { createTheme } from '@charcoal-ui/styled'
+import { countCodePointsInString, mergeRefs } from '../../_lib'
 
 const theme = createTheme(styled)
 
@@ -30,24 +31,6 @@ export interface TextAreaProps
    * tab-indexがｰ1かどうか
    */
   readonly excludeFromTabOrder?: boolean
-}
-
-function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
-  return (value) => {
-    for (const ref of refs) {
-      if (typeof ref === 'function') {
-        ref(value)
-      } else if (ref !== null) {
-        ;(ref as React.MutableRefObject<T | null>).current = value
-      }
-    }
-  }
-}
-
-function countCodePointsInString(string: string) {
-  // [...string] とするとproduction buildで動かなくなる
-  // cf. https://twitter.com/f_subal/status/1497214727511891972
-  return Array.from(string).length
 }
 
 const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -36,11 +36,6 @@ export interface TextAreaProps
   readonly showLabel?: boolean
   readonly assistiveText?: string
   readonly invalid?: boolean
-
-  /**
-   * tab-indexがｰ1かどうか
-   */
-  readonly excludeFromTabOrder?: boolean
 }
 
 const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -1,23 +1,16 @@
 import { useTextField } from '@react-aria/textfield'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
-import styled from 'styled-components'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import styled, { css } from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { createTheme } from '@charcoal-ui/styled'
 
 const theme = createTheme(styled)
 
-export interface TextFieldProps
+export interface TextAreaProps
   extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'> {
-  readonly type?: string
-  readonly prefix?: ReactNode
-  readonly suffix?: ReactNode
+  readonly autoHeight?: boolean
+  readonly rows?: number
   readonly className?: string
   readonly defaultValue?: string
   readonly value?: string
@@ -57,12 +50,12 @@ function countCodePointsInString(string: string) {
   return Array.from(string).length
 }
 
-const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-  function SingleLineTextFieldInner({ onChange, ...props }, forwardRef) {
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  function TextAreaInner({ onChange, ...props }, forwardRef) {
     const {
       className,
-      showLabel = false,
       showCount = false,
+      showLabel = false,
       label,
       requiredText,
       subLabel,
@@ -71,19 +64,25 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       invalid = false,
       assistiveText,
       maxLength,
-      prefix = null,
-      suffix = null,
+      autoHeight = false,
+      rows: initialRows = 4,
     } = props
 
     const { visuallyHiddenProps } = useVisuallyHidden()
-    const ariaRef = useRef<HTMLInputElement>(null)
-    const prefixRef = useRef<HTMLSpanElement>(null)
-    const suffixRef = useRef<HTMLSpanElement>(null)
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+    const ariaRef = useRef<HTMLTextAreaElement>(null)
     const [count, setCount] = useState(
       countCodePointsInString(props.value ?? '')
     )
-    const [prefixWidth, setPrefixWidth] = useState(0)
-    const [suffixWidth, setSuffixWidth] = useState(0)
+    const [rows, setRows] = useState(initialRows)
+
+    const syncHeight = useCallback(
+      (textarea: HTMLTextAreaElement) => {
+        const rows = (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
+        setRows(initialRows <= rows ? rows : initialRows)
+      },
+      [initialRows]
+    )
 
     const nonControlled = props.value === undefined
     const handleChange = useCallback(
@@ -95,9 +94,12 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         if (nonControlled) {
           setCount(count)
         }
+        if (autoHeight && textareaRef.current !== null) {
+          syncHeight(textareaRef.current)
+        }
         onChange?.(value)
       },
-      [maxLength, nonControlled, onChange]
+      [autoHeight, maxLength, nonControlled, onChange, syncHeight]
     )
 
     useEffect(() => {
@@ -107,7 +109,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     const { inputProps, labelProps, descriptionProps, errorMessageProps } =
       useTextField(
         {
-          inputElementType: 'input',
+          inputElementType: 'textarea',
           isDisabled: disabled,
           isRequired: required,
           validationState: invalid ? 'invalid' : 'valid',
@@ -120,25 +122,10 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       )
 
     useEffect(() => {
-      const prefixObserver = new ResizeObserver((entries) => {
-        setPrefixWidth(entries[0].contentRect.width)
-      })
-      const suffixObserver = new ResizeObserver((entries) => {
-        setSuffixWidth(entries[0].contentRect.width)
-      })
-
-      if (prefixRef.current !== null) {
-        prefixObserver.observe(prefixRef.current)
+      if (autoHeight && textareaRef.current !== null) {
+        syncHeight(textareaRef.current)
       }
-      if (suffixRef.current !== null) {
-        suffixObserver.observe(suffixRef.current)
-      }
-
-      return () => {
-        suffixObserver.disconnect()
-        prefixObserver.disconnect()
-      }
-    }, [])
+    }, [autoHeight, syncHeight])
 
     return (
       <TextFieldRoot className={className} isDisabled={disabled}>
@@ -150,26 +137,22 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           {...labelProps}
           {...(!showLabel ? visuallyHiddenProps : {})}
         />
-        <StyledInputContainer>
-          <PrefixContainer ref={prefixRef}>
-            <Affix>{prefix}</Affix>
-          </PrefixContainer>
-          <StyledInput
-            ref={mergeRefs(forwardRef, ariaRef)}
-            invalid={invalid}
-            extraLeftPadding={prefixWidth}
-            extraRightPadding={suffixWidth}
+        <StyledTextareaContainer
+          invalid={invalid}
+          rows={showCount ? rows + 1 : rows}
+        >
+          <StyledTextarea
+            ref={mergeRefs(textareaRef, forwardRef, ariaRef)}
+            rows={rows}
+            noBottomPadding={showCount}
             {...inputProps}
           />
-          <SuffixContainer ref={suffixRef}>
-            <Affix>{suffix}</Affix>
-            {showCount && (
-              <SingleLineCounter>
-                {maxLength !== undefined ? `${count}/${maxLength}` : count}
-              </SingleLineCounter>
-            )}
-          </SuffixContainer>
-        </StyledInputContainer>
+          {showCount && (
+            <MultiLineCounter>
+              {maxLength !== undefined ? `${count}/${maxLength}` : count}
+            </MultiLineCounter>
+          )}
+        </StyledTextareaContainer>
         {assistiveText != null && assistiveText.length !== 0 && (
           <AssistiveText
             invalid={invalid}
@@ -183,7 +166,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   }
 )
 
-export default TextField
+export default TextArea
 
 const TextFieldRoot = styled.div<{ isDisabled: boolean }>`
   display: flex;
@@ -196,74 +179,71 @@ const TextFieldLabel = styled(FieldLabel)`
   ${theme((o) => o.margin.bottom(8))}
 `
 
-const StyledInputContainer = styled.div`
-  height: 40px;
-  display: grid;
+const StyledTextareaContainer = styled.div<{ rows: number; invalid: boolean }>`
   position: relative;
+  overflow: hidden;
+  padding: 0 8px;
+
+  ${(p) =>
+    theme((o) => [
+      o.bg.surface3.hover,
+      p.invalid && o.outline.assertive,
+      o.font.text2,
+      o.borderRadius(4),
+    ])}
+
+  &:focus-within {
+    ${(p) =>
+      theme((o) => (p.invalid ? o.outline.assertive : o.outline.default))}
+  }
+
+  ${({ rows }) => css`
+    height: calc(22px * ${rows} + 18px);
+  `};
 `
 
-const PrefixContainer = styled.span`
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  transform: translateY(-50%);
-  z-index: 1;
-`
-
-const SuffixContainer = styled.span`
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  transform: translateY(-50%);
-
-  display: flex;
-  gap: 8px;
-`
-
-const Affix = styled.span`
-  user-select: none;
-
-  ${theme((o) => [o.typography(14).preserveHalfLeading, o.font.text2])}
-`
-
-const StyledInput = styled.input<{
-  invalid: boolean
-  extraLeftPadding: number
-  extraRightPadding: number
-}>`
+const StyledTextarea = styled.textarea<{ noBottomPadding: boolean }>`
   border: none;
-  box-sizing: border-box;
   outline: none;
+  resize: none;
   font-family: inherit;
+  color: inherit;
 
   /* Prevent zooming for iOS Safari */
   transform-origin: top left;
   transform: scale(0.875);
   width: calc(100% / 0.875);
-  height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + ${(p) => p.extraLeftPadding}px) / 0.875);
-  padding-right: calc((8px + ${(p) => p.extraRightPadding}px) / 0.875);
-  border-radius: calc(4px / 0.875);
+  padding: calc(9px / 0.875) 0 ${(p) => (p.noBottomPadding ? 0 : '')};
+
+  ${({ rows = 1 }) => css`
+    height: calc(22px / 0.875 * ${rows});
+  `};
 
   /* Display box-shadow for iOS Safari */
   appearance: none;
 
-  ${(p) =>
-    theme((o) => [
-      o.bg.surface3.hover,
-      o.outline.default.focus,
-      p.invalid && o.outline.assertive,
-      o.font.text2,
-    ])}
+  background: none;
 
   &::placeholder {
     ${theme((o) => o.font.text3)}
   }
+
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  /* Hide scrollbar for IE, Edge and Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 `
 
-const SingleLineCounter = styled.span`
+const MultiLineCounter = styled.span`
+  position: absolute;
+  bottom: 9px;
+  right: 8px;
+
   ${theme((o) => [o.typography(14).preserveHalfLeading, o.font.text3])}
 `
 

--- a/packages/react/src/components/TextField/TextField.story.tsx
+++ b/packages/react/src/components/TextField/TextField.story.tsx
@@ -17,7 +17,6 @@ export default {
     disabled: false,
     required: false,
     invalid: false,
-    autoFocus: false,
   },
 }
 

--- a/packages/react/src/components/TextField/TextField.story.tsx
+++ b/packages/react/src/components/TextField/TextField.story.tsx
@@ -3,11 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Clickable from '../Clickable'
-import TextField, {
-  MultiLineTextFieldProps,
-  SingleLineTextFieldProps,
-  TextFieldProps,
-} from '.'
+import TextField, { TextFieldProps } from '.'
 import { px } from '@charcoal-ui/utils'
 import IconButton from '../IconButton'
 
@@ -38,19 +34,8 @@ const Template: Story<Partial<TextFieldProps>> = (args) => (
       subLabel={
         <Clickable onClick={action('label-click')}>Text Link</Clickable>
       }
-      placeholder="Single Line"
-      {...(args as Partial<SingleLineTextFieldProps>)}
-      multiline={false}
-    />
-    <TextField
-      label="Label"
-      requiredText="*必須"
-      subLabel={
-        <Clickable onClick={action('label-click')}>Text Link</Clickable>
-      }
-      placeholder="Multi Line"
-      {...(args as Partial<MultiLineTextFieldProps>)}
-      multiline
+      placeholder="TextField"
+      {...args}
     />
   </Container>
 )
@@ -70,7 +55,7 @@ HasCount.args = {
   maxLength: 100,
 }
 
-export const HasAffix: Story<Partial<SingleLineTextFieldProps>> = (args) => (
+export const HasAffix: Story<Partial<TextFieldProps>> = (args) => (
   <TextField label="Label" placeholder="path/to/your/file" {...args} />
 )
 HasAffix.args = {
@@ -80,14 +65,7 @@ HasAffix.args = {
   suffix: '.png',
 }
 
-export const AutoHeight: Story<Partial<MultiLineTextFieldProps>> = (args) => (
-  <TextField label="Label" placeholder="Multi Line" {...args} multiline />
-)
-AutoHeight.args = {
-  autoHeight: true,
-}
-
-export const PrefixIcon: Story<Partial<SingleLineTextFieldProps>> = (args) => (
+export const PrefixIcon: Story<Partial<TextFieldProps>> = (args) => (
   <TextField
     label="Label"
     placeholder="Icon prefix"

--- a/packages/react/src/components/TextField/TextField.story.tsx
+++ b/packages/react/src/components/TextField/TextField.story.tsx
@@ -18,6 +18,7 @@ export default {
     disabled: false,
     required: false,
     invalid: false,
+    autoFocus: false,
   },
 }
 

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -10,6 +10,7 @@ import React, {
 import styled from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { createTheme } from '@charcoal-ui/styled'
+import { countCodePointsInString, mergeRefs } from '../../_lib'
 
 const theme = createTheme(styled)
 
@@ -37,24 +38,6 @@ export interface TextFieldProps
    * tab-indexがｰ1かどうか
    */
   readonly excludeFromTabOrder?: boolean
-}
-
-function mergeRefs<T>(...refs: React.Ref<T>[]): React.RefCallback<T> {
-  return (value) => {
-    for (const ref of refs) {
-      if (typeof ref === 'function') {
-        ref(value)
-      } else if (ref !== null) {
-        ;(ref as React.MutableRefObject<T | null>).current = value
-      }
-    }
-  }
-}
-
-function countCodePointsInString(string: string) {
-  // [...string] とするとproduction buildで動かなくなる
-  // cf. https://twitter.com/f_subal/status/1497214727511891972
-  return Array.from(string).length
 }
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -42,11 +42,6 @@ export interface TextFieldProps
   readonly showLabel?: boolean
   readonly assistiveText?: string
   readonly invalid?: boolean
-
-  /**
-   * tab-indexがｰ1かどうか
-   */
-  readonly excludeFromTabOrder?: boolean
 }
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -34,6 +34,7 @@ export interface TextFieldProps
   readonly required?: boolean
   readonly invalid?: boolean
   readonly maxLength?: number
+  readonly autoFocus?: boolean
   /**
    * tab-indexがｰ1かどうか
    */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -35,9 +35,8 @@ export { default as Switch, type SwitchProps } from './components/Switch'
 export {
   default as TextField,
   type TextFieldProps,
-  type SingleLineTextFieldProps,
-  type MultiLineTextFieldProps,
 } from './components/TextField'
+export { default as TextArea, type TextAreaProps } from './components/TextArea'
 export { default as Icon, type IconProps } from './components/Icon'
 export { default as Modal, type ModalProps } from './components/Modal'
 export {


### PR DESCRIPTION
Reverts pixiv/charcoal#286

closes: #164

ref: #211 https://github.com/pixiv/charcoal/issues/209

## やったこと

- storybook 上で TextField の中身を分割して TextField と TextArea に分けた

## 動作確認環境
- storybook

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した

## 備考

- めちゃくちゃ破壊的変更なのでこれを merge したあとどこの version に混ぜるかは考えたほうが良さそうだと思いました。
