### PR TITLE
@charcoal-ui/icons のドキュメントのページを追加

### DIFF
--- a/docs/src/components/GlobalStyle.tsx
+++ b/docs/src/components/GlobalStyle.tsx
@@ -60,5 +60,9 @@ pre {
   margin-bottom: 0;
 }
 
+hr {
+  ${theme((o) => o.border.default)}
+}
+
 ${resetPixivIcon}
 `

--- a/docs/src/components/GlobalStyle.tsx
+++ b/docs/src/components/GlobalStyle.tsx
@@ -43,6 +43,10 @@ html, body, #__next {
   ${theme((o) => o.font.text1)}
 }
 
+a {
+  ${theme((o) => o.font.link1)};
+}
+
 p {
   line-height: 24px;
 }

--- a/docs/src/components/InlineCode.tsx
+++ b/docs/src/components/InlineCode.tsx
@@ -9,3 +9,7 @@ export const InlineCode = styled(Code)`
   margin: 0 2px;
   ${theme((o) => o.bg.surface3)}
 `
+
+export const TagName = styled(InlineCode).attrs(({ children }) => ({
+  children: `<${children?.toString()}>` as string,
+}))``

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -76,6 +76,10 @@ const iconsList: ListItem[] = [
     href: '/@charcoal-ui/icons/element',
   },
   {
+    text: 'SSR時のレイアウトシフトを防ぐ',
+    href: '/@charcoal-ui/icons/ssr',
+  },
+  {
     text: '独自のアイコンを登録する',
     href: '/@charcoal-ui/icons/extend',
   },

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -71,6 +71,18 @@ const iconsList: ListItem[] = [
     text: 'クイックスタート',
     href: '/@charcoal-ui/icons/quickstart',
   },
+  {
+    text: '<pixiv-icon>',
+    href: '/@charcoal-ui/icons/element',
+  },
+  {
+    text: '独自のアイコンを登録する',
+    href: '/@charcoal-ui/icons/extend',
+  },
+  {
+    text: 'Reactと組み合わせて使う',
+    href: '/@charcoal-ui/icons/react',
+  },
 ]
 
 export const NavList: FC<{ className?: string }> = (props) => {

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@charcoal-ui/react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { FC, useEffect } from 'react'
+import { FC, useCallback, useEffect } from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../utils/theme'
 import pkgJson from '../../../packages/react/package.json'
@@ -66,6 +66,13 @@ const reactList: ListItem[] = [
   }),
 ]
 
+const iconsList: ListItem[] = [
+  {
+    text: 'クイックスタート',
+    href: '/@charcoal-ui/icons/quickstart',
+  },
+]
+
 export const NavList: FC<{ className?: string }> = (props) => {
   const router = useRouter()
   useEffect(() => {
@@ -73,6 +80,18 @@ export const NavList: FC<{ className?: string }> = (props) => {
     window.scroll({ top: 0, left: 0 })
   }, [router])
   const href = router.pathname
+
+  const renderListItem = useCallback(
+    (item: ListItem) => {
+      return (
+        <ListItem key={item.href} active={href === item.href}>
+          <ListItemLink href={item.href}>{item.text}</ListItemLink>
+        </ListItem>
+      )
+    },
+    [href]
+  )
+
   return (
     <StyledUl className={props.className}>
       <ListItemHeader>v{pkgJson.version}</ListItemHeader>
@@ -80,21 +99,11 @@ export const NavList: FC<{ className?: string }> = (props) => {
       {/* <ListItem active={href === '/@charcoal-ui/styled/Colors'}>
         <ListItemLink href="/@charcoal-ui/styled/Colors">Colors</ListItemLink>
       </ListItem> */}
-      {styledList.map((item) => {
-        return (
-          <ListItem key={item.href} active={href === item.text}>
-            <ListItemLink href={item.href}>{item.text}</ListItemLink>
-          </ListItem>
-        )
-      })}
+      {styledList.map(renderListItem)}
       <ListItemHeader>@charcoal-ui/react</ListItemHeader>
-      {reactList.map((item) => {
-        return (
-          <ListItem key={item.href} active={href == item.href}>
-            <ListItemLink href={item.href}>{item.text}</ListItemLink>
-          </ListItem>
-        )
-      })}
+      {reactList.map(renderListItem)}
+      <ListItemHeader>@charcoal-ui/icons</ListItemHeader>
+      {iconsList.map(renderListItem)}
       <ListItemHeader>Links</ListItemHeader>
       <ExternalLink href="https://github.com/pixiv/charcoal" text="GitHub" />
       <ExternalLink href="https://pixiv.github.io/charcoal/" text="Storybook" />

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -76,16 +76,16 @@ const iconsList: ListItem[] = [
     href: '/@charcoal-ui/icons/element',
   },
   {
-    text: 'SSR時のレイアウトシフトを防ぐ',
-    href: '/@charcoal-ui/icons/ssr',
+    text: 'Reactと組み合わせて使う',
+    href: '/@charcoal-ui/icons/react',
   },
   {
     text: '独自のアイコンを登録する',
     href: '/@charcoal-ui/icons/extend',
   },
   {
-    text: 'Reactと組み合わせて使う',
-    href: '/@charcoal-ui/icons/react',
+    text: 'SSR時のレイアウトシフトを防ぐ',
+    href: '/@charcoal-ui/icons/ssr',
   },
 ]
 

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -84,7 +84,7 @@ const iconsList: ListItem[] = [
     href: '/@charcoal-ui/icons/extend',
   },
   {
-    text: 'SSR時のレイアウトシフトを防ぐ',
+    text: 'サーバーサイドレンダリング',
     href: '/@charcoal-ui/icons/ssr',
   },
 ]

--- a/docs/src/components/NavList.tsx
+++ b/docs/src/components/NavList.tsx
@@ -41,7 +41,7 @@ const reactList: ListItem[] = [
     href: '/@charcoal-ui/react/quickstart',
   },
   {
-    text: 'SSR',
+    text: 'サーバーサイドレンダリング',
     href: '/@charcoal-ui/react/ssr',
   },
   ...[

--- a/docs/src/components/Table.tsx
+++ b/docs/src/components/Table.tsx
@@ -1,0 +1,93 @@
+import styled from 'styled-components'
+import { theme } from '../utils/theme'
+
+export type TableItem = Record<string, any>
+export type TableDataInterface = Record<string, TableItem>
+
+interface Props<T> {
+  data: T
+}
+
+/**
+ * 型をもとに良い感じにテーブルの値を作る
+ */
+function toTableCell(value: unknown) {
+  switch (typeof value) {
+    case 'boolean': {
+      return value ? 'YES' : 'NO'
+    }
+
+    case 'string':
+    case 'number': {
+      return value
+    }
+
+    default: {
+      return value?.toString() ?? JSON.stringify(value) ?? '???'
+    }
+  }
+}
+
+/**
+ * 汎用のテーブルコンポーネント
+ *
+ * TODO: th を変えたいときに変えられるようにする
+ */
+export function Table<T extends TableDataInterface>({ data }: Props<T>) {
+  const [sample] = Object.values(data)
+  const columns = Object.keys(sample) as (keyof TableItem)[]
+
+  return (
+    <TableParentDiv>
+      <StyledTable>
+        <thead>
+          <StyledTr>
+            <th>name</th>
+            {columns.map((column) => (
+              <th key={column}>{column}</th>
+            ))}
+          </StyledTr>
+        </thead>
+        <tbody>
+          {Object.entries(data)
+            .sort((a, b) => a[0].localeCompare(b[0]))
+            .sort((a, b) => (b[1].required ? 1 : 0) - (a[1].required ? 1 : 0))
+            .map(([key, value]) => {
+              return (
+                <StyledTr key={key}>
+                  <td>{key}</td>
+                  {columns.map((column) => (
+                    <td key={column}>{toTableCell(value[column])}</td>
+                  ))}
+                </StyledTr>
+              )
+            })}
+        </tbody>
+      </StyledTable>
+    </TableParentDiv>
+  )
+}
+
+const StyledTable = styled.table`
+  width: 100%;
+  font-size: 14px;
+  border-collapse: collapse;
+  font-weight: normal;
+  font-family: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono',
+    Menlo, Consolas, monospace;
+`
+
+const StyledTr = styled.tr`
+  ${theme((o) => o.border.default.bottom)}
+  height: 32px;
+
+  > td,
+  > th {
+    padding: 8px 18px;
+  }
+`
+const TableParentDiv = styled.div`
+  overflow-x: auto;
+  max-width: 100%;
+  ${theme((o) => o.border.default)}
+`

--- a/docs/src/pages/@charcoal-ui/icons/element.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/element.page.tsx
@@ -1,0 +1,39 @@
+import styled from 'styled-components'
+import { ContentRoot } from '../../../components/ContentRoot'
+import { TagName } from '../../../components/InlineCode'
+import { Table } from '../../../components/Table'
+
+export default function ElementPage() {
+  return (
+    <ContentRoot>
+      <h1>
+        <TagNameInHead>pixiv-icon</TagNameInHead>
+      </h1>
+      <p>アイコン用のCustom Element</p>
+
+      <h2>属性</h2>
+      <Table data={apiData} />
+    </ContentRoot>
+  )
+}
+
+const TagNameInHead = styled(TagName)`
+  font-size: inherit !important;
+`
+
+const apiData = {
+  name: {
+    description:
+      'アイコンの名前です。{size}/{filename}という形式をしています。利用できる名前の一覧はリポジトリのpackages/icons/svg以下を見てください。',
+    type: 'string',
+  },
+  scale: {
+    description:
+      'アイコンの拡大率を倍率で指定します。拡大は「24/〇〇」系のアイコンでのみサポートされます。',
+    type: '1 | 2 | 3',
+  },
+  'unsafe-non-guideline-scale': {
+    description: 'ガイドラインに従わない倍率を無理やり指定する場合に使います。',
+    type: 'number',
+  },
+}

--- a/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
@@ -40,6 +40,44 @@ export default function ExtendPage() {
         TypeScript 環境下では、<InlineCode>KnownIconType</InlineCode>
         という型を拡張することで、カスタムアイコンに対しても補完が効くようになります。
       </p>
+
+      <h2>独自アイコンのためのバンドラ設定</h2>
+      <p>
+        <InlineCode>PixivIcon.extend()</InlineCode>
+        に渡すオブジェクトはキーがアイコン名、値がSVGファイルに対するパス名またはURLである必要があります。
+        <br />
+        （内部的には、ここで渡した文字列に対して<InlineCode>fetch()</InlineCode>
+        が走ります）
+      </p>
+      <p>
+        SVGファイルを<InlineCode>import</InlineCode>
+        して渡す場合、プロジェクトのバンドラが<InlineCode>*.svg</InlineCode>を
+        <strong>パス文字列として（ファイルの内容の文字列ではなく）</strong>
+        ロードする設定になっていることを確認してください。
+      </p>
+      <p>
+        たとえばWebpackの場合、当該アイコンファイルに対するルールは
+        <a
+          href="https://webpack.js.org/guides/asset-modules/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <InlineCode>type: 'asset/resource'</InlineCode>
+        </a>
+        であるべきです。
+        <br />
+        <a
+          href="https://react-svgr.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          svgr
+        </a>
+        など、SVGファイルを文字列以外の値にトランスフォームするツールを使っているプロジェクトでは、
+        <br />
+        <InlineCode>PixivIcon.extend()</InlineCode>に渡す用の
+        <InlineCode>.svg</InlineCode>ファイルをその対象から除いてください。
+      </p>
     </ContentRoot>
   )
 }

--- a/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
@@ -1,0 +1,45 @@
+import { ContentRoot } from '../../../components/ContentRoot'
+import { InlineCode, TagName } from '../../../components/InlineCode'
+import { SSRHighlight } from '../../../components/SSRHighlight'
+import { dedent } from '../../../utils/string'
+
+export default function ExtendPage() {
+  return (
+    <ContentRoot>
+      <h1>独自のアイコンを登録する</h1>
+      <p>
+        <TagName>pixiv-icon</TagName>の<InlineCode>name</InlineCode>
+        に存在しないSVGをアイコンとして登録することができます。
+      </p>
+
+      <SSRHighlight
+        code={dedent`
+          import { PixivIcon } from '@charcoal-ui/icons'
+          import NewFeature from './NewFeature.svg'
+
+          PixivIcon.extend({
+            '16/NewFeature': require('./icons/16/NewFeature.svg'),
+            '24/NewFeature': 'https://example.com/hoge.svg',
+            '32/NewFeature': NewFeature,
+          })
+
+          declare module '@charcoal-ui/icons' {
+            export interface KnownIconType {
+              '16/NewFeature': unknown
+              '24/NewFeature': unknown
+              '32/NewFeature': unknown
+            }
+          }
+        `}
+        lang="typescript"
+      />
+      <p>
+        その場合も名前の形式は <InlineCode>{'{size}/{name}'}</InlineCode>
+        である必要があります。
+        <br />
+        TypeScript 環境下では、<InlineCode>KnownIconType</InlineCode>
+        という型を拡張することで、カスタムアイコンに対しても補完が効くようになります。
+      </p>
+    </ContentRoot>
+  )
+}

--- a/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/extend.page.tsx
@@ -56,13 +56,13 @@ export default function ExtendPage() {
         ロードする設定になっていることを確認してください。
       </p>
       <p>
-        たとえばWebpackの場合、当該アイコンファイルに対するルールは
+        たとえばWebpackの場合、当該アイコンファイルに対するルールのtypeは
         <a
           href="https://webpack.js.org/guides/asset-modules/"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <InlineCode>type: 'asset/resource'</InlineCode>
+          <InlineCode>asset/resource</InlineCode>
         </a>
         であるべきです。
         <br />

--- a/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import { ContentRoot } from '../../../components/ContentRoot'
 
-import { InlineCode } from '../../../components/InlineCode'
+import { InlineCode, TagName } from '../../../components/InlineCode'
 import { SSRHighlight } from '../../../components/SSRHighlight'
+import { dedent } from '../../../utils/string'
 
 export default function InstallPage() {
   return (
@@ -21,12 +22,42 @@ export default function InstallPage() {
       <SSRHighlight code="yarn add @charcoal-ui/icons" lang="shell" />
       <h2>使い方</h2>
       <p>
-        <InlineCode>WIP</InlineCode>
+        アプリケーションのエントリポイントで<InlineCode>import</InlineCode>
+        します。
+        <br />
+        Storybookの場合は<InlineCode>preview.(js|ts)</InlineCode>
+        に書くと良いでしょう。
       </p>
       <SSRHighlight
-        code={`import 'pixiv-icon'`.trimStart()}
+        code={dedent`import '@charcoal-ui/icons'`}
         lang="typescript"
       />
+      <p>
+        これだけで、<TagName>pixiv-icon</TagName>という
+        HTMLタグが利用可能になります。
+        TypeScriptの型定義がグローバルにインストールされるので、JSX で
+        <TagName>pixiv-icon</TagName>
+        を書く際にも型チェックが効きます。
+      </p>
+      <h2>収録アイコン</h2>
+      <p>
+        <InlineCode>@charcoal-ui/react</InlineCode>の
+        <Link href="/@charcoal-ui/react/Icon/">Icon</Link>
+        のページを見てください。
+      </p>
+      <h2>各種バンドラとの組み合わせ</h2>
+      <p>
+        <InlineCode>@charcoal-ui/icons@v2.0.0</InlineCode>
+        以前、このライブラリはアイコンを
+        <InlineCode>.svg</InlineCode>
+        ファイルとしてエクスポートしていました。したがって利用の際は、各種バンドラで
+        <InlineCode>.svg</InlineCode>
+        ファイルをimportできるように設定ファイルを変更する必要がありました。
+      </p>
+      <p>
+        <InlineCode>v2.0.0</InlineCode>
+        以降、アイコンはJavaScriptの文字列としてエクスポートされるようになっています。したがってバンドラの設定はもはや必要ありません。
+      </p>
     </ContentRoot>
   )
 }

--- a/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
@@ -23,6 +23,27 @@ export default function InstallPage() {
 
       <hr />
 
+      <h2>概要</h2>
+      <p>
+        <InlineCode>@charcoal-ui/icons</InlineCode>は、SVGアイコンを
+        <a
+          href="https://developer.mozilla.org/ja/docs/Web/API/Web_components"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Web Components
+        </a>
+        の
+        <a
+          href="https://developer.mozilla.org/ja/docs/Web/API/Web_components/Using_custom_elements"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Custom Elements
+        </a>
+        として利用できるライブラリです。
+      </p>
+
       <h2>使い方</h2>
       <p>
         アプリケーションのエントリポイントで<InlineCode>import</InlineCode>

--- a/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { ContentRoot } from '../../../components/ContentRoot'
+
+import { InlineCode } from '../../../components/InlineCode'
+import { SSRHighlight } from '../../../components/SSRHighlight'
+
+export default function InstallPage() {
+  return (
+    <ContentRoot>
+      <h1>@charcoal-ui/icons クイックスタート</h1>
+      <Link href="https://www.npmjs.com/package/@charcoal-ui/icons">
+        <img
+          alt="npm-badge"
+          src="https://img.shields.io/npm/v/@charcoal-ui/icons?label=%40charcoal-ui%2Ficons&style=flat-square&logo=npm"
+        />
+      </Link>
+      <h2>インストール</h2>
+      <h3>npm</h3>
+      <SSRHighlight code="npm install @charcoal-ui/icons" lang="shell" />
+      <h3>yarn</h3>
+      <SSRHighlight code="yarn add @charcoal-ui/icons" lang="shell" />
+      <h2>使い方</h2>
+      <p>
+        <InlineCode>WIP</InlineCode>
+      </p>
+      <SSRHighlight
+        code={`import 'pixiv-icon'`.trimStart()}
+        lang="typescript"
+      />
+    </ContentRoot>
+  )
+}

--- a/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
@@ -20,6 +20,9 @@ export default function InstallPage() {
       <SSRHighlight code="npm install @charcoal-ui/icons" lang="shell" />
       <h3>yarn</h3>
       <SSRHighlight code="yarn add @charcoal-ui/icons" lang="shell" />
+
+      <hr />
+
       <h2>使い方</h2>
       <p>
         アプリケーションのエントリポイントで<InlineCode>import</InlineCode>
@@ -27,6 +30,15 @@ export default function InstallPage() {
         <br />
         Storybookの場合は<InlineCode>preview.(js|ts)</InlineCode>
         に書くと良いでしょう。
+      </p>
+      <p>
+        <strong>
+          <InlineCode>@charcoal-ui/react</InlineCode>の{' '}
+          <Link href="/@charcoal-ui/react/Icon">
+            <TagName>Icon</TagName>
+          </Link>
+          コンポーネントを利用している場合、このimportは内部で自動的に行われます。
+        </strong>
       </p>
       <SSRHighlight
         code={dedent`import '@charcoal-ui/icons'`}
@@ -42,9 +54,12 @@ export default function InstallPage() {
       <h2>収録アイコン</h2>
       <p>
         <InlineCode>@charcoal-ui/react</InlineCode>の
-        <Link href="/@charcoal-ui/react/Icon/">Icon</Link>
+        <Link href="/@charcoal-ui/react/Icon/">
+          <TagName>Icon</TagName>
+        </Link>
         のページを見てください。
       </p>
+      <hr />
       <h2>各種バンドラとの組み合わせ</h2>
       <p>
         <InlineCode>@charcoal-ui/icons@v2.0.0</InlineCode>

--- a/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/quickstart.page.tsx
@@ -50,13 +50,28 @@ export default function InstallPage() {
         <InlineCode>@charcoal-ui/icons@v2.0.0</InlineCode>
         以前、このライブラリはアイコンを
         <InlineCode>.svg</InlineCode>
-        ファイルとしてエクスポートしていました。したがって利用の際は、各種バンドラで
+        ファイルとしてエクスポートしていました。
+        <br />
+        したがって利用の際は、各種バンドラで
         <InlineCode>.svg</InlineCode>
         ファイルをimportできるように設定ファイルを変更する必要がありました。
       </p>
       <p>
         <InlineCode>v2.0.0</InlineCode>
-        以降、アイコンはJavaScriptの文字列としてエクスポートされるようになっています。したがってバンドラの設定はもはや必要ありません。
+        以降、アイコンはJavaScriptの文字列としてエクスポートされるようになっています。
+        <br />
+        <strong>
+          したがって、
+          <InlineCode>@charcoal-ui/icons</InlineCode>
+          に収録されたアイコンを利用するだけなら、バンドラの設定は必要ありません。
+        </strong>
+      </p>
+      <p>
+        プロジェクト内のSVGファイルをアイコンとして登録したい場合は、
+        <Link href="/@charcoal-ui/icons/extend">
+          必要に応じて<InlineCode>.svg</InlineCode>
+          をimportできるように設定してください。
+        </Link>
       </p>
     </ContentRoot>
   )

--- a/docs/src/pages/@charcoal-ui/icons/react.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/react.page.tsx
@@ -1,5 +1,7 @@
+import Link from 'next/link'
+import styled from 'styled-components'
 import { ContentRoot } from '../../../components/ContentRoot'
-import { InlineCode } from '../../../components/InlineCode'
+import { InlineCode, TagName } from '../../../components/InlineCode'
 import { SSRHighlight } from '../../../components/SSRHighlight'
 import { dedent } from '../../../utils/string'
 
@@ -7,6 +9,20 @@ export default function ReactPage() {
   return (
     <ContentRoot>
       <h1>React と組み合わせて使う</h1>
+
+      <p>
+        <InlineCode>@charcoal-ui/react</InlineCode>に
+        <Link href="/@charcoal-ui/react/Icon">
+          <TagName>Icon</TagName>
+        </Link>
+        コンポーネントが収録されているので、基本的にはそちらを利用してください。
+      </p>
+
+      <hr />
+
+      <h2>
+        <InlineCodeInHead>@charcoal-ui/react</InlineCodeInHead>を使わない場合
+      </h2>
       <p>
         Custom Elementは
         <strong>
@@ -32,7 +48,7 @@ export default function ReactPage() {
       <p>
         もし<InlineCode>styled-components</InlineCode>などを使っていて
         <InlineCode>className</InlineCode>
-        を渡せないと困るケースでは、ラッパーコンポーネントを作ってください。
+        を渡せないと困るケースでは、ラッパーコンポーネントを作ることができます。
       </p>
 
       <SSRHighlight
@@ -52,3 +68,7 @@ export default function ReactPage() {
     </ContentRoot>
   )
 }
+
+export const InlineCodeInHead = styled(InlineCode)`
+  font-size: inherit !important;
+`

--- a/docs/src/pages/@charcoal-ui/icons/react.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/react.page.tsx
@@ -25,7 +25,7 @@ export default function ReactPage() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          参考: React公式ドキュメント
+          React公式ドキュメントより
         </a>
       </blockquote>
 

--- a/docs/src/pages/@charcoal-ui/icons/react.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/react.page.tsx
@@ -23,7 +23,7 @@ export default function ReactPage() {
         <a
           href="https://ja.react.dev/reference/react-dom/components#custom-html-elements"
           target="_blank"
-          rel="noopener"
+          rel="noopener noreferrer"
         >
           参考: React公式ドキュメント
         </a>

--- a/docs/src/pages/@charcoal-ui/icons/react.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/react.page.tsx
@@ -1,0 +1,54 @@
+import { ContentRoot } from '../../../components/ContentRoot'
+import { InlineCode } from '../../../components/InlineCode'
+import { SSRHighlight } from '../../../components/SSRHighlight'
+import { dedent } from '../../../utils/string'
+
+export default function ReactPage() {
+  return (
+    <ContentRoot>
+      <h1>React と組み合わせて使う</h1>
+      <p>
+        Custom Elementは
+        <strong>
+          <InlineCode>className</InlineCode>
+          というpropsを受け取ることが通常できません。
+        </strong>
+      </p>
+      <blockquote>
+        Custom elements accept <InlineCode>class</InlineCode> rather than{' '}
+        <InlineCode>className</InlineCode>, and <InlineCode>for</InlineCode>{' '}
+        rather than
+        <InlineCode>htmlFor</InlineCode>.
+        <br />
+        <a
+          href="https://ja.react.dev/reference/react-dom/components#custom-html-elements"
+          target="_blank"
+          rel="noopener"
+        >
+          参考: React公式ドキュメント
+        </a>
+      </blockquote>
+
+      <p>
+        もし<InlineCode>styled-components</InlineCode>などを使っていて
+        <InlineCode>className</InlineCode>
+        を渡せないと困るケースでは、ラッパーコンポーネントを作ってください。
+      </p>
+
+      <SSRHighlight
+        code={dedent`
+          import { Props as IconProps } from '@charcoal-ui/icons'
+
+          interface Props extends Omit<IconProps, 'class'> {
+            className?: string
+          }
+
+          export const Icon: React.FC<Props> = ({ className, ...props }) => (
+            <pixiv-icon class={className} {...props} />
+          )
+        `}
+        lang="typescript"
+      />
+    </ContentRoot>
+  )
+}

--- a/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
@@ -81,7 +81,7 @@ export default function SsrPage() {
         <strong>
           現状
           <InlineCode>unsafe-non-guideline-scale</InlineCode>
-          をつけた要素はレイアウトシフトが防げません。
+          をつけた要素は、リセットCSSだけではレイアウトシフトが防げません。
         </strong>
         <br />
         CSSの<InlineCode>attr()</InlineCode>

--- a/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
@@ -1,0 +1,79 @@
+import { ContentRoot } from '../../../components/ContentRoot'
+import { InlineCode, TagName } from '../../../components/InlineCode'
+import { SSRHighlight } from '../../../components/SSRHighlight'
+import { dedent } from '../../../utils/string'
+
+export default function SsrPage() {
+  return (
+    <ContentRoot>
+      <h1>SSR時のレイアウトシフトを防ぐ</h1>
+      <p>
+        「
+        <strong>
+          <TagName>pixiv-icon</TagName>はCustom
+          Elementですが、サーバーサイドレンダリングをサポートしますか？
+        </strong>
+        」
+      </p>
+      <p>
+        という疑問を受けることがあります。
+        <br />
+        これはSSRの際、結果となるHTMLに
+        <TagName>pixiv-icon</TagName>
+        要素を含んでも特に問題が起きないという点ではYESです。
+        <br />
+        <InlineCode>@charcoal-ui/icons</InlineCode>
+        は、Node.jsの環境下でimportされたり、APIを呼び出されても問題が起きないように設計されています。
+      </p>
+      <p>
+        一方、Custom Elementであるということは、
+        <strong>SVGアイコンの読み込みはクライアントサイドで行われます。</strong>
+        <br />
+        したがって、大きさが確定せずにレイアウトシフトが起こりうるのは、SSRにおける注意点の一つと言えます。
+      </p>
+      <hr />
+      <p>
+        以下のようなコードをリセットCSSに含めることで、
+        <TagName>pixiv-icon</TagName>
+        によるレイアウトシフトの発生を防ぐことができます。
+        <br />
+        （簡単のため、ネスト記法が利用できるケースを念頭に説明をしています）
+      </p>
+      <SSRHighlight
+        code={dedent`
+          pixiv-icon {
+            display: inline-flex;
+            width: calc(var(--icon-size, 1em) * var(--scale, 1));
+            height: calc(var(--icon-size, 1em) * var(--scale, 1));
+        
+            &[name^='16/'] {
+              --icon-size: 16px;
+            }
+        
+            &[name^='24/'] {
+              --icon-size: 24px;
+            }
+        
+            &[name^='32/'] {
+              --icon-size: 32px;
+            }
+        
+            &[scale='2'] {
+              --scale: 2;
+            }
+        
+            &[scale='3'] {
+              --scale: 3;
+            }
+        
+            /** NOTICE: 現状だと attr(... number) はほとんどのブラウザで動かない */
+            &[unsafe-non-guideline-scale] {
+              --scale: attr(unsafe-non-guideline-scale number);
+            }
+          }
+        `}
+        lang="css"
+      />
+    </ContentRoot>
+  )
+}

--- a/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
@@ -47,27 +47,27 @@ export default function SsrPage() {
             display: inline-flex;
             width: calc(var(--icon-size, 1em) * var(--scale, 1));
             height: calc(var(--icon-size, 1em) * var(--scale, 1));
-        
+
             &[name^='16/'] {
               --icon-size: 16px;
             }
-        
+
             &[name^='24/'] {
               --icon-size: 24px;
             }
-        
+
             &[name^='32/'] {
               --icon-size: 32px;
             }
-        
+
             &[scale='2'] {
               --scale: 2;
             }
-        
+
             &[scale='3'] {
               --scale: 3;
             }
-        
+
             /** NOTICE: 現状だと attr(... number) はほとんどのブラウザで動かない */
             &[unsafe-non-guideline-scale] {
               --scale: attr(unsafe-non-guideline-scale number);

--- a/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
@@ -6,23 +6,10 @@ import { dedent } from '../../../utils/string'
 export default function SsrPage() {
   return (
     <ContentRoot>
-      <h1>SSR時のレイアウトシフトを防ぐ</h1>
+      <h1>サーバーサイドレンダリング</h1>
       <p>
-        「
-        <strong>
-          <TagName>pixiv-icon</TagName>はCustom
-          Elementですが、サーバーサイドレンダリングをサポートしますか？
-        </strong>
-        」
-      </p>
-      <p>
-        という疑問を受けることがあります。
-        <br />
-        これはSSRの際、結果となるHTMLに
         <TagName>pixiv-icon</TagName>
-        要素を含んでも特に問題が起きないという点では
-        <strong>YES</strong>
-        です。
+        はサーバーサイドレンダリング時にも利用できます。
         <br />
         <InlineCode>@charcoal-ui/icons</InlineCode>
         は、Node.jsの環境下でimportされたり、APIを呼び出されても問題が起きないように設計されています。

--- a/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/icons/ssr.page.tsx
@@ -20,7 +20,9 @@ export default function SsrPage() {
         <br />
         これはSSRの際、結果となるHTMLに
         <TagName>pixiv-icon</TagName>
-        要素を含んでも特に問題が起きないという点ではYESです。
+        要素を含んでも特に問題が起きないという点では
+        <strong>YES</strong>
+        です。
         <br />
         <InlineCode>@charcoal-ui/icons</InlineCode>
         は、Node.jsの環境下でimportされたり、APIを呼び出されても問題が起きないように設計されています。
@@ -73,6 +75,25 @@ export default function SsrPage() {
           }
         `}
         lang="css"
