### PR TITLE
fix: <RadioInput> のラジオボタンも cursor: pointer となるように修正した

### DIFF
--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -82,6 +82,8 @@ export const RadioInput = styled.input.attrs({ type: 'radio' })<{
     width: 20px;
     height: 20px;
 
+    cursor: pointer;
+
     ${({ hasError = false }) =>
       theme((o) => [
         o.borderRadius('oval'),


### PR DESCRIPTION
## やったこと

- `<RadioInput>` のラジオボタン部分も cursor: pointer となるように修正した

## 動作確認環境

- Storybook

https://github.com/pixiv/charcoal/assets/20609120/fdca55a9-6f59-4e51-bee5-ef94a617b2a3

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
