### PR TITLE
Reactのimportを削除する 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,8 @@ const config = {
     'react/prop-types': 'off',
     'react/no-unknown-property': ['error', { ignore: ['css'] }],
     'no-console': 'warn',
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
   parserOptions: {
     project: ['./tsconfig.json', './packages/**/tsconfig.json'],

--- a/.storybook/theme-decorator.tsx
+++ b/.storybook/theme-decorator.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { ThemeProvider } from 'styled-components'
 import { useDarkMode } from 'storybook-dark-mode'
 import { light, dark } from '@charcoal-ui/theme'

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,8 @@
+// 現状 jest（babel-jest）で JSX Transform を動かす用途でのみ使用している
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript',
+  ],
+}

--- a/docs/src/components/SideMenuModal.tsx
+++ b/docs/src/components/SideMenuModal.tsx
@@ -4,7 +4,8 @@ import {
   AriaModalOverlayProps,
 } from '@react-aria/overlays'
 import { OverlayTriggerState } from 'react-stately'
-import React, { FC, useRef } from 'react'
+import { FC, useRef } from 'react'
+import * as React from 'react'
 import { FocusScope } from '@react-aria/focus'
 import styled from 'styled-components'
 import { theme } from '../utils/theme'

--- a/docs/src/pages/@charcoal-ui/tailwind-diff/quickstart.page.tsx
+++ b/docs/src/pages/@charcoal-ui/tailwind-diff/quickstart.page.tsx
@@ -12,7 +12,7 @@ export default function InstallPage() {
       <Link href="https://www.npmjs.com/package/@charcoal-ui/tailwind-diff">
         <img
           alt="npm-badge"
-          src="https://img.shields.io/npm/v/@charcoal-ui/tailwind-diff?label=%40charcoal-ui%2Ficons&style=flat-square&logo=npm"
+          src="https://img.shields.io/npm/v/@charcoal-ui/tailwind-diff?label=%40charcoal-ui%2Ftailwind-diff&style=flat-square&logo=npm"
         />
       </Link>
       <h2>インストール</h2>

--- a/docs/src/pages/_document.page.tsx
+++ b/docs/src/pages/_document.page.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Document, {
   DocumentContext,
   Html,

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -13,7 +13,7 @@ const defaultConfig = () => ({
   testEnvironment: 'jsdom',
   // node_modules内のためにjsxも含める
   transform: {
-    '^.+\\.(t|j)sx?$': ['esbuild-jest', { target: 'esnext', format: 'cjs' }],
+    '^.+\\.(t|j)sx?$': 'babel-jest',
   },
   // tsconfigのpathsに対応 (依存パッケージをビルドせずにテストが可能)
   moduleNameMapper: {

--- a/packages/icons/src/PixivIcon.story.tsx
+++ b/packages/icons/src/PixivIcon.story.tsx
@@ -1,6 +1,6 @@
 /// <reference types='@types/webpack-env' />
 
-import React from 'react'
+import * as React from 'react'
 import styled, { createGlobalStyle } from 'styled-components'
 import TestIconThatNeverExists from './16/TestIconThatNeverExists.svg'
 import { Props } from './PixivIcon'

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -56,7 +56,7 @@
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.13.1",
+    "react": ">=17.0.0",
     "react-dom": ">=16.13.1",
     "styled-components": ">=5.1.1"
   },

--- a/packages/react-sandbox/src/_lib/compat.ts
+++ b/packages/react-sandbox/src/_lib/compat.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 /**
  * import { Story } from '@storybook/react/types-6-0'

--- a/packages/react-sandbox/src/components/Carousel/index.story.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.story.tsx
@@ -1,5 +1,4 @@
 import { boolean, number, select, withKnobs } from '@storybook/addon-knobs'
-import React from 'react'
 import styled, { css } from 'styled-components'
 import Carousel from '.'
 

--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
+import * as React from 'react'
 import { animated, useSpring } from 'react-spring'
 import styled, { css } from 'styled-components'
 import { useDebounceAnimationState } from '../../foundation/hooks'

--- a/packages/react-sandbox/src/components/CarouselButton/index.story.tsx
+++ b/packages/react-sandbox/src/components/CarouselButton/index.story.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, number, select, withKnobs } from '@storybook/addon-knobs'
-import React from 'react'
 import CarouselButton, { Direction, ScrollHintButton } from '.'
 
 export default {

--- a/packages/react-sandbox/src/components/CarouselButton/index.tsx
+++ b/packages/react-sandbox/src/components/CarouselButton/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled, { css } from 'styled-components'
 import { unreachable } from '../../foundation/utils'
 import NextIcon, { WedgeDirection } from '../icons/NextIcon'

--- a/packages/react-sandbox/src/components/Filter/index.story.tsx
+++ b/packages/react-sandbox/src/components/Filter/index.story.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
-import React from 'react'
 import {
   Link as RouterLink,
   MemoryRouter as Router,

--- a/packages/react-sandbox/src/components/Filter/index.tsx
+++ b/packages/react-sandbox/src/components/Filter/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useComponentAbstraction, LinkProps } from '@charcoal-ui/react'
 import { maxWidth } from '@charcoal-ui/utils'

--- a/packages/react-sandbox/src/components/HintText/index.story.tsx
+++ b/packages/react-sandbox/src/components/HintText/index.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story } from '../../_lib/compat'
 import HintText from '.'
 

--- a/packages/react-sandbox/src/components/HintText/index.tsx
+++ b/packages/react-sandbox/src/components/HintText/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import InfoIcon from '../icons/InfoIcon'

--- a/packages/react-sandbox/src/components/Layout/index.story.tsx
+++ b/packages/react-sandbox/src/components/Layout/index.story.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled from 'styled-components'
 import { dummyText } from '../../misc/storybook-helper'
 import { theme } from '../../styled'

--- a/packages/react-sandbox/src/components/Layout/index.tsx
+++ b/packages/react-sandbox/src/components/Layout/index.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+import * as React from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import {
   MAIN_COLUMN_HORIZONTAL_MIN_MARGIN,

--- a/packages/react-sandbox/src/components/LeftMenu/index.tsx
+++ b/packages/react-sandbox/src/components/LeftMenu/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { MenuListLinkItem } from '../MenuListItem'
 import { useComponentAbstraction } from '@charcoal-ui/react'

--- a/packages/react-sandbox/src/components/MenuListItem/index.story.tsx
+++ b/packages/react-sandbox/src/components/MenuListItem/index.story.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import React from 'react'
 import styled from 'styled-components'
 import SwitchCheckbox from '../SwitchCheckbox'
 import WithIcon from '../WithIcon'

--- a/packages/react-sandbox/src/components/MenuListItem/index.tsx
+++ b/packages/react-sandbox/src/components/MenuListItem/index.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import { TextEllipsis } from '../TextEllipsis'

--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import {
   MemoryRouter as Router,
   Route,

--- a/packages/react-sandbox/src/components/Pager/index.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useDebugValue, useMemo } from 'react'
+import { memo, useCallback, useDebugValue, useMemo } from 'react'
 
 import styled, { css } from 'styled-components'
 import warning from 'warning'
@@ -75,11 +75,7 @@ export interface PagerProps extends CommonProps {
 }
 
 // this pager is just regular buttons; for links use LinkPager
-export default React.memo(function Pager({
-  page,
-  pageCount,
-  onChange,
-}: PagerProps) {
+export default memo(function Pager({ page, pageCount, onChange }: PagerProps) {
   // TODO: refactor Pager and LinkPager to use a common parent component
   const window = usePagerWindow(page, pageCount)
   const makeClickHandler = useCallback(

--- a/packages/react-sandbox/src/components/SwitchCheckbox/index.story.tsx
+++ b/packages/react-sandbox/src/components/SwitchCheckbox/index.story.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions'
 import { boolean } from '@storybook/addon-knobs'
-import React from 'react'
 import SwitchCheckbox from '.'
 
 export default {

--- a/packages/react-sandbox/src/components/SwitchCheckbox/index.tsx
+++ b/packages/react-sandbox/src/components/SwitchCheckbox/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import styled, { css } from 'styled-components'
 import { applyEffect } from '@charcoal-ui/utils'

--- a/packages/react-sandbox/src/components/TextEllipsis/index.story.tsx
+++ b/packages/react-sandbox/src/components/TextEllipsis/index.story.tsx
@@ -1,5 +1,4 @@
 import { number, text } from '@storybook/addon-knobs'
-import React from 'react'
 import styled from 'styled-components'
 import { TextEllipsis } from '.'
 

--- a/packages/react-sandbox/src/components/WithIcon/index.story.tsx
+++ b/packages/react-sandbox/src/components/WithIcon/index.story.tsx
@@ -1,5 +1,5 @@
 import { boolean } from '@storybook/addon-knobs'
-import React from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
 import WithIcon from '.'

--- a/packages/react-sandbox/src/components/WithIcon/index.tsx
+++ b/packages/react-sandbox/src/components/WithIcon/index.tsx
@@ -1,4 +1,5 @@
-import React, { useRef } from 'react'
+import { useRef } from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useElementSize } from '../../foundation/hooks'
 

--- a/packages/react-sandbox/src/components/icons/Base.tsx
+++ b/packages/react-sandbox/src/components/icons/Base.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled from 'styled-components'
 
 export type IconSizes = 16 | 24 | 32

--- a/packages/react-sandbox/src/components/icons/DotsIcon.tsx
+++ b/packages/react-sandbox/src/components/icons/DotsIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 interface Props {

--- a/packages/react-sandbox/src/components/icons/InfoIcon.tsx
+++ b/packages/react-sandbox/src/components/icons/InfoIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import IconBase from './Base'
 

--- a/packages/react-sandbox/src/components/icons/NextIcon.tsx
+++ b/packages/react-sandbox/src/components/icons/NextIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { unreachable } from '../../foundation/utils'
 import IconBase from './Base'
 

--- a/packages/react-sandbox/src/components/icons/WedgeIcon.tsx
+++ b/packages/react-sandbox/src/components/icons/WedgeIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 
 import { unreachable } from '../../foundation/utils'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -73,7 +73,7 @@
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.13.1",
+    "react": ">=17.0.0",
     "styled-components": ">=5.1.1"
   },
   "files": [

--- a/packages/react/src/_lib/compat.ts
+++ b/packages/react/src/_lib/compat.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 /**
  * import { Story } from '@storybook/react/types-6-0'

--- a/packages/react/src/components/Button/index.story.tsx
+++ b/packages/react/src/components/Button/index.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import { Story } from '../../_lib/compat'
 import { ClickableElement } from '../Clickable'
 import Button, { ButtonProps } from '.'

--- a/packages/react/src/components/Button/index.test.tsx
+++ b/packages/react/src/components/Button/index.test.tsx
@@ -1,6 +1,5 @@
 import 'jest-styled-components'
 
-import React from 'react'
 import Button from '.'
 import renderder from 'react-test-renderer'
 import { ThemeProvider } from 'styled-components'

--- a/packages/react/src/components/Button/index.tsx
+++ b/packages/react/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { unreachable } from '../../_lib'
 import { theme } from '../../styled'
@@ -24,7 +24,7 @@ interface StyledProps {
 
 export type ButtonProps = Partial<StyledProps> & ClickableProps
 
-const Button = React.forwardRef<ClickableElement, ButtonProps>(function Button(
+const Button = forwardRef<ClickableElement, ButtonProps>(function Button(
   {
     children,
     variant = 'Default',

--- a/packages/react/src/components/Checkbox/index.story.tsx
+++ b/packages/react/src/components/Checkbox/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import Checkbox from '.'
 import { Story } from '../../_lib/compat'
 

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, memo, useMemo } from 'react'
+import { forwardRef, memo, useMemo } from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useCheckbox } from '@react-aria/checkbox'
 import { useObjectRef } from '@react-aria/utils'

--- a/packages/react/src/components/Clickable/index.story.tsx
+++ b/packages/react/src/components/Clickable/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import Clickable from '.'
 
 export default {

--- a/packages/react/src/components/Clickable/index.tsx
+++ b/packages/react/src/components/Clickable/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import {
   LinkProps,

--- a/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
+++ b/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from 'react'
+import { Key, useEffect, useRef } from 'react'
 import Popover, { PopoverProps } from './Popover'
 
 type DropdownPopoverProps = PopoverProps & {
-  value?: React.Key
+  value?: Key
 }
 
 /**

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import DropdownSelector, { DropdownSelectorProps } from '.'
 import { Story } from '../../_lib/compat'
 import { Divider } from './Divider'

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef, useState } from 'react'
+import { ReactNode, useState, useRef } from 'react'
 import styled from 'styled-components'
 import { disabledSelector } from '@charcoal-ui/utils'
 import Icon from '../Icon'

--- a/packages/react/src/components/FieldLabel/index.tsx
+++ b/packages/react/src/components/FieldLabel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styled from 'styled-components'
 import { createTheme } from '@charcoal-ui/styled'
 

--- a/packages/react/src/components/Icon/index.story.tsx
+++ b/packages/react/src/components/Icon/index.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Icon, { IconProps } from '.'
 import { KNOWN_ICON_FILES } from '@charcoal-ui/icons'
 import { Story } from '../../_lib/compat'

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 import '@charcoal-ui/icons'
 import type { PixivIcon, Props } from '@charcoal-ui/icons'

--- a/packages/react/src/components/IconButton/index.story.tsx
+++ b/packages/react/src/components/IconButton/index.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { Story } from '../../_lib/compat'
 import '@charcoal-ui/icons'
 import IconButton from '.'

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { forwardRef } from 'react'
 import styled from 'styled-components'
 import { theme } from '../../styled'
 import Clickable, { ClickableElement, ClickableProps } from '../Clickable'
@@ -15,7 +15,7 @@ interface StyledProps {
 
 export type IconButtonProps = StyledProps & ClickableProps
 
-const IconButton = React.forwardRef<ClickableElement, IconButtonProps>(
+const IconButton = forwardRef<ClickableElement, IconButtonProps>(
   function IconButtonInner(
     { variant = 'Default', size = 'M', icon, ...rest }: IconButtonProps,
     ref

--- a/packages/react/src/components/LoadingSpinner/index.story.tsx
+++ b/packages/react/src/components/LoadingSpinner/index.story.tsx
@@ -5,7 +5,7 @@ import {
   text,
   withKnobs,
 } from '@storybook/addon-knobs'
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import LoadingSpinner, {
   LoadingSpinnerIcon,
   LoadingSpinnerIconHandler,

--- a/packages/react/src/components/LoadingSpinner/index.tsx
+++ b/packages/react/src/components/LoadingSpinner/index.tsx
@@ -1,4 +1,4 @@
-import React, { useImperativeHandle, useRef } from 'react'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
 import styled, { keyframes } from 'styled-components'
 import { theme } from '../../styled'
 
@@ -67,23 +67,22 @@ export interface LoadingSpinnerIconHandler {
   restart(): void
 }
 
-export const LoadingSpinnerIcon = React.forwardRef<
-  LoadingSpinnerIconHandler,
-  Props
->(function LoadingSpinnerIcon({ once = false }, ref) {
-  const iconRef = useRef<HTMLDivElement>(null)
+export const LoadingSpinnerIcon = forwardRef<LoadingSpinnerIconHandler, Props>(
+  function LoadingSpinnerIcon({ once = false }, ref) {
+    const iconRef = useRef<HTMLDivElement>(null)
 
-  useImperativeHandle(ref, () => ({
-    restart: () => {
-      if (!iconRef.current) {
-        return
-      }
-      iconRef.current.dataset.resetAnimation = 'true'
-      // Force reflow hack!
-      void iconRef.current.offsetWidth
-      delete iconRef.current.dataset.resetAnimation
-    },
-  }))
+    useImperativeHandle(ref, () => ({
+      restart: () => {
+        if (!iconRef.current) {
+          return
+        }
+        iconRef.current.dataset.resetAnimation = 'true'
+        // Force reflow hack!
+        void iconRef.current.offsetWidth
+        delete iconRef.current.dataset.resetAnimation
+      },
+    }))
 
-  return <Icon ref={iconRef} once={once} />
-})
+    return <Icon ref={iconRef} once={once} />
+  }
+)

--- a/packages/react/src/components/Modal/ModalPlumbing.tsx
+++ b/packages/react/src/components/Modal/ModalPlumbing.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { ModalTitle } from '.'
 import styled from 'styled-components'
 import { theme } from '../../styled'

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Story } from '../../_lib/compat'
 import Modal, { ModalDismissButton, ModalProps } from '.'
 import { OverlayProvider } from '@react-aria/overlays'

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useRef } from 'react'
+import { useContext, useRef } from 'react'
+import * as React from 'react'
 import {
   AriaModalOverlayProps,
   Overlay,

--- a/packages/react/src/components/MultiSelect/index.story.tsx
+++ b/packages/react/src/components/MultiSelect/index.story.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Story } from '../../_lib/compat'
 import styled from 'styled-components'
 import { MultiSelectGroup, default as MultiSelect } from '.'

--- a/packages/react/src/components/MultiSelect/index.test.tsx
+++ b/packages/react/src/components/MultiSelect/index.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import React from 'react'
 import { ThemeProvider } from 'styled-components'
 import { default as MultiSelect, MultiSelectGroup } from '.'
 import { light } from '@charcoal-ui/theme'

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -1,4 +1,5 @@
-import React, { ChangeEvent, useCallback, useContext } from 'react'
+import { ChangeEvent, useCallback, useContext } from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import warning from 'warning'
 import { theme } from '../../styled'

--- a/packages/react/src/components/Radio/index.story.tsx
+++ b/packages/react/src/components/Radio/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import { css } from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Radio, { RadioGroup } from '.'

--- a/packages/react/src/components/Radio/index.test.tsx
+++ b/packages/react/src/components/Radio/index.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import React from 'react'
 import { ThemeProvider } from 'styled-components'
 import Radio, { RadioGroup } from '.'
 import { light } from '@charcoal-ui/theme'

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useContext } from 'react'
+import { useCallback, useContext } from 'react'
+import * as React from 'react'
 import styled from 'styled-components'
 import warning from 'warning'
 import { theme } from '../../styled'

--- a/packages/react/src/components/SegmentedControl/RadioGroupContext.tsx
+++ b/packages/react/src/components/SegmentedControl/RadioGroupContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react'
+import { createContext, useContext } from 'react'
+import * as React from 'react'
 import { RadioGroupState } from 'react-stately'
 
 const RadioContext = createContext<RadioGroupState | null>(null)

--- a/packages/react/src/components/SegmentedControl/index.story.tsx
+++ b/packages/react/src/components/SegmentedControl/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import SegmentedControl, { SegmentedControlProps } from '.'
 import { Story } from '../../_lib/compat'
 

--- a/packages/react/src/components/SegmentedControl/index.tsx
+++ b/packages/react/src/components/SegmentedControl/index.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, forwardRef, memo, useMemo, useRef } from 'react'
+import { ReactNode, forwardRef, memo, useMemo, useRef } from 'react'
+import * as React from 'react'
 import { useRadioGroupState } from 'react-stately'
 import {
   AriaRadioGroupProps,

--- a/packages/react/src/components/Switch/index.story.tsx
+++ b/packages/react/src/components/Switch/index.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Story } from '../../_lib/compat'
 import Switch from '.'
 

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -1,6 +1,7 @@
 import { useSwitch } from '@react-aria/switch'
 import type { AriaSwitchProps } from '@react-types/switch'
-import React, { useRef, useMemo } from 'react'
+import { useRef, useMemo } from 'react'
+import * as React from 'react'
 import { useToggleState } from 'react-stately'
 import styled from 'styled-components'
 import { theme } from '../../styled'

--- a/packages/react/src/components/TagItem/index.story.tsx
+++ b/packages/react/src/components/TagItem/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import styled from 'styled-components'
 import TagItem, { TagItemProps } from '.'
 import { Story } from '../../_lib/compat'

--- a/packages/react/src/components/TagItem/index.tsx
+++ b/packages/react/src/components/TagItem/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  forwardRef,
-  memo,
-  useMemo,
-  ComponentPropsWithoutRef,
-} from 'react'
+import { forwardRef, memo, useMemo, ComponentPropsWithoutRef } from 'react'
 import { useObjectRef } from '@react-aria/utils'
 import styled, { css } from 'styled-components'
 import { theme } from '../../styled'

--- a/packages/react/src/components/TextField/index.story.tsx
+++ b/packages/react/src/components/TextField/index.story.tsx
@@ -1,5 +1,4 @@
 import { action } from '@storybook/addon-actions'
-import React from 'react'
 import styled from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Clickable from '../Clickable'

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -1,12 +1,7 @@
 import { useTextField } from '@react-aria/textfield'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
+import * as React from 'react'
 import styled, { css } from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { createTheme } from '@charcoal-ui/styled'

--- a/packages/react/src/components/a11y.test.tsx
+++ b/packages/react/src/components/a11y.test.tsx
@@ -1,7 +1,6 @@
 import path from 'path'
 import glob from 'glob'
 import { axe, toHaveNoViolations } from 'jest-axe'
-import React from 'react'
 import { render } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 import { Story } from '../_lib/compat'

--- a/packages/react/src/core/CharcoalProvider.tsx
+++ b/packages/react/src/core/CharcoalProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { ThemeProvider } from 'styled-components'
 import ComponentAbstraction, { Components } from './ComponentAbstraction'
 import { TokenInjector } from '@charcoal-ui/styled'

--- a/packages/react/src/core/ComponentAbstraction.tsx
+++ b/packages/react/src/core/ComponentAbstraction.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
+import * as React from 'react'
 
 export type LinkProps = {
   /**

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -38,7 +38,7 @@
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=16.13.1",
+    "react": ">=17.0.0",
     "styled-components": ">=5.1.1"
   },
   "files": [

--- a/packages/styled/src/SetThemeScript.tsx
+++ b/packages/styled/src/SetThemeScript.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   assertKeyString,
   DEFAULT_ROOT_ATTRIBUTE,

--- a/packages/styled/src/TokenInjector.tsx
+++ b/packages/styled/src/TokenInjector.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createGlobalStyle, css } from 'styled-components'
 import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
 import { defineThemeVariables, withPrefixes } from './util'

--- a/packages/styled/src/index.story.tsx
+++ b/packages/styled/src/index.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled, { CSSProp, DefaultTheme, ThemeProvider } from 'styled-components'
 import { createTheme, ThemeProp, defineThemeVariables } from '.'
 import { disabledSelector } from '@charcoal-ui/utils'

--- a/packages/styled/src/index.test.tsx
+++ b/packages/styled/src/index.test.tsx
@@ -1,7 +1,6 @@
 import { light } from '@charcoal-ui/theme'
 import 'jest-styled-components'
 
-import React from 'react'
 import renderder from 'react-test-renderer'
 import { ThemeProvider } from 'styled-components'
 import { Example, TailwindLike } from './index.story'

--- a/packages/tailwind-config/src/_lib/compat.ts
+++ b/packages/tailwind-config/src/_lib/compat.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 
 /**
  * import { Story } from '@storybook/react/types-6-0'

--- a/packages/tailwind-config/src/docs/borderRadius/BorderRadius.tsx
+++ b/packages/tailwind-config/src/docs/borderRadius/BorderRadius.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { borderRadius } from '.'
 
 export const BorderRadius: React.FC = () => {

--- a/packages/tailwind-config/src/docs/colors/Colors.tsx
+++ b/packages/tailwind-config/src/docs/colors/Colors.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { EffectType } from '@charcoal-ui/theme'
 import { colors } from '.'
 

--- a/packages/tailwind-config/src/docs/colors/TextBgColor.story.tsx
+++ b/packages/tailwind-config/src/docs/colors/TextBgColor.story.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { Story } from '../../_lib/compat'
 
 import { colors } from '.'

--- a/packages/tailwind-config/src/docs/colors/TextColors.tsx
+++ b/packages/tailwind-config/src/docs/colors/TextColors.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { colors } from '.'
 
 export const TextColors: React.FC = () => (

--- a/packages/tailwind-config/src/docs/gradient/Gradients.tsx
+++ b/packages/tailwind-config/src/docs/gradient/Gradients.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { utilityClasses, directions, effectTypes } from '.'
 import { getUniqueGradientNames } from './utils'
 

--- a/packages/tailwind-config/src/docs/screens/Screens.tsx
+++ b/packages/tailwind-config/src/docs/screens/Screens.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { screens } from '.'
 
 export const Screens: React.FC = () => {

--- a/packages/tailwind-config/src/docs/spacing/Spacing.tsx
+++ b/packages/tailwind-config/src/docs/spacing/Spacing.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { spacing } from '.'
 
 export const Spacing: React.FC = () => {

--- a/packages/tailwind-config/src/docs/typography/HalfLeading.tsx
+++ b/packages/tailwind-config/src/docs/typography/HalfLeading.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { sizeClasses } from '.'
 
 export const HalfLeading: React.FC = () => (

--- a/packages/tailwind-config/src/docs/typography/Sizes.tsx
+++ b/packages/tailwind-config/src/docs/typography/Sizes.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { sizeClasses } from '.'
 
 export const Sizes: React.FC = () => (

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     // "noUncheckedIndexedAccess": true
-    "jsx": "react",
+    "jsx": "react-jsx",
     "declaration": true,
     "declarationMap": true,
     "paths": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1691,7 +1691,7 @@ __metadata:
     typescript: ^4.9.5
     warning: ^4.0.3
   peerDependencies:
-    react: ">=16.13.1"
+    react: ">=17.0.0"
     react-dom: ">=16.13.1"
     styled-components: ">=5.1.1"
   languageName: unknown
@@ -1753,7 +1753,7 @@ __metadata:
     typescript: ^4.9.5
     warning: ^4.0.3
   peerDependencies:
-    react: ">=16.13.1"
+    react: ">=17.0.0"
     styled-components: ">=5.1.1"
   languageName: unknown
   linkType: soft
@@ -1779,7 +1779,7 @@ __metadata:
     typescript: ^4.9.5
     warning: ^4.0.3
   peerDependencies:
-    react: ">=16.13.1"
+    react: ">=17.0.0"
     styled-components: ">=5.1.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## やったこと

- closed: https://github.com/pixiv/charcoal/issues/333
  - `import React from 'react'`の削除
  - eslint-pulugin-reactの以下のルールを無効化
    - `react/jsx-uses-react`
    - `react/react-in-jsx-scope`
  - tsconfig.baseのcompilerOptions更新
    - `jsx: react` → `jsx: react-jsx`
 - ~`v2.9.0` → `v3.0.0`に変更~  
    - React16.x系との互換が切れる破壊的変更の為 
- `peerDependencies`のreactバージョンを`>=17.0.0`に更新 
- jestのtransformを`esbuild-jest`から`babel-jest`に変更
  -  esbuild-jestは更新が2年以上停止しており、新しいJSXトランスフォームに非対応の為

## 動作確認環境
- storybook

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
