### PR TITLE
fix: remove `<Modal>` vertical padding

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -241,7 +241,6 @@ const ModalDialog = animated(styled.div<{
 }>`
   position: relative;
   margin: auto;
-  padding: 24px 0;
 
   ${theme((o) => [o.bg.background1, o.borderRadius(24)])}
   @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {


### PR DESCRIPTION
## やったこと
https://github.com/pixiv/charcoal/commit/73b17f3fe3cc8f741825036a7ae2f475f18aabc7#r121234349 を直す

- `<Modal>`のルートについている上下の余白により、`<ModalHeader>`や`<ModalButtons>`と併用したときに壊れてしまう
  - 上下のpaddingをなくした

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
