### PR TITLE
chore: comment out build-storybook-vite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,23 +35,6 @@ jobs:
       - run: yarn build
       - run: yarn storybook:build
 
-  build-storybook-vite:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.node-version'
-          cache: yarn
-
-      - run: yarn install --immutable --inline-builds
-      - run: yarn build
-      - run: yarn storybook:build-vite
-        env:
-          NODE_OPTIONS: --max_old_space_size=6144
-          USE_VITE: '1'
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## やったこと

- storybook 7.4アプデで不調になったstorybookのviteビルドを `test.yml` から削除しました。
- 直し方がわかったら直します

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
