### PR TITLE
fix(react-sandbox): 手動スクロールに関連する挙動修正

### DIFF
--- a/packages/react-sandbox/src/components/Carousel/index.story.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.story.tsx
@@ -1,6 +1,6 @@
-import { boolean, number, select, withKnobs } from '@storybook/addon-knobs'
+import { number } from '@storybook/addon-knobs'
 import styled, { css } from 'styled-components'
-import Carousel from '.'
+import Carousel, { CarouselProps } from '.'
 
 const dummyText = css`
   color: ${({ theme }) => theme.color.text4};
@@ -19,43 +19,20 @@ const Dummy = styled.div`
 `
 export default {
   title: 'Sandbox/Carousel',
-  decorators: [withKnobs],
+  component: Carousel,
 }
 
-export const _Carousel = () => {
-  const hasGradient = boolean('Gradient', false)
-  const fadeInGradient = boolean('FadeInGradient', false)
-  const buttonOffset = number('buttonOffset', 0)
-  const buttonPadding = number('buttonPadding', 16)
-  const defaultScrollAlign = select(
-    'scrollAlign',
-    {
-      Left: 'left',
-      Center: 'center',
-      Right: 'right',
-    },
-    'left'
-  )
-  const defaultScrollOffset = number('scrollOffset', 0)
+const DefaultStory = (args: CarouselProps) => {
   const itemCount = number('Item count', 20)
   const itemSize = number('Item size', 118)
 
   const items = Array.from({ length: itemCount })
   return (
     <Base>
-      <Carousel
-        buttonOffset={buttonOffset}
-        buttonPadding={buttonPadding}
-        defaultScroll={{
-          align: defaultScrollAlign,
-          offset: defaultScrollOffset,
-        }}
-        hasGradient={hasGradient}
-        fadeInGradient={fadeInGradient}
-      >
+      <Carousel {...args}>
         <Container>
           {items.map((_value, index) => (
-            <Box size={itemSize} key={index}>
+            <Box size={itemSize} key={index} tabIndex={0}>
               Dummy
             </Box>
           ))}
@@ -64,6 +41,9 @@ export const _Carousel = () => {
     </Base>
   )
 }
+
+export const Default = DefaultStory.bind({})
+
 const Base = styled.div`
   width: 100%;
   padding: 0 108px;

--- a/packages/react-sandbox/src/components/Carousel/index.tsx
+++ b/packages/react-sandbox/src/components/Carousel/index.tsx
@@ -38,7 +38,7 @@ export type CarouselGradientProps =
 type CarouselAppearanceProps = CarouselBaseAppearanceProps &
   CarouselGradientProps
 
-type Props = CarouselAppearanceProps & {
+export type CarouselProps = CarouselAppearanceProps & {
   onScroll?: (left: number) => void
   onResize?: (width: number) => void
   children: React.ReactNode
@@ -63,9 +63,8 @@ export default function Carousel({
   onScrollStateChange,
   scrollAmountCoef = SCROLL_AMOUNT_COEF,
   ...options
-}: Props) {
+}: CarouselProps) {
   // スクロール位置を保存する
-  // アニメーション中の場合は、アニメーション終了時のスクロール位置が保存される
   const [scrollLeft, setScrollLeft] = useDebounceAnimationState(0)
   // アニメーション中かどうか
   const animation = useRef(false)


### PR DESCRIPTION
issue: https://github.com/pixiv/charcoal/issues/375

## やったこと

- 手動スクロールによるスクロール位置の変更がscrollLeftに反映されていないことが原因なので、handleScrollMoveでscrollLeftを変更
  - 必要無くなったhandleScrollを削除
  - 変更前は自動スクロール終了時の位置をscrollLeftにおいていため分離
- タップした際に自動スクロールが停止するように
  - 本当はキー操作によるスクロール、フォーカス移動によるスクロール位置の変更でも自動スクロールを止めたい
  - しかし、手動/自動スクロールを区別できないこと、人による操作で起こりにくいことから放置した 

## 動作確認環境

![output (6)](https://github.com/pixiv/charcoal/assets/56821703/534e8e0f-0550-49d4-a394-690b1c46a3f7)

storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
