### PR TITLE
fix: SegmentedControlにラベルの付与を追加

### DIFF
--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -47,6 +47,7 @@ export const Sections: Story<DropdownSelectorProps> = (props) => {
     <div>
       <DropdownSelector
         {...props}
+        label="sections"
         placeholder={'Drop Down menu'}
         onChange={action('change')}
         onOpenChange={action('open')}
@@ -68,6 +69,7 @@ export const Bottom: Story<DropdownSelectorProps> = (props) => {
     <div style={{ marginTop: '1000px' }}>
       <DropdownSelector
         {...props}
+        label="bottom"
         placeholder={'Drop Down menu'}
         onChange={action('change')}
         onOpenChange={action('open')}
@@ -86,6 +88,7 @@ export const Many: Story<DropdownSelectorProps> = (props) => {
     <div style={{ padding: '300px 100px' }}>
       <DropdownSelector
         {...props}
+        label="many"
         placeholder={'Drop Down menu'}
         onChange={(v) => {
           setValue(v.toString())
@@ -181,7 +184,7 @@ type InvalidProps = {
 }
 export const Invalid: Story<InvalidProps> = ({ disabled }) => {
   const props: Omit<DropdownSelectorProps, 'children'> = {
-    label: '',
+    label: 'invalid',
     assertiveText: 'error message',
     invalid: true,
   }

--- a/packages/react/src/components/SegmentedControl/index.story.tsx
+++ b/packages/react/src/components/SegmentedControl/index.story.tsx
@@ -13,6 +13,7 @@ export const StringSegments: Story<SegmentedControlProps> = (props) => {
 }
 
 StringSegments.args = {
+  name: 'test',
   data: ['option1', 'option2', 'option3'],
   disabled: false,
   readonly: false,
@@ -24,6 +25,7 @@ export const ObjectSegments: Story<SegmentedControlProps> = (props) => {
 }
 
 ObjectSegments.args = {
+  name: 'test',
   data: [
     { label: '選択肢1', value: 'option1' },
     { label: '選択肢2', value: 'option2' },

--- a/packages/react/src/components/SegmentedControl/index.tsx
+++ b/packages/react/src/components/SegmentedControl/index.tsx
@@ -41,6 +41,7 @@ const SegmentedControl = forwardRef<HTMLDivElement, SegmentedControlProps>(
         isDisabled: props.disabled,
         isReadOnly: props.readonly,
         isRequired: props.required,
+        'aria-label': props.name,
       }),
       [props]
     )


### PR DESCRIPTION
## やったこと

- SegmentedControlにラベルの付与を追加
- storyのlabelに関する警告を修正

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
