### PR TITLE
chore(react): change icon color

### DIFF
--- a/packages/react/src/components/TextField/index.story.tsx
+++ b/packages/react/src/components/TextField/index.story.tsx
@@ -102,7 +102,7 @@ export const PrefixIcon: Story<Partial<SingleLineTextFieldProps>> = (args) => (
 )
 
 const PrefixIconWrap = styled.div`
-  color: ${({ theme }) => theme.color.text4};
+  color: ${({ theme }) => theme.color.text3};
   margin-top: 2px;
   margin-right: 4px;
 `


### PR DESCRIPTION
## やったこと

- TextField の storybook にある PrefixIcon に使用されている icon のカラーを `text4` から `text3` に変更

## 動作確認環境

## チェックリスト
- storybook

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
