### PR TITLE
chore(react): remove dropdown selector border

### DIFF
--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -108,6 +108,7 @@ const DropdownButton = styled.button<{ invalid?: boolean }>`
   height: 40px;
   width: 100%;
   box-sizing: border-box;
+  border: none;
   cursor: pointer;
 
   ${disabledSelector} {
@@ -116,7 +117,6 @@ const DropdownButton = styled.button<{ invalid?: boolean }>`
 
   ${({ invalid }) =>
     theme((o) => [
-      o.border.default,
       o.padding.horizontal(8),
       o.outline.default.focus,
       o.bg.surface3,


### PR DESCRIPTION
## やったこと

- dropdownselector から border を削除

## 動作確認環境
- storybook 

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
