### PR TITLE
fix: npmjsバッジのラベルが @charcoal-ui/icons のままだったのを修正

### DIFF
--- a/docs/src/pages/@charcoal-ui/tailwind-diff/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/tailwind-diff/quickstart.page.tsx
@@ -12,7 +12,7 @@ export default function InstallPage() {
       <Link href="https://www.npmjs.com/package/@charcoal-ui/tailwind-diff">
         <img
           alt="npm-badge"
-          src="https://img.shields.io/npm/v/@charcoal-ui/tailwind-diff?label=%40charcoal-ui%2Ficons&style=flat-square&logo=npm"
+          src="https://img.shields.io/npm/v/@charcoal-ui/tailwind-diff?label=%40charcoal-ui%2Ftailwind-diff&style=flat-square&logo=npm"
         />
       </Link>
       <h2>インストール</h2>


### PR DESCRIPTION
## やったこと

- tailwind-diff のドキュメントのnpmjsのバッジのラベルが `@charcoal-ui/icons` だったのを `@charcoal-ui/tailwind-diff` へ修正しました。

## 動作確認環境
CIから発行されるURLの `/@charcoal-ui/tailwind-diff/quickstart/` を見る
