### PR TITLE
chore(react): fix wrong text color

### DIFF
--- a/packages/react/src/components/FieldLabel/index.tsx
+++ b/packages/react/src/components/FieldLabel/index.tsx
@@ -48,7 +48,7 @@ const Label = styled.label`
 `
 
 const RequiredText = styled.span`
-  ${theme((o) => [o.typography(14), o.font.text3])}
+  ${theme((o) => [o.typography(14), o.font.text2])}
 `
 
 const SubLabelClickable = styled.div`


### PR DESCRIPTION
## やったこと

- FieldLabel の RequiredLabel の色を figma と合わせた

## 動作確認環境
- storybook 
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
