### PR TITLE
fix: Modalの大きさによってスクロールバーが非表示になるように修正

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -188,7 +188,7 @@ const ModalContext = React.createContext<{
 
 const ModalBackground = animated(styled.div<{ zIndex: number }>`
   z-index: ${({ zIndex }) => zIndex};
-  overflow: scroll;
+  overflow: auto;
   display: flex;
   position: fixed;
   top: 0;


### PR DESCRIPTION
デスクトップの場合、Modalの大きさに関わらずXYのスクロールバーが表示されていたため

## やったこと

- ModalBackgroundのoverflowプロパティを`scroll`から`auto`へ変更

## 動作確認環境

## チェックリスト


