### PR TITLE
fix: set YARN_ENABLE_IMMUTABLE_INSTALLS in yarn install after setting…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
         run: yarn install
 
       - name: git commit yarn.lock
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: |
           git add yarn.lock
           git commit -m "chore: yarn install [ci skip]"


### PR DESCRIPTION
… version

## やったこと

- リリースをActionsでするようにしてる
- package.jsonのバージョン更新後の `yarn install` が immutable になっていたので環境変数を指定して回避

## 動作確認環境
https://github.com/pixiv/charcoal/actions/workflows/publish.yml

