### PR TITLE
fix: set YARN_CHECKSUM_BEHAVIOR for yarn.lock update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: git commit yarn.lock
         env:
-          YARN_ENABLE_IMMUTABLE_INSTALLS: false
+          YARN_CHECKSUM_BEHAVIOR: update
         run: |
           git add yarn.lock
           git commit -m "chore: yarn install [ci skip]"


### PR DESCRIPTION
## やったこと
- リリースをActionsでするようにしてる
- YARN_CHECKSUM_BEHAVIOR="update" にすると yarn.lock を更新できるようになる

## 動作確認環境
https://github.com/pixiv/charcoal/actions/workflows/publish.yml