### PR TITLE
TextArea と TextField は通常のhtmlと同じ属性を受け付ける

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -1,9 +1,15 @@
 import { TextAreaProps } from '@charcoal-ui/react'
-import { ApiTableData } from '../_components/ApiTable'
+import { TableItem } from '../_components/ApiTable'
 
 export const apiData: Omit<
-  ApiTableData<TextAreaProps, HTMLInputElement>,
-  'type' | 'value'
+  Record<
+    Exclude<
+      keyof TextAreaProps,
+      keyof React.InputHTMLAttributes<HTMLTextAreaElement>
+    >,
+    TableItem
+  >,
+  'type' | 'value' | 'cols' | 'dirName' | 'wrap'
 > = {
   label: {
     default: '',
@@ -20,11 +26,6 @@ export const apiData: Omit<
     description: '高さを自動で変える',
     type: 'boolean',
   },
-  disabled: {
-    default: 'false',
-    description: '無効にする',
-    type: 'boolean',
-  },
   excludeFromTabOrder: {
     default: 'false',
     description: 'Tabキーを押したときにフォーカスの対象から除く',
@@ -33,21 +34,6 @@ export const apiData: Omit<
   invalid: {
     default: 'false',
     description: '入力が不正か',
-    type: 'boolean',
-  },
-  maxLength: {
-    default: '',
-    description: '入力できる最大値',
-    type: 'number',
-  },
-  required: {
-    default: 'false',
-    description: '入力必須か',
-    type: 'boolean',
-  },
-  autoFocus: {
-    default: 'false',
-    description: 'オートフォーカスをするか',
     type: 'boolean',
   },
   requiredText: {

--- a/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/index.page.tsx
@@ -39,7 +39,8 @@ const TextAreaPage: FC = () => {
 
       <h2>Props</h2>
       <p>
-        <InlineCode>&lt;input&gt;</InlineCode>の<InlineCode>props</InlineCode>
+        <InlineCode>&lt;textarea&gt;</InlineCode>の
+        <InlineCode>props</InlineCode>
         を継承しています。
       </p>
       <p>

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -1,8 +1,14 @@
 import { TextFieldProps } from '@charcoal-ui/react'
-import { ApiTableData } from '../_components/ApiTable'
+import { TableItem } from '../_components/ApiTable'
 
 export const apiData: Omit<
-  ApiTableData<TextFieldProps, HTMLInputElement>,
+  Record<
+    Exclude<
+      keyof TextFieldProps,
+      keyof React.InputHTMLAttributes<HTMLInputElement>
+    >,
+    TableItem
+  >,
   'type' | 'value'
 > = {
   label: {
@@ -15,11 +21,6 @@ export const apiData: Omit<
     description: 'エラーのテキスト',
     type: 'string',
   },
-  disabled: {
-    default: 'false',
-    description: '無効にする',
-    type: 'boolean',
-  },
   excludeFromTabOrder: {
     default: 'false',
     description: 'Tabキーを押したときにフォーカスの対象から除く',
@@ -28,21 +29,6 @@ export const apiData: Omit<
   invalid: {
     default: 'false',
     description: '入力が不正か',
-    type: 'boolean',
-  },
-  maxLength: {
-    default: '',
-    description: '入力できる最大値',
-    type: 'number',
-  },
-  required: {
-    default: 'false',
-    description: '入力必須か',
-    type: 'boolean',
-  },
-  autoFocus: {
-    default: 'false',
-    description: 'オートフォーカスをするか',
     type: 'boolean',
   },
   requiredText: {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -188,7 +188,7 @@ __metadata:
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 3.0.0-beta.2
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=57b4da&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=1901e5&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/icons": ^3.0.0-beta.2
     "@charcoal-ui/styled": ^3.0.0-beta.2
@@ -215,7 +215,7 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
     styled-components: ">=5.1.1"
-  checksum: 4079c47cc0c93c492b3d2ba657436c7ba1794f57c952bb53f44ca2fe484764c84280de811fab9a8a4c5efb977275264d7e58953f9d9af4a9d3e5ff02c46ad178
+  checksum: 4ad038064ba1dcd00a45070e0fa0f89840aa866dc4f83c59a4378d9afad7df50be0c197625f935fc6680608d2aa28ae7c3293721718f2a342924a9969947dabe
   languageName: node
   linkType: hard
 

--- a/packages/react/src/_lib/compat.ts
+++ b/packages/react/src/_lib/compat.ts
@@ -10,3 +10,22 @@ import React from 'react'
  * `Type alias 'Interpolation' circularly references itself. ts(2456)`
  */
 export type Story<P> = React.ComponentType<P> & { args?: P }
+
+/**
+ * react-ariaの`useTextField()`は、<textarea>をサポートするにも関わらず、
+ * `React.KeyboardEvent<HTMLInputElement>`しか想定していないイベントハンドラがいくつかある
+ * ↓ が直るまで、以下のイベントハンドラの型は信用しない（本当は`Element`ではなく`HTMLTextAreaElement`とかにしたい）
+ *
+ * @see https://github.com/adobe/react-spectrum/issues/4662
+ */
+export interface ReactAreaUseTextFieldCompat<E = Element> {
+  readonly onCopy?: React.ClipboardEventHandler<E>
+  readonly onPaste?: React.ClipboardEventHandler<E>
+  readonly onCut?: React.ClipboardEventHandler<E>
+  readonly onCompositionStart?: React.CompositionEventHandler<E>
+  readonly onCompositionEnd?: React.CompositionEventHandler<E>
+  readonly onCompositionUpdate?: React.CompositionEventHandler<E>
+  readonly onSelect?: React.ReactEventHandler<E>
+  readonly onBeforeInput?: React.FormEventHandler<E>
+  readonly onInput?: React.FormEventHandler<E>
+}

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -8,10 +8,7 @@ import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
 import { theme } from '../../styled'
 
 type DOMProps = Omit<
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLTextAreaElement>,
-    HTMLTextAreaElement
-  >,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
   // react-ariaのhookは、onChangeが`(v: string) => void`想定
   | 'onChange'
   // ReactAreaUseTextFieldCompatに書いてあるような事情で、ここにあるイベントハンドラの型をゆるめる
@@ -24,22 +21,22 @@ export interface TextAreaProps
     ReactAreaUseTextFieldCompat {
   readonly autoHeight?: boolean
   readonly rows?: number
-  readonly className?: string
+
+  // <input> 要素は number とか string[] もありうるが、今はこれしか想定してない
   readonly defaultValue?: string
   readonly value?: string
   readonly onChange?: (value: string) => void
+
+  // react-ariaの型定義のせいでHTMLTextAreaElementにできない
   readonly onKeyDown?: (event: React.KeyboardEvent<Element>) => void
   readonly onFocus?: (event: React.FocusEvent<Element>) => void
   readonly onBlur?: (event: React.FocusEvent<Element>) => void
+
   readonly showCount?: boolean
   readonly showLabel?: boolean
-  readonly placeholder?: string
   readonly assistiveText?: string
-  readonly disabled?: boolean
-  readonly required?: boolean
   readonly invalid?: boolean
-  readonly maxLength?: number
-  readonly autoFocus?: boolean
+
   /**
    * tab-indexがｰ1かどうか
    */

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -3,13 +3,25 @@ import { useVisuallyHidden } from '@react-aria/visually-hidden'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
-import { createTheme } from '@charcoal-ui/styled'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
+import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
+import { theme } from '../../styled'
 
-const theme = createTheme(styled)
+type DOMProps = Omit<
+  React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLTextAreaElement>,
+    HTMLTextAreaElement
+  >,
+  // react-ariaのhookは、onChangeが`(v: string) => void`想定
+  | 'onChange'
+  // ReactAreaUseTextFieldCompatに書いてあるような事情で、ここにあるイベントハンドラの型をゆるめる
+  | keyof ReactAreaUseTextFieldCompat
+>
 
 export interface TextAreaProps
-  extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'> {
+  extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'>,
+    DOMProps,
+    ReactAreaUseTextFieldCompat {
   readonly autoHeight?: boolean
   readonly rows?: number
   readonly className?: string

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -14,10 +14,7 @@ import { theme } from '../../styled'
 import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
 
 type DOMProps = Omit<
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLInputElement>,
-    HTMLInputElement
-  >,
+  React.InputHTMLAttributes<HTMLInputElement>,
   // react-ariaのhookは、onChangeが`(v: string) => void`想定
   | 'onChange'
 
@@ -33,25 +30,24 @@ export interface TextFieldProps
   extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'>,
     DOMProps,
     ReactAreaUseTextFieldCompat {
-  readonly type?: string
   readonly prefix?: ReactNode
   readonly suffix?: ReactNode
-  readonly className?: string
+
+  // <input> 要素は number とか string[] もありうるが、今はこれしか想定してない
   readonly defaultValue?: string
   readonly value?: string
   readonly onChange?: (value: string) => void
+
+  // react-ariaの型定義のせいでHTMLInputElementにできない
   readonly onKeyDown?: (event: React.KeyboardEvent<Element>) => void
   readonly onFocus?: (event: React.FocusEvent<Element>) => void
   readonly onBlur?: (event: React.FocusEvent<Element>) => void
+
   readonly showCount?: boolean
   readonly showLabel?: boolean
-  readonly placeholder?: string
   readonly assistiveText?: string
-  readonly disabled?: boolean
-  readonly required?: boolean
   readonly invalid?: boolean
-  readonly maxLength?: number
-  readonly autoFocus?: boolean
+
   /**
    * tab-indexがｰ1かどうか
    */

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -9,13 +9,30 @@ import React, {
 } from 'react'
 import styled from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
-import { createTheme } from '@charcoal-ui/styled'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
+import { theme } from '../../styled'
+import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
 
-const theme = createTheme(styled)
+type DOMProps = Omit<
+  React.DetailedHTMLProps<
+    React.HTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >,
+  // react-ariaのhookは、onChangeが`(v: string) => void`想定
+  | 'onChange'
+
+  // RDFa Attributeとかぶる
+  // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/58d57ca87ac7be0d306c0844dc254e90c150bd0d/types/react/index.d.ts#L1951
+  | 'prefix'
+
+  // ReactAreaUseTextFieldCompatに書いてあるような事情で、ここにあるイベントハンドラの型をゆるめる
+  | keyof ReactAreaUseTextFieldCompat
+>
 
 export interface TextFieldProps
-  extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'> {
+  extends Pick<FieldLabelProps, 'label' | 'requiredText' | 'subLabel'>,
+    DOMProps,
+    ReactAreaUseTextFieldCompat {
   readonly type?: string
   readonly prefix?: ReactNode
   readonly suffix?: ReactNode


### PR DESCRIPTION
## やったこと

TextArea は `<textarea>` の、TextField は `<input>` の属性を基本的に受け付けるようにしたい（完全に一緒ではない箇所もある）

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