+      />
+      <p>
+        ただしコメントにもある通り、
+        <strong>
+          現状
+          <InlineCode>unsafe-non-guideline-scale</InlineCode>
+          をつけた要素はレイアウトシフトが防げません。
+        </strong>
+        <br />
+        CSSの<InlineCode>attr()</InlineCode>
+        が数値の解釈をサポートするまでは、個別にインラインスタイルを用いて大きさを確定させるなどのワークアラウンドが必要です。
+      </p>
+      <SSRHighlight
+        code={dedent`
+          <pixiv-icon name="24/Add" unsafe-non-guideline-scale="0.5" style="--scale: 0.5;">
+
+          <pixiv-icon name="24/Add" unsafe-non-guideline-scale="0.5" style="width: 12px; height: 12px;">
+        `}
+        lang="html"
       />
     </ContentRoot>
   )

--- a/docs/src/pages/@charcoal-ui/react/_components/ApiTable.tsx
+++ b/docs/src/pages/@charcoal-ui/react/_components/ApiTable.tsx
@@ -1,5 +1,4 @@
-import styled from 'styled-components'
-import { theme } from '../../../../utils/theme'
+import { Table } from '../../../../components/Table'
 
 export type TableItem = {
   type: string
@@ -8,9 +7,9 @@ export type TableItem = {
   required?: boolean
 }
 
-type DomProps<T> = React.DetailedHTMLProps<React.HTMLAttributes<T>, T>
+export type TableDataInterface = Record<string, TableItem>
 
-export type ApiTableDataInterface = Record<string, TableItem>
+type DomProps<T> = React.DetailedHTMLProps<React.HTMLAttributes<T>, T>
 
 /**
  * コンポーネントのPropsの型から、そのキー名を必須のキーとなるようなドキュメント構造の型
@@ -25,60 +24,6 @@ export type ApiTableData<T, U> = {
  * コンポーネントのPropsのドキュメントをテーブル形式で表示する
  * @param props ex. { data: { [propName]: { type: .... } } }
  */
-export function ApiTable(props: { data: ApiTableDataInterface }) {
-  return (
-    <TableParentDiv>
-      <StyledTable>
-        <thead>
-          <StyledTr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default</th>
-            <th>required</th>
-          </StyledTr>
-        </thead>
-        <tbody>
-          {Object.entries(props.data)
-            .sort((a, b) => a[0].localeCompare(b[0]))
-            .sort((a, b) => (b[1].required ? 1 : 0) - (a[1].required ? 1 : 0))
-            .map(([key, value]) => {
-              return (
-                <StyledTr key={key}>
-                  <td>{key}</td>
-                  <td>{value.description}</td>
-                  <td>{value.type}</td>
-                  <td>{value.default}</td>
-                  <td>{value.required ? 'required' : 'optional'}</td>
-                </StyledTr>
-              )
-            })}
-        </tbody>
-      </StyledTable>
-    </TableParentDiv>
-  )
+export function ApiTable(props: { data: TableDataInterface }) {
+  return <Table {...props} />
 }
-
-const StyledTable = styled.table`
-  width: 100%;
-  font-size: 14px;
-  border-collapse: collapse;
-  font-weight: normal;
-  font-family: 'SF Mono', SFMono-Regular, ui-monospace, 'DejaVu Sans Mono',
-    Menlo, Consolas, monospace;
-`
-
-const StyledTr = styled.tr`
-  ${theme((o) => o.border.default.bottom)}
-  height: 32px;
-
-  > td,
-  > th {
-    padding: 8px 18px;
-  }
-`
-const TableParentDiv = styled.div`
-  overflow-x: auto;
-  max-width: 100%;
-  ${theme((o) => o.border.default)}
-`

--- a/docs/src/pages/@charcoal-ui/react/ssr.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/ssr.page.tsx
@@ -9,7 +9,7 @@ import { SSRHighlight } from '../../../components/SSRHighlight'
 export default function InstallPage() {
   return (
     <ContentRoot>
-      <h1>SSR</h1>
+      <h1>サーバーサイドレンダリング</h1>
       <p>
         charcoal は<StyledLink href="https://nextjs.org/"> Next.js </StyledLink>
         などのサーバーサイドレンダリングをサポートしています。

--- a/docs/src/utils/string.ts
+++ b/docs/src/utils/string.ts
@@ -1,0 +1,39 @@
+/**
+ * インデントを良い感じに取り除く
+ *
+ * タグ付きテンプレートリテラルで書けるが、変数埋め込みはサポートしない
+ */
+export function dedent(tag: TemplateStringsArray) {
+  if (tag.length > 1) {
+    throw new Error('Do not interpolate value')
+  }
+
+  const lines = tag[0].split(/\n/)
+  const minimumIndent = getMinimumIndent(lines)
+
+  const 行の先頭にあるminimumIndent個のスペース = new RegExp(
+    `^\\s{${minimumIndent}}`
+  )
+
+  return lines
+    .map((line) => line.replace(行の先頭にあるminimumIndent個のスペース, ''))
+    .join('\n')
+    .trim()
+}
+
+function getMinimumIndent(lines: string[]) {
+  // 空白しかない行を除く
+  const lineWithNonSpaces = lines.filter((line) => !/^\s+$/.test(line))
+
+  const indents = lineWithNonSpaces
+    .map(getIndentCount)
+    .filter((indent) => indent > 0)
+
+  return Math.min(...indents)
+}
+
+function getIndentCount(line: string) {
+  const spaces = line.match(/^\s+/)?.[0]
+
+  return spaces?.length ?? 0
+}

--- a/docs/src/utils/string.ts
+++ b/docs/src/utils/string.ts
@@ -16,20 +16,28 @@ export function dedent(tag: TemplateStringsArray) {
   )
 
   return lines
-    .map((line) => line.replace(行の先頭にあるminimumIndent個のスペース, ''))
+    .map((line) => {
+      if (isWhiteSpaceOnly(line)) {
+        return ''
+      }
+
+      return line.replace(行の先頭にあるminimumIndent個のスペース, '')
+    })
     .join('\n')
     .trim()
 }
 
 function getMinimumIndent(lines: string[]) {
-  // 空白しかない行を除く
-  const lineWithNonSpaces = lines.filter((line) => !/^\s+$/.test(line))
-
-  const indents = lineWithNonSpaces
+  const indents = lines
+    .filter((line) => !isWhiteSpaceOnly(line))
     .map(getIndentCount)
     .filter((indent) => indent > 0)
 
   return Math.min(...indents)
+}
+
+function isWhiteSpaceOnly(line: string) {
+  return /^\s+$/.test(line)
 }
 
 function getIndentCount(line: string) {


### PR DESCRIPTION
## やったこと

`@charcoal-ui/icons` の使い方に関するページを追加。

だいたい旧ドキュメントサイトやREADMEの転記だが、2.0.0 以降の実態に合わせた。

`icon-files` や `icons-cli` のドキュメントも書くか考えたが、メンテナしか知らなくていいよなと思って一旦除いている（迷ってる）

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
