### PR TITLE
fix: Modalの挙動と外観を修正

### DIFF
--- a/packages/react/src/components/Modal/ModalPlumbing.tsx
+++ b/packages/react/src/components/Modal/ModalPlumbing.tsx
@@ -1,20 +1,32 @@
-import { ModalTitle } from '.'
-import styled from 'styled-components'
+import { BottomSheet, ModalContext, ModalTitle } from '.'
+import styled, { css } from 'styled-components'
 import { theme } from '../../styled'
+import { useContext } from 'react'
+import { maxWidth } from '@charcoal-ui/utils'
 
 export function ModalHeader() {
+  const modalCtx = useContext(ModalContext)
   return (
-    <ModalHeaderRoot>
+    <ModalHeaderRoot $bottomSheet={modalCtx.bottomSheet}>
       <StyledModalTitle />
     </ModalHeaderRoot>
   )
 }
 
-const ModalHeaderRoot = styled.div`
+const ModalHeaderRoot = styled.div<{
+  $bottomSheet: BottomSheet
+}>`
   height: 64px;
   display: grid;
   align-content: center;
   justify-content: center;
+  @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+    ${(p) =>
+      p.$bottomSheet !== false &&
+      css`
+        height: 48px;
+      `}
+  }
 `
 
 const StyledModalTitle = styled(ModalTitle)`

--- a/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
+++ b/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
@@ -26,33 +26,51 @@ export const BottomSheetOverflowStory: Story<ModalProps> = (
               }}
             ></div>
           </ModalBodyOverflowDiv>
-          <ModalButtons>
+          <TopBorderButtons>
             <Button fullWidth onClick={() => state.close()}>
               Close
             </Button>
-          </ModalButtons>
+          </TopBorderButtons>
         </ModalBody>
       </Modal>
     </OverlayProvider>
   )
 }
 
-// underlay padding-top: 24px (desktop)
-// underlay padding-bottom: 24px (desktop)
+// underlay padding-top: 40px (desktop)
+// underlay padding-bottom: 40px (desktop)
 // modal header: 64px
 // modal padding-bottom: 40px
 // button and space: 56px
+const MAX_HEIGHT_OFFSET = 64 + 40 + 40 + 40
+const MAX_HEIGHT_OFFSET_MOBILE = MAX_HEIGHT_OFFSET - 40 * 2
 const ModalBodyOverflowDiv = styled.div<{
   $offset: number
   $bottomSheet?: BottomSheet
 }>`
   overflow: auto;
-  max-height: calc(100vh - 152px - ${({ $offset }) => $offset}px);
+  max-height: calc(
+    100vh - ${MAX_HEIGHT_OFFSET}px - ${({ $offset }) => $offset}px
+  );
   ${({ $bottomSheet, $offset }) =>
     ($bottomSheet === true || $bottomSheet === 'full') &&
     css`
       @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
-        max-height: calc(100vh - 104px - ${$offset}px);
+        max-height: calc(100vh - ${MAX_HEIGHT_OFFSET_MOBILE}px - ${$offset}px);
       }
     `}
+`
+
+const TopBorderButtons = styled(ModalButtons)`
+  position: relative;
+  &::before {
+    content: '';
+    pointer-events: none;
+    border-top: 1px solid ${({ theme }) => theme.border.default.color};
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
 `

