### PR TITLE
fix: textFieldのprefixがinputの背景色の影響を受ける #248

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/sections.tsx
@@ -80,6 +80,23 @@ export const sections: PreviewSection<TextFieldProps>[] = [
     ],
   },
   {
+    title: 'prefix',
+    previewMetas: [
+      {
+        children: undefined,
+        props: {
+          label: 'Label',
+          placeholder: 'placeholder',
+          prefix: (
+            <StyledDiv>
+              <Icon name="24/Search" />
+            </StyledDiv>
+          ),
+        },
+      },
+    ],
+  },
+  {
     title: 'suffix',
     previewMetas: [
       {

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -349,6 +349,7 @@ const PrefixContainer = styled.span`
   top: 50%;
   left: 8px;
   transform: translateY(-50%);
+  z-index: 1;
 `
 
 const SuffixContainer = styled.span`


### PR DESCRIPTION
## やったこと
fix: #248 

ツリー構造を変えないためにprefixにz-indexを追加

## 動作確認環境
docs
