### PR TITLE
chore: pixiv-icon 向けの reset.css を書いてレイアウトシフトを防ぐ

### DIFF
--- a/docs/src/components/GlobalStyle.tsx
+++ b/docs/src/components/GlobalStyle.tsx
@@ -1,5 +1,32 @@
-import { createGlobalStyle } from 'styled-components'
+import { createGlobalStyle, css } from 'styled-components'
 import { theme } from '../utils/theme'
+
+const resetPixivIcon = css`
+  pixiv-icon {
+    width: calc(var(--icon-size, 1em) * var(--scale, 1));
+    height: calc(var(--icon-size, 1em) * var(--scale, 1));
+
+    &[name^='16/'] {
+      --icon-size: 16px;
+    }
+
+    &[name^='24/'] {
+      --icon-size: 24px;
+    }
+
+    &[name^='32/'] {
+      --icon-size: 32px;
+    }
+
+    &[scale] {
+      --scale: attr(scale number);
+    }
+
+    &[unsafe-non-guideline-scale] {
+      --scale: attr(unsafe-non-guideline-scale number);
+    }
+  }
+`
 
 export const GlobalStyle = createGlobalStyle`
 html, body, #__next {
@@ -23,4 +50,5 @@ pre {
   margin-bottom: 0;
 }
 
+${resetPixivIcon}
 `


### PR DESCRIPTION
## やったこと

pixiv-icon は Custom Element であり、SVG はクライアントサイドで読み込まれる。

このとき、レイアウトシフトが起こらないよう `<pixiv-icon>` の大きさの初期値を書く。

うまく行けば、pixiv-icon 導入時のベストプラクティスとして説明に書くか、そもそも css を配ってしまうのが良いだろう。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