--- a/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
+++ b/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
@@ -39,11 +39,12 @@ export const BottomSheetOverflowStory: Story<ModalProps> = (
 
 // underlay padding-top: 40px (desktop)
 // underlay padding-bottom: 40px (desktop)
-// modal header: 64px
+// modal header: 64px (desktop)
+// modal header: 48px (mobile-bottom-sheet)
 // modal padding-bottom: 40px
 // button and space: 56px
 const MAX_HEIGHT_OFFSET = 64 + 40 + 40 + 40
-const MAX_HEIGHT_OFFSET_MOBILE = MAX_HEIGHT_OFFSET - 40 * 2
+const MAX_HEIGHT_OFFSET_MOBILE = MAX_HEIGHT_OFFSET - 40 * 2 - 16
 const ModalBodyOverflowDiv = styled.div<{
   $offset: number
   $bottomSheet?: BottomSheet

--- a/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
+++ b/packages/react/src/components/Modal/__stories__/BottomSheetOverflowStory.tsx
@@ -1,0 +1,58 @@
+import { Story } from '../../../_lib/compat'
+import Modal, { BottomSheet, ModalProps } from '..'
+import { OverlayProvider } from '@react-aria/overlays'
+import { useOverlayTriggerState } from 'react-stately'
+import Button from '../../Button'
+import { ModalBody, ModalButtons, ModalHeader } from '../ModalPlumbing'
+import styled, { css } from 'styled-components'
+import { maxWidth } from '@charcoal-ui/utils'
+
+export const BottomSheetOverflowStory: Story<ModalProps> = (
+  args: ModalProps
+) => {
+  const state = useOverlayTriggerState({})
+  return (
+    <OverlayProvider>
+      <Button onClick={() => state.open()}>Open Modal</Button>
+
+      <Modal {...args} isOpen={state.isOpen} onClose={() => state.close()}>
+        <ModalHeader />
+        <ModalBody>
+          <ModalBodyOverflowDiv $offset={56} $bottomSheet={args.bottomSheet}>
+            <div
+              style={{
+                height: 1000,
+                background: `linear-gradient(#e66465, #9198e5)`,
+              }}
+            ></div>
+          </ModalBodyOverflowDiv>
+          <ModalButtons>
+            <Button fullWidth onClick={() => state.close()}>
+              Close
+            </Button>
+          </ModalButtons>
+        </ModalBody>
+      </Modal>
+    </OverlayProvider>
+  )
+}
+
+// underlay padding-top: 24px (desktop)
+// underlay padding-bottom: 24px (desktop)
+// modal header: 64px
+// modal padding-bottom: 40px
+// button and space: 56px
+const ModalBodyOverflowDiv = styled.div<{
+  $offset: number
+  $bottomSheet?: BottomSheet
+}>`
+  overflow: auto;
+  max-height: calc(100vh - 152px - ${({ $offset }) => $offset}px);
+  ${({ $bottomSheet, $offset }) =>
+    ($bottomSheet === true || $bottomSheet === 'full') &&
+    css`
+      @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+        max-height: calc(100vh - 104px - ${$offset}px);
+      }
+    `}
+`

--- a/packages/react/src/components/Modal/__stories__/InternalScrollStory.tsx
+++ b/packages/react/src/components/Modal/__stories__/InternalScrollStory.tsx
@@ -7,9 +7,7 @@ import { ModalBody, ModalButtons, ModalHeader } from '../ModalPlumbing'
 import styled, { css } from 'styled-components'
 import { maxWidth } from '@charcoal-ui/utils'
 
-export const InternalScrollStory: Story<ModalProps> = (
-  args: ModalProps
-) => {
+export const InternalScrollStory: Story<ModalProps> = (args: ModalProps) => {
   const state = useOverlayTriggerState({})
   return (
     <OverlayProvider>

--- a/packages/react/src/components/Modal/__stories__/InternalScrollStory.tsx
+++ b/packages/react/src/components/Modal/__stories__/InternalScrollStory.tsx
@@ -7,7 +7,7 @@ import { ModalBody, ModalButtons, ModalHeader } from '../ModalPlumbing'
 import styled, { css } from 'styled-components'
 import { maxWidth } from '@charcoal-ui/utils'
 
-export const BottomSheetOverflowStory: Story<ModalProps> = (
+export const InternalScrollStory: Story<ModalProps> = (
   args: ModalProps
 ) => {
   const state = useOverlayTriggerState({})

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -192,3 +192,5 @@ const BottomSheetStory = (args: ModalProps) => {
 }
 
 export const BottomSheet: Story<ModalProps> = BottomSheetStory.bind({})
+
+export { BottomSheetOverflowStory } from './__stories__/BottomSheetOverflowStory'

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -194,4 +194,4 @@ const BottomSheetStory = (args: ModalProps) => {
 
 export const BottomSheet: Story<ModalProps> = BottomSheetStory.bind({})
 
-export { BottomSheetOverflowStory } from './__stories__/BottomSheetOverflowStory'
+export { InternalScrollStory as InternalScroll } from './__stories__/InternalScrollStory'

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -43,48 +43,49 @@ const DefaultStory = (args: ModalProps) => {
     // hidden from screen readers when a modal opens.
     <OverlayProvider>
       <Button onClick={() => state.open()}>Open Modal</Button>
-
-      <Modal
+      <M
         {...args}
+        isDismissable
         isOpen={state.isOpen}
         onClose={() => state.close()}
-        isDismissable
-      >
-        <ModalHeader />
-        <ModalBody>
-          <ModalVStack>
-            <StyledModalText>
-              Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
-              placeat tenetur, necessitatibus laudantium cumque exercitationem
-              provident. Quaerat iure enim, eveniet dolores earum odio quo
-              possimus fugiat aspernatur, numquam, commodi repellat.
-            </StyledModalText>
-            <ModalAlign>
-              <TextField
-                showLabel
-                label="Name"
-                placeholder="Nagisa"
-              ></TextField>
-            </ModalAlign>
-            <ModalAlign>
-              <TextField
-                showLabel
-                label="Country"
-                placeholder="Tokyo"
-              ></TextField>
-            </ModalAlign>
-          </ModalVStack>
-          <ModalButtons>
-            <Button variant="Primary" onClick={() => state.close()} fullWidth>
-              Apply
-            </Button>
-            <Button onClick={() => state.close()} fullWidth>
-              Cancel
-            </Button>
-          </ModalButtons>
-        </ModalBody>
-      </Modal>
+      />
     </OverlayProvider>
+  )
+}
+
+const M = (props: ModalProps) => {
+  return (
+    <Modal {...props}>
+      <ModalHeader />
+      <ModalBody>
+        <ModalVStack>
+          <StyledModalText>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Quod
+            placeat tenetur, necessitatibus laudantium cumque exercitationem
+            provident. Quaerat iure enim, eveniet dolores earum odio quo
+            possimus fugiat aspernatur, numquam, commodi repellat.
+          </StyledModalText>
+          <ModalAlign>
+            <TextField showLabel label="Name" placeholder="Nagisa"></TextField>
+          </ModalAlign>
+          <ModalAlign>
+            <TextField
+              showLabel
+              label="Country"
+              placeholder="Tokyo"
+            ></TextField>
+          </ModalAlign>
+        </ModalVStack>
+        <ModalButtons>
+          <Button variant="Primary" onClick={() => props.onClose()} fullWidth>
+            Apply
+          </Button>
+          <Button onClick={() => props.onClose()} fullWidth>
+            Cancel
+          </Button>
+        </ModalButtons>
+      </ModalBody>
+    </Modal>
   )
 }
 

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -20,7 +20,7 @@ import Button, { ButtonProps } from '../Button'
 import IconButton from '../IconButton'
 import { useObjectRef } from '@react-aria/utils'
 
-type BottomSheet = boolean | 'full'
+export type BottomSheet = boolean | 'full'
 type Size = 'S' | 'M' | 'L'
 
 export type ModalProps = AriaModalOverlayProps &
@@ -138,6 +138,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
             zIndex={zIndex}
             {...underlayProps}
             style={transitionEnabled ? { backgroundColor } : {}}
+            $bottomSheet={bottomSheet}
           >
             <FocusScope contain restoreFocus autoFocus>
               <DialogContainer bottomSheet={bottomSheet} size={size}>
@@ -186,7 +187,10 @@ const ModalContext = React.createContext<{
   showDismiss: true,
 })
 
-const ModalBackground = animated(styled.div<{ zIndex: number }>`
+const ModalBackground = animated(styled.div<{
+  zIndex: number
+  $bottomSheet: BottomSheet
+}>`
   z-index: ${({ zIndex }) => zIndex};
   overflow: auto;
   display: flex;
@@ -197,6 +201,14 @@ const ModalBackground = animated(styled.div<{ zIndex: number }>`
   height: 100%;
 
   ${theme((o) => [o.bg.surface4])}
+
+  ${({ $bottomSheet }) =>
+    ($bottomSheet === true || $bottomSheet === 'full') &&
+    css`
+      @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+        overflow: hidden;
+      }
+    `}
 `)
 
 const DialogContainer = styled.div<{ bottomSheet: BottomSheet; size: Size }>`
@@ -248,6 +260,7 @@ const ModalDialog = animated(styled.div<{
       p.bottomSheet !== false &&
       css`
         border-radius: 0;
+        overflow: hidden;
         ${p.bottomSheet === 'full' &&
         css`
           height: 100%;

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -220,6 +220,8 @@ const ModalBackground = animated(styled.div<{
   width: 100%;
   height: 100%;
   justify-content: center;
+  padding: 40px 0;
+  box-sizing: border-box;
 
   ${theme((o) => [o.bg.surface4])}
 `)
@@ -228,7 +230,7 @@ const ModalDialog = animated(styled.div<{
   size: Size
   bottomSheet: BottomSheet
 }>`
-  margin: 40px 0;
+  margin: auto;
   position: relative;
   height: fit-content;
   width: ${(p) => {

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -262,6 +262,7 @@ const ModalDialog = animated(styled.div<{
   border-radius: 24px;
 
   @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+    max-width: 440px;
     width: calc(100% - 48px);
     ${(p) =>
       p.bottomSheet !== false &&

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -223,7 +223,15 @@ const ModalBackground = animated(styled.div<{
   padding: 40px 0;
   box-sizing: border-box;
 
-  ${theme((o) => [o.bg.surface4])}
+  background-color: ${({ theme }) => theme.color.surface4};
+
+  @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+    ${(p) =>
+      p.$bottomSheet !== false &&
+      css`
+        padding: 0;
+      `}
+  }
 `)
 
 const ModalDialog = animated(styled.div<{
@@ -250,8 +258,11 @@ const ModalDialog = animated(styled.div<{
     }
   }}px;
 
-  ${theme((o) => [o.bg.background1, o.borderRadius(24)])}
+  background-color: ${({ theme }) => theme.color.background1};
+  border-radius: 24px;
+
   @media ${({ theme }) => maxWidth(theme.breakpoint.screen1)} {
+    width: calc(100% - 48px);
     ${(p) =>
       p.bottomSheet !== false &&
       css`


### PR DESCRIPTION
## やったこと
### 機能の修正
- bottomSheetのコンテンツがオーバーフローした際に適切にスクロール可能になるように修正
- Focusがモーダル内の最後で止まるのを修正
  - useDialogのコンポーネントを分離
 
### 外観の修正
- モーダル上下の余白を24pxから40pxに修正
- bottomSheetの時のタイトルの高さを64pxから48pxに修正

### Storybook
- 内部スクロールの例を追加