### PR TITLE
wip: build-storybookが壊れているのを直す

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Output files
         run: |
-          yarn build-storybook -o public-pages --quiet
+          yarn storybook:build -o public-pages --quiet
           cp .storybook/badge.svg public-pages/storybook-badge.svg
           mv pages public-pages/docs
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
 
   build-storybook:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
## やったこと

- mainでのみ走るworkflowの gh-pages.yml のstorybookコマンドを置き換えた

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
