### PR TITLE
fix: add git config user.name and git config user.email

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install node dependencies
         run: yarn install --immutable
 
+      - name: Set git username and email
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "actions-user"
+
       - name: Set package version
         run: yarn lerna version ${{ github.event.inputs.version }} --no-push --force-publish --yes
 


### PR DESCRIPTION
## やったこと


- リリースをActionsでするようにしてる
- git config user.name、git config user.emailが無くて止まったので追加

## 動作確認環境
https://github.com/pixiv/charcoal/actions/workflows/publish.yml

