### PR TITLE
DropdownButtonに type=button をつける

### DIFF
--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -72,6 +72,28 @@ export const Basic: Story<DropdownSelectorProps> = (
 
 Basic.args = { ...baseProps }
 
+export const InFormTag: Story<DropdownSelectorProps> = (
+  props: DropdownSelectorProps
+) => {
+  const [selected, setSelected] = useState('')
+  return (
+    <form style={{ width: 288 }}>
+      <DropdownSelector
+        {...props}
+        onChange={(value) => {
+          setSelected(value)
+        }}
+        value={selected}
+        label="label"
+      >
+        <DropdownMenuItem value={'10'}>Apple</DropdownMenuItem>
+        <DropdownMenuItem value={'20'}>Banana</DropdownMenuItem>
+        <DropdownMenuItem value={'30'}>Orange</DropdownMenuItem>
+      </DropdownSelector>
+    </form>
+  )
+}
+
 export const CustomChildren: Story<DropdownSelectorProps> = (
   props: DropdownSelectorProps
 ) => {

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -48,6 +48,7 @@ export default function DropdownSelector(props: DropdownSelectorProps) {
           setIsOpen(true)
         }}
         ref={triggerRef}
+        type="button"
       >
         <DropdownButtonText>
           {props.placeholder !== undefined && preview === undefined


### PR DESCRIPTION
## やったこと

- DropdownButtonに `type=button` をつけた
    - 明示しないと `type=submit` となり、フォーム内でDropdownSelectorを使ったときに選択肢を選んだだけでSubmitされてしまうため
    - #355 対応

## 動作確認環境
Storybookで `localhost:6006/?path=/story/dropdownselector--in-form-tag` をチェック  
`type="button"` を指定することで `<form>` タグ内に配置されていてもページ遷移が起きなくなることを確認しました。

