### PR TITLE
ドキュメントの修正と更新

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/_components/Previews.tsx
+++ b/docs/src/pages/@charcoal-ui/react/_components/Previews.tsx
@@ -54,7 +54,6 @@ export const PreviewDiv = styled.div`
   ${theme((o) => [o.border.default, o.borderRadius(8)])}
   padding: 16px;
   flex-wrap: wrap;
-  width: 100%;
   gap: 16px;
 `
 

--- a/docs/src/pages/v3.0.0-guide.page.tsx
+++ b/docs/src/pages/v3.0.0-guide.page.tsx
@@ -2,6 +2,7 @@ import { css } from 'styled-components'
 import { ContentRoot } from '../components/ContentRoot'
 import { InlineCode } from '../components/InlineCode'
 import { theme } from '../utils/theme'
+import { StyledLink } from './@charcoal-ui/react/ssr.page'
 
 export default function V2toV3GuidePage() {
   return (
@@ -12,6 +13,13 @@ export default function V2toV3GuidePage() {
       <p>
         v3.0.0 では一部コンポーネントの props を見直し、命名の統一や不要な props
         の削除を行いました。
+      </p>
+      <p>
+        依存するReactの最低バージョンを
+        <StyledLink href="https://ja.legacy.reactjs.org/blog/2020/10/20/react-v17.html">
+          React v17.0
+        </StyledLink>
+        に更新しました。
       </p>
       <p>DropdownSelector のパフォーマンスの改善を行いました。</p>
       <h3


### PR DESCRIPTION
## やったこと
- v3.0.0でreact17に変えた旨を追記
- コンテンツが横にスクロール可能になってしまう問題を修正
  - https://pixiv-charcoal-web--pr298-v3-0-0-ypwjowl4.web.app/@charcoal-ui/styled/bg/ などPreviewDivがあるページでコンテンツエリアをはみ出していた

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
