### PR TITLE
feat: Checkboxコンポーネントのinvalid状態を実装

### DIFF
--- a/packages/react/src/components/Checkbox/index.story.tsx
+++ b/packages/react/src/components/Checkbox/index.story.tsx
@@ -13,6 +13,7 @@ type Props = {
   disabled: boolean
   readonly: boolean
   className?: string
+  invalid: boolean
 }
 
 export const Labelled: Story<Props> = (props) => {
@@ -56,6 +57,7 @@ Labelled.args = {
   defaultChecked: false,
   disabled: false,
   readonly: false,
+  invalid: false,
 }
 
 export const Unlabelled: Story<Props> = (props) => {
@@ -79,4 +81,5 @@ Unlabelled.args = {
   defaultChecked: false,
   disabled: false,
   readonly: false,
+  invalid: false,
 }

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -27,6 +27,7 @@ export type CheckboxProps = CheckboxLabelProps & {
   readonly defaultChecked?: boolean
   readonly disabled?: boolean
   readonly readonly?: boolean
+  readonly invalid?: boolean
 
   readonly onClick?: () => void
   readonly onChange?: (isSelected: boolean) => void
@@ -35,17 +36,18 @@ export type CheckboxProps = CheckboxLabelProps & {
 }
 
 const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  function CheckboxInner(props, ref) {
+  function CheckboxInner({ invalid = false, ...props }, ref) {
     const ariaCheckboxProps = useMemo<AriaCheckboxProps>(
       () => ({
         ...props,
         isSelected: props.checked,
         defaultSelected: props.defaultChecked,
+        validationState: invalid ? 'invalid' : 'valid',
         // children がいない場合は aria-label をつけないといけない
         'aria-label': 'children' in props ? undefined : props.label,
         isDisabled: props.disabled,
       }),
-      [props]
+      [invalid, props]
     )
     const state = useToggleState(ariaCheckboxProps)
     const objectRef = useObjectRef(ref)
@@ -56,7 +58,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     return (
       <InputRoot aria-disabled={isDisabled} className={props.className}>
         <CheckboxRoot>
-          <CheckboxInput type="checkbox" {...inputProps} />
+          <CheckboxInput type="checkbox" {...inputProps} invalid={invalid} />
           <CheckboxInputOverlay aria-hidden={true} checked={inputProps.checked}>
             <Icon name="24/Check" unsafeNonGuidelineScale={2 / 3} />
           </CheckboxInputOverlay>
@@ -91,7 +93,7 @@ const CheckboxRoot = styled.div`
   position: relative;
 `
 
-const CheckboxInput = styled.input`
+const CheckboxInput = styled.input<{ invalid: boolean }>`
   &[type='checkbox'] {
     appearance: none;
     display: block;
@@ -109,6 +111,7 @@ const CheckboxInput = styled.input`
       border-color: ${({ theme }) => theme.color.text4};
     }
     ${theme((o) => [o.outline.default.focus, o.borderRadius(4)])}
+    ${(p) => p.invalid && theme((o) => [o.outline.assertive])}
 
     /* FIXME: o.outline.default.focus の transition に o.bg.brand の transition が打ち消されてしまう */
     transition: all 0.2s !important;


### PR DESCRIPTION
## やったこと

- Checkboxにinvalid属性を追加（[Figma](https://www.figma.com/file/ZfumEAYeBUubytKhRAfHg8/Charcoal---Web-Components-(Community)?node-id=32%3A28&mode=dev)）
- Storybookを更新

## 動作確認環境

Storybookで確認できます。
<img width="295" alt="Screenshot 2023-09-22 at 18 13 05" src="https://github.com/pixiv/charcoal/assets/38908416/3ced0047-eecf-4150-81ce-6991d329a1a1">
