### PR TITLE
styled: theme.border の色を CSS Variables で扱うようにする

### DIFF
--- a/packages/styled/src/TokenInjector.tsx
+++ b/packages/styled/src/TokenInjector.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
-import { defineThemeVariables } from './util'
+import { defineThemeVariables, withPrefixes } from './util'
 import { mapObject } from '@charcoal-ui/utils'
 
 const GlobalStyle = createGlobalStyle`
@@ -59,7 +59,7 @@ export default function TokenInjector<T extends Theme>({
 const defineColorVariableCSS = (theme: Theme) => {
   const borders = mapObject(theme.border, (name, { color }) => [
     // REVIEW: もしtheme.colorにたまたまborder-〇〇で始まる色名がいたら被りうる
-    `border-${name}`,
+    withPrefixes('border', name),
     color,
   ])
 

--- a/packages/styled/src/TokenInjector.tsx
+++ b/packages/styled/src/TokenInjector.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
 import { defineThemeVariables } from './util'
+import { mapObject } from '@charcoal-ui/utils'
 
 const GlobalStyle = createGlobalStyle`
   ${<T extends Theme>({
@@ -43,7 +44,7 @@ export interface ThemeMap<T extends Theme> {
   [selector: string]: T
 }
 
-type Theme = Pick<CharcoalAbstractTheme, 'color' | 'effect'>
+type Theme = Pick<CharcoalAbstractTheme, 'color' | 'effect' | 'border'>
 
 export default function TokenInjector<T extends Theme>({
   theme: themeMap,
@@ -55,9 +56,22 @@ export default function TokenInjector<T extends Theme>({
   return <GlobalStyle themeMap={themeMap} background={background} />
 }
 
-const defineColorVariableCSS = (theme: Theme) =>
-  Object.entries(defineThemeVariables(theme.color)({ theme }))
+const defineColorVariableCSS = (theme: Theme) => {
+  const borders = mapObject(theme.border, (name, { color }) => [
+    // REVIEW: もしtheme.colorにたまたまborder-〇〇で始まる色名がいたら被りうる
+    `border-${name}`,
+    color,
+  ])
+
+  const colors = defineThemeVariables({ ...theme.color, ...borders })({ theme })
+
+  return toCSSVariables(colors)
+}
+
+function toCSSVariables(css: Record<string, string | number>) {
+  return Object.entries(css)
     .map(([varName, value]) => variableDefinition(varName, value.toString()))
     .join(';')
+}
 
 const variableDefinition = (prop: string, value: string) => `${prop}: ${value}`

--- a/packages/styled/src/__snapshots__/index.test.tsx.snap
+++ b/packages/styled/src/__snapshots__/index.test.tsx.snap
@@ -463,7 +463,7 @@ exports[`Story <Example /> 1`] = `
   padding-bottom: 20px;
   padding-right: 24px;
   padding-left: 24px;
-  border: solid 1px rgba(0,0,0,0.08);
+  border: solid 1px var(--charcoal-border-default);
   border-radius: 8px;
 }
 

--- a/packages/styled/src/builders/border.ts
+++ b/packages/styled/src/builders/border.ts
@@ -1,6 +1,6 @@
 import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
 import { CSSObject } from 'styled-components'
-import { keyof, variable } from '../util'
+import { keyof, variable, withPrefixes } from '../util'
 import { Internal, createInternal } from '../internals'
 import {
   defineConstantProperties,
@@ -17,9 +17,10 @@ export const createBorderCss = <T extends CharcoalAbstractTheme>(
   directions: readonly BorderDirection[]
 ): Internal => {
   const all = directions.length === 0
-  const colorName = `border-${variant.toString()}`
 
-  const value = `solid 1px ${variable(customPropertyToken(colorName))}`
+  const value = `solid 1px ${variable(
+    customPropertyToken(withPrefixes('border', variant.toString()))
+  )}`
 
   return createInternal({
     toCSS() {

--- a/packages/styled/src/builders/border.ts
+++ b/packages/styled/src/builders/border.ts
@@ -1,60 +1,52 @@
 import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
 import { CSSObject } from 'styled-components'
-import { keyof } from '../util'
+import { keyof, variable } from '../util'
 import { Internal, createInternal } from '../internals'
 import {
   defineConstantProperties,
   defineProperties,
   definePropertyChains,
 } from '../factories/lib'
+import { customPropertyToken } from '@charcoal-ui/utils'
 
 export const borderDirections = ['top', 'right', 'bottom', 'left'] as const
 type BorderDirection = (typeof borderDirections)[number]
 
-function borderProperty(direction: BorderDirection) {
-  return `border-${direction}`
+export const createBorderCss = <T extends CharcoalAbstractTheme>(
+  variant: keyof T['border'],
+  directions: readonly BorderDirection[]
+): Internal => {
+  const all = directions.length === 0
+  const colorName = `border-${variant.toString()}`
+
+  const value = `solid 1px ${variable(customPropertyToken(colorName))}`
+
+  return createInternal({
+    toCSS() {
+      return {
+        ...(all
+          ? { border: value }
+          : directions.reduce<CSSObject>(
+              (acc, direction) => ({
+                ...acc,
+                [`border-${direction}`]: value,
+              }),
+              {}
+            )),
+      }
+    },
+  })
 }
-
-function borderShorthand(color: string) {
-  return `solid 1px ${color}`
-}
-
-export const createBorderCss =
-  <T extends CharcoalAbstractTheme>(theme: T) =>
-  (
-    variant: keyof T['border'],
-    directions: readonly BorderDirection[]
-  ): Internal => {
-    const all = directions.length === 0
-    const value = borderShorthand(theme.border[variant].color)
-
-    return createInternal({
-      toCSS() {
-        return {
-          ...(all
-            ? { border: value }
-            : directions.reduce<CSSObject>(
-                (acc, direction) => ({
-                  ...acc,
-                  [borderProperty(direction)]: value,
-                }),
-                {}
-              )),
-        }
-      },
-    })
-  }
 
 export default function border<T extends CharcoalAbstractTheme>(theme: T) {
   const borderTypes = keyof<T['border']>(theme.border)
 
-  const borderCss = createBorderCss(theme)
   const borderObject = defineConstantProperties(
     {},
     {
       border: defineProperties({}, borderTypes, (variant) =>
         definePropertyChains(borderDirections, (modifiers) =>
-          borderCss(variant, modifiers)
+          createBorderCss(variant, modifiers)
         )
       ),
     }

--- a/packages/styled/src/util.ts
+++ b/packages/styled/src/util.ts
@@ -186,3 +186,7 @@ export function onEffectPseudo(effect: EffectType, css: CSSObject) {
     ? { [disabledSelector]: css }
     : unreachable(effect)
 }
+
+export function withPrefixes(...parts: string[]) {
+  return parts.join('-')
+}


### PR DESCRIPTION
## やったこと

fixes: https://github.com/pixiv/charcoal/issues/242

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
