### PR TITLE
react-sandbox の Pager に要素の数を調節できるpropsの追加

### DIFF
--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -29,9 +29,9 @@ export default {
     pageRangeDisplayed: {
       control: {
         type: 'number',
-        min: 3
-      }
-    }
+        min: 3,
+      },
+    },
   },
 }
 
@@ -54,7 +54,11 @@ Default.args = {
 
 const makeUrl = (page: number) => `/${page}`
 
-const LinkStory: Story<Props> = ({ page: defaultPage, pageCount, pageRangeDisplayed }) => (
+const LinkStory: Story<Props> = ({
+  page: defaultPage,
+  pageCount,
+  pageRangeDisplayed,
+}) => (
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   <ComponentAbstraction components={{ Link: RouterLink }}>
@@ -67,18 +71,36 @@ const LinkStory: Story<Props> = ({ page: defaultPage, pageCount, pageRangeDispla
       <Routes>
         <Route
           path="/:page"
-          element={<CurrentPager pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed}></CurrentPager>}
+          element={
+            <CurrentPager
+              pageCount={pageCount}
+              pageRangeDisplayed={pageRangeDisplayed}
+            ></CurrentPager>
+          }
         />
       </Routes>
     </Router>
   </ComponentAbstraction>
 )
 
-function CurrentPager({ pageCount, pageRangeDisplayed }: { pageCount: number, pageRangeDisplayed?: number }) {
+function CurrentPager({
+  pageCount,
+  pageRangeDisplayed,
+}: {
+  pageCount: number
+  pageRangeDisplayed?: number
+}) {
   const params = useParams()
   const page = params.page !== undefined ? parseInt(params.page, 10) : 1
 
-  return <LinkPager makeUrl={makeUrl} page={page} pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed} />
+  return (
+    <LinkPager
+      makeUrl={makeUrl}
+      page={page}
+      pageCount={pageCount}
+      pageRangeDisplayed={pageRangeDisplayed}
+    />
+  )
 }
 
 export const Link = LinkStory.bind({})
@@ -115,5 +137,5 @@ export const LittlePageRangeDisplayed = LinkStory.bind({})
 LittlePageRangeDisplayed.args = {
   page: 1,
   pageCount: 10,
-  pageRangeDisplayed: 4
+  pageRangeDisplayed: 4,
 }

--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -41,15 +41,16 @@ interface Props {
   pageRangeDisplayed?: number
 }
 
-const DefaultStory: Story<Props> = ({ page: defaultPage, pageCount }) => {
+const DefaultStory: Story<Props> = ({ page: defaultPage, pageCount, pageRangeDisplayed }) => {
   const [page, setPage] = useState(defaultPage)
-  return <Pager page={page} onChange={setPage} pageCount={pageCount} />
+  return <Pager page={page} onChange={setPage} pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed} />
 }
 
 export const Default = DefaultStory.bind({})
 Default.args = {
   page: 1,
   pageCount: 10,
+  pageRangeDisplayed: undefined
 }
 
 const makeUrl = (page: number) => `/${page}`

--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -26,12 +26,19 @@ export default {
         min: 1,
       },
     },
+    pageRangeDisplayed: {
+      control: {
+        type: 'number',
+        min: 3
+      }
+    }
   },
 }
 
 interface Props {
   page: number
   pageCount: number
+  pageRangeDisplayed?: number
 }
 
 const DefaultStory: Story<Props> = ({ page: defaultPage, pageCount }) => {
@@ -47,7 +54,7 @@ Default.args = {
 
 const makeUrl = (page: number) => `/${page}`
 
-const LinkStory: Story<Props> = ({ page: defaultPage, pageCount }) => (
+const LinkStory: Story<Props> = ({ page: defaultPage, pageCount, pageRangeDisplayed }) => (
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   <ComponentAbstraction components={{ Link: RouterLink }}>
@@ -60,18 +67,18 @@ const LinkStory: Story<Props> = ({ page: defaultPage, pageCount }) => (
       <Routes>
         <Route
           path="/:page"
-          element={<CurrentPager pageCount={pageCount}></CurrentPager>}
+          element={<CurrentPager pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed}></CurrentPager>}
         />
       </Routes>
     </Router>
   </ComponentAbstraction>
 )
 
-function CurrentPager({ pageCount }: { pageCount: number }) {
+function CurrentPager({ pageCount, pageRangeDisplayed }: { pageCount: number, pageRangeDisplayed?: number }) {
   const params = useParams()
   const page = params.page !== undefined ? parseInt(params.page, 10) : 1
 
-  return <LinkPager makeUrl={makeUrl} page={page} pageCount={pageCount} />
+  return <LinkPager makeUrl={makeUrl} page={page} pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed} />
 }
 
 export const Link = LinkStory.bind({})
@@ -102,4 +109,11 @@ export const One = LinkStory.bind({})
 One.args = {
   page: 1,
   pageCount: 1,
+}
+
+export const LittlePageRangeDisplayed = LinkStory.bind({})
+LittlePageRangeDisplayed.args = {
+  page: 1,
+  pageCount: 10,
+  pageRangeDisplayed: 4
 }

--- a/packages/react-sandbox/src/components/Pager/index.story.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.story.tsx
@@ -41,16 +41,27 @@ interface Props {
   pageRangeDisplayed?: number
 }
 
-const DefaultStory: Story<Props> = ({ page: defaultPage, pageCount, pageRangeDisplayed }) => {
+const DefaultStory: Story<Props> = ({
+  page: defaultPage,
+  pageCount,
+  pageRangeDisplayed,
+}) => {
   const [page, setPage] = useState(defaultPage)
-  return <Pager page={page} onChange={setPage} pageCount={pageCount} pageRangeDisplayed={pageRangeDisplayed} />
+  return (
+    <Pager
+      page={page}
+      onChange={setPage}
+      pageCount={pageCount}
+      pageRangeDisplayed={pageRangeDisplayed}
+    />
+  )
 }
 
 export const Default = DefaultStory.bind({})
 Default.args = {
   page: 1,
   pageCount: 10,
-  pageRangeDisplayed: undefined
+  pageRangeDisplayed: undefined,
 }
 
 const makeUrl = (page: number) => `/${page}`

--- a/packages/react-sandbox/src/components/Pager/index.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.tsx
@@ -6,7 +6,7 @@ import DotsIcon from '../icons/DotsIcon'
 import WedgeIcon, { WedgeDirection } from '../icons/WedgeIcon'
 import { useComponentAbstraction } from '@charcoal-ui/react'
 
-function usePagerWindow(page: number, pageCount: number, windowSize = 7) {
+function usePagerWindow(page: number, pageCount: number, pageRangeDisplayed = 7) {
   // ページャーのリンク生成例:
   //
   //     < [ 1 ] [*2*] [ 3 ] [ 4 ] [ 5 ] [ 6 ] [ 7 ] >
@@ -29,23 +29,25 @@ function usePagerWindow(page: number, pageCount: number, windowSize = 7) {
       (pageCount | 0) === pageCount,
       `\`pageCount\` must be integer (${pageCount})`
     )
+    warning((pageRangeDisplayed | 0) === pageRangeDisplayed, `\`pageRangeDisplayed\` must be integer (${pageRangeDisplayed})`)
+    warning(pageRangeDisplayed > 2, `\`windowSize\` must be greater than 2`)
   }
 
   const window = useMemo(() => {
     const visibleFirstPage = 1
     const visibleLastPage = Math.min(
       pageCount,
-      Math.max(page + Math.floor(windowSize / 2), windowSize)
+      Math.max(page + Math.floor(pageRangeDisplayed / 2), pageRangeDisplayed)
     )
 
-    if (visibleLastPage <= windowSize) {
+    if (visibleLastPage <= pageRangeDisplayed) {
       // 表示範囲が1-7ページなら省略は無い。
       return Array.from(
         { length: 1 + visibleLastPage - visibleFirstPage },
         (_, i) => visibleFirstPage + i
       )
     } else {
-      const start = visibleLastPage - (windowSize - 1) + 2
+      const start = visibleLastPage - (pageRangeDisplayed - 1) + 2
       return [
         // 表示範囲が1-7ページを超えるなら、
         // - 1ページ目は固定で表示する
@@ -58,7 +60,7 @@ function usePagerWindow(page: number, pageCount: number, windowSize = 7) {
         ),
       ]
     }
-  }, [page, pageCount, windowSize])
+  }, [page, pageCount, pageRangeDisplayed])
 
   useDebugValue(window)
 
@@ -68,6 +70,7 @@ function usePagerWindow(page: number, pageCount: number, windowSize = 7) {
 interface CommonProps {
   page: number
   pageCount: number
+  pageRangeDisplayed?: number
 }
 
 export interface PagerProps extends CommonProps {
@@ -75,9 +78,9 @@ export interface PagerProps extends CommonProps {
 }
 
 // this pager is just regular buttons; for links use LinkPager
-export default memo(function Pager({ page, pageCount, onChange }: PagerProps) {
+export default memo(function Pager({ page, pageCount, pageRangeDisplayed, onChange }: PagerProps) {
   // TODO: refactor Pager and LinkPager to use a common parent component
-  const window = usePagerWindow(page, pageCount)
+  const window = usePagerWindow(page, pageCount, pageRangeDisplayed)
   const makeClickHandler = useCallback(
     (value: number) => () => {
       onChange(value)
@@ -132,9 +135,9 @@ export interface LinkPagerProps extends CommonProps {
   makeUrl(page: number): string
 }
 
-export function LinkPager({ page, pageCount, makeUrl }: LinkPagerProps) {
+export function LinkPager({ page, pageCount, pageRangeDisplayed, makeUrl }: LinkPagerProps) {
   const { Link } = useComponentAbstraction()
-  const window = usePagerWindow(page, pageCount)
+  const window = usePagerWindow(page, pageCount, pageRangeDisplayed)
 
   const hasNext = page < pageCount
   const hasPrev = page > 1

--- a/packages/react-sandbox/src/components/Pager/index.tsx
+++ b/packages/react-sandbox/src/components/Pager/index.tsx
@@ -6,7 +6,11 @@ import DotsIcon from '../icons/DotsIcon'
 import WedgeIcon, { WedgeDirection } from '../icons/WedgeIcon'
 import { useComponentAbstraction } from '@charcoal-ui/react'
 
-function usePagerWindow(page: number, pageCount: number, pageRangeDisplayed = 7) {
+function usePagerWindow(
+  page: number,
+  pageCount: number,
+  pageRangeDisplayed = 7
+) {
   // ページャーのリンク生成例:
   //
   //     < [ 1 ] [*2*] [ 3 ] [ 4 ] [ 5 ] [ 6 ] [ 7 ] >
@@ -29,7 +33,10 @@ function usePagerWindow(page: number, pageCount: number, pageRangeDisplayed = 7)
       (pageCount | 0) === pageCount,
       `\`pageCount\` must be integer (${pageCount})`
     )
-    warning((pageRangeDisplayed | 0) === pageRangeDisplayed, `\`pageRangeDisplayed\` must be integer (${pageRangeDisplayed})`)
+    warning(
+      (pageRangeDisplayed | 0) === pageRangeDisplayed,
+      `\`pageRangeDisplayed\` must be integer (${pageRangeDisplayed})`
+    )
     warning(pageRangeDisplayed > 2, `\`windowSize\` must be greater than 2`)
   }
 
@@ -78,7 +85,12 @@ export interface PagerProps extends CommonProps {
 }
 
 // this pager is just regular buttons; for links use LinkPager
-export default memo(function Pager({ page, pageCount, pageRangeDisplayed, onChange }: PagerProps) {
+export default memo(function Pager({
+  page,
+  pageCount,
+  pageRangeDisplayed,
+  onChange,
+}: PagerProps) {
   // TODO: refactor Pager and LinkPager to use a common parent component
   const window = usePagerWindow(page, pageCount, pageRangeDisplayed)
   const makeClickHandler = useCallback(
@@ -135,7 +147,12 @@ export interface LinkPagerProps extends CommonProps {
   makeUrl(page: number): string
 }
 
-export function LinkPager({ page, pageCount, pageRangeDisplayed, makeUrl }: LinkPagerProps) {
+export function LinkPager({
+  page,
+  pageCount,
+  pageRangeDisplayed,
+  makeUrl,
+}: LinkPagerProps) {
   const { Link } = useComponentAbstraction()
   const window = usePagerWindow(page, pageCount, pageRangeDisplayed)
 


### PR DESCRIPTION
## やったこと

- react-sandboxのpagerに `pageRangeDisplayed` という props を追加しました
    - Pager の中に一度に表示される要素の数を調整することができます

## 動作確認環境
Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
