### PR TITLE
styled 高速化実験: createTheme の段階で theme を受け取ってしまう

### DIFF
--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -4,10 +4,15 @@ import { useCheckbox } from '@react-aria/checkbox'
 import { useObjectRef } from '@react-aria/utils'
 import { useToggleState } from 'react-stately'
 import { disabledSelector, px } from '@charcoal-ui/utils'
-import { theme } from '../../styled'
 
 import type { AriaCheckboxProps } from '@react-types/checkbox'
 import Icon from '../Icon'
+import { CANARY__createTheme } from '@charcoal-ui/styled'
+import { light } from '@charcoal-ui/theme'
+
+const theme = CANARY__createTheme({
+  ':root': light,
+})
 
 type CheckboxLabelProps =
   | {

--- a/packages/styled/src/CANARY__createTheme.ts
+++ b/packages/styled/src/CANARY__createTheme.ts
@@ -1,0 +1,53 @@
+import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
+import { CSSObject } from 'styled-components'
+import createO from './builders/o'
+import transition from './builders/transition'
+import { Internal, toCSSObjects } from './internals'
+import { ThemeMap } from './TokenInjector'
+import { ArrayOrSingle, isPresent, wrapArray } from './util'
+
+type Blank = null | undefined | false
+
+const nonBlank = <T>(value: T): value is T extends Blank ? never : T =>
+  isPresent(value) && (value as unknown) !== false
+
+export function CANARY__createTheme<T extends CharcoalAbstractTheme>(
+  themeMap: ThemeMap<T>
+) {
+  type Builder = ReturnType<typeof createO<T>>
+  type SpecFunction = (o: Builder) => ArrayOrSingle<Internal | Blank>
+
+  const defaultTheme = themeMap[':root']
+  if (!isPresent(defaultTheme)) {
+    throw new Error(':root does not exist')
+  }
+
+  const theme = (specFn: SpecFunction): ArrayOrSingle<CSSObject> => {
+    const internals = [
+      // ユーザーが定義したルール
+      ...wrapArray(
+        /**
+         * こう書いてはいけない
+         *
+         * ❌
+         * ```ts
+         * const o = createO(theme)
+         * const declaration = spec(o)
+         * ```
+         *
+         * `o` を一時変数に入れてしまうと型 `T` の具象化が行われるので関数内に書く
+         */
+        specFn(/** o = */ createO(defaultTheme))
+      ),
+
+      // 必ず挿入される共通のルール
+      transition(defaultTheme),
+    ].filter(nonBlank)
+
+    const css = toCSSObjects(internals)
+
+    return css
+  }
+
+  return theme
+}

--- a/packages/styled/src/CANARY__createTheme.ts
+++ b/packages/styled/src/CANARY__createTheme.ts
@@ -22,26 +22,16 @@ export function CANARY__createTheme<T extends CharcoalAbstractTheme>(
     throw new Error(':root does not exist')
   }
 
+  const commonResult = [transition(defaultTheme)]
+  const o = createO<T>(defaultTheme)
+
   const theme = (specFn: SpecFunction): ArrayOrSingle<CSSObject> => {
     const internals = [
       // ユーザーが定義したルール
-      ...wrapArray(
-        /**
-         * こう書いてはいけない
-         *
-         * ❌
-         * ```ts
-         * const o = createO(theme)
-         * const declaration = spec(o)
-         * ```
-         *
-         * `o` を一時変数に入れてしまうと型 `T` の具象化が行われるので関数内に書く
-         */
-        specFn(/** o = */ createO(defaultTheme))
-      ),
+      ...wrapArray(specFn(o)),
 
       // 必ず挿入される共通のルール
-      transition(defaultTheme),
+      ...commonResult,
     ].filter(nonBlank)
 
     const css = toCSSObjects(internals)

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -17,6 +17,7 @@ export {
 } from './helper'
 export { defineThemeVariables } from './util'
 export * from './SetThemeScript'
+export { CANARY__createTheme } from './CANARY__createTheme'
 
 type Blank = null | undefined | false
 


### PR DESCRIPTION
## やったこと

related: #300 

レンダリングのたびに毎回 theme を受け取らないし、`createO` を呼ばない

この方針で行く場合、動的な値はすべて CSS variables に寄せる必要がある

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
