### PR TITLE
v3.0.0: TextAreaのフォーカスアニメーションを修正

### DIFF
--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -175,6 +175,7 @@ const StyledTextareaContainer = styled.div<{ rows: number; invalid: boolean }>`
   ${(p) =>
     theme((o) => [
       o.bg.surface3.hover,
+      o.outline.default.focus,
       p.invalid && o.outline.assertive,
       o.font.text2,
       o.borderRadius(4),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,7 +1585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@charcoal-ui/foundation@^3.0.0-beta.3, @charcoal-ui/foundation@workspace:packages/foundation":
+"@charcoal-ui/foundation@^3.0.0-beta.4, @charcoal-ui/foundation@workspace:packages/foundation":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/foundation@workspace:packages/foundation"
   dependencies:
@@ -1596,7 +1596,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/icon-files@^3.0.0-beta.3, @charcoal-ui/icon-files@workspace:packages/icon-files":
+"@charcoal-ui/icon-files@^3.0.0-beta.4, @charcoal-ui/icon-files@workspace:packages/icon-files":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/icon-files@workspace:packages/icon-files"
   languageName: unknown
@@ -1633,11 +1633,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/icons@^3.0.0-beta.3, @charcoal-ui/icons@workspace:packages/icons":
+"@charcoal-ui/icons@^3.0.0-beta.4, @charcoal-ui/icons@workspace:packages/icons":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/icons@workspace:packages/icons"
   dependencies:
-    "@charcoal-ui/icon-files": ^3.0.0-beta.3
+    "@charcoal-ui/icon-files": ^3.0.0-beta.4
     "@types/dompurify": ^2.3.3
     "@types/jest": ^27.4.0
     "@types/react": ^17.0.38
@@ -1656,11 +1656,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/react-sandbox@workspace:packages/react-sandbox"
   dependencies:
-    "@charcoal-ui/foundation": ^3.0.0-beta.3
-    "@charcoal-ui/react": ^3.0.0-beta.3
-    "@charcoal-ui/styled": ^3.0.0-beta.3
-    "@charcoal-ui/theme": ^3.0.0-beta.3
-    "@charcoal-ui/utils": ^3.0.0-beta.3
+    "@charcoal-ui/foundation": ^3.0.0-beta.4
+    "@charcoal-ui/react": ^3.0.0-beta.4
+    "@charcoal-ui/styled": ^3.0.0-beta.4
+    "@charcoal-ui/theme": ^3.0.0-beta.4
+    "@charcoal-ui/utils": ^3.0.0-beta.4
     "@storybook/addon-actions": ^6.4.17
     "@storybook/addon-knobs": ^6.4.0
     "@storybook/addons": ^6.4.17
@@ -1697,14 +1697,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/react@^3.0.0-beta.3, @charcoal-ui/react@workspace:packages/react":
+"@charcoal-ui/react@^3.0.0-beta.4, @charcoal-ui/react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/react@workspace:packages/react"
   dependencies:
-    "@charcoal-ui/icons": ^3.0.0-beta.3
-    "@charcoal-ui/styled": ^3.0.0-beta.3
-    "@charcoal-ui/theme": ^3.0.0-beta.3
-    "@charcoal-ui/utils": ^3.0.0-beta.3
+    "@charcoal-ui/icons": ^3.0.0-beta.4
+    "@charcoal-ui/styled": ^3.0.0-beta.4
+    "@charcoal-ui/theme": ^3.0.0-beta.4
+    "@charcoal-ui/utils": ^3.0.0-beta.4
     "@react-aria/button": ^3.7.0
     "@react-aria/checkbox": ^3.8.0
     "@react-aria/dialog": ^3.5.0
@@ -1758,13 +1758,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/styled@^3.0.0-beta.3, @charcoal-ui/styled@workspace:packages/styled":
+"@charcoal-ui/styled@^3.0.0-beta.4, @charcoal-ui/styled@workspace:packages/styled":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/styled@workspace:packages/styled"
   dependencies:
-    "@charcoal-ui/foundation": ^3.0.0-beta.3
-    "@charcoal-ui/theme": ^3.0.0-beta.3
-    "@charcoal-ui/utils": ^3.0.0-beta.3
+    "@charcoal-ui/foundation": ^3.0.0-beta.4
+    "@charcoal-ui/theme": ^3.0.0-beta.4
+    "@charcoal-ui/utils": ^3.0.0-beta.4
     "@types/react": ^17.0.38
     "@types/react-test-renderer": ^17.0.2
     "@types/styled-components": ^5.1.21
@@ -1788,9 +1788,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/tailwind-config@workspace:packages/tailwind-config"
   dependencies:
-    "@charcoal-ui/foundation": ^3.0.0-beta.3
-    "@charcoal-ui/theme": ^3.0.0-beta.3
-    "@charcoal-ui/utils": ^3.0.0-beta.3
+    "@charcoal-ui/foundation": ^3.0.0-beta.4
+    "@charcoal-ui/theme": ^3.0.0-beta.4
+    "@charcoal-ui/utils": ^3.0.0-beta.4
     postcss: ^8.4.5
     postcss-selector-parser: ^6.0.9
     react: ^18.0.0
@@ -1821,12 +1821,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/theme@^3.0.0-beta.3, @charcoal-ui/theme@workspace:packages/theme":
+"@charcoal-ui/theme@^3.0.0-beta.4, @charcoal-ui/theme@workspace:packages/theme":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/theme@workspace:packages/theme"
   dependencies:
-    "@charcoal-ui/foundation": ^3.0.0-beta.3
-    "@charcoal-ui/utils": ^3.0.0-beta.3
+    "@charcoal-ui/foundation": ^3.0.0-beta.4
+    "@charcoal-ui/utils": ^3.0.0-beta.4
     npm-run-all: ^4.1.5
     polished: ^4.1.4
     rimraf: ^3.0.2
@@ -1835,11 +1835,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@charcoal-ui/utils@^3.0.0-beta.3, @charcoal-ui/utils@workspace:packages/utils":
+"@charcoal-ui/utils@^3.0.0-beta.4, @charcoal-ui/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@charcoal-ui/utils@workspace:packages/utils"
   dependencies:
-    "@charcoal-ui/foundation": ^3.0.0-beta.3
+    "@charcoal-ui/foundation": ^3.0.0-beta.4
     npm-run-all: ^4.1.5
     polished: ^4.1.4
     rimraf: ^3.0.2


### PR DESCRIPTION
## やったこと
- TextAreaのフォーカスアニメーションを修正
  - focusアウト時のアニメーションが無くなっていた

before:
https://pixiv-charcoal-web--pr298-v3-0-0-ypwjowl4.web.app/@charcoal-ui/react/TextArea/

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
