### PR TITLE
Feat: skip dom purify for trusted content

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -181,7 +181,7 @@ export class PixivIcon extends HTMLElement {
     if (typeof size !== 'number') {
       throw new TypeError(`icon size must be number but found ${typeof size}`)
     }
-    if (Number.isNaN(size)) {
+    if (!Number.isFinite(size)) {
       throw new TypeError(`icon size must not be NaN`)
     }
 

--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -3,7 +3,6 @@ import warning from 'warning'
 import { KnownIconFile } from './charcoalIconFiles'
 import { getIcon, addCustomIcon } from './loaders'
 import { __SERVER__ } from './ssr'
-import DOMPurify from 'dompurify'
 
 const attributes = ['name', 'scale', 'unsafe-non-guideline-scale'] as const
 
@@ -179,8 +178,14 @@ export class PixivIcon extends HTMLElement {
   render() {
     const size = this.forceResizedSize ?? this.scaledSize
 
-    const style = DOMPurify.sanitize(
-      `<style>
+    if (typeof size !== 'number') {
+      throw new TypeError(`icon size must be number but found ${typeof size}`)
+    }
+    if (Number.isNaN(size)) {
+      throw new TypeError(`icon size must not be NaN`)
+    }
+
+    const style = `<style>
   :host {
     display: inline-flex;
     --size: ${size}px;
@@ -190,23 +195,28 @@ export class PixivIcon extends HTMLElement {
     width: var(--size);
     height: var(--size);
   }
-</style>`,
-      { ALLOWED_TAGS: ['style'], FORCE_BODY: true }
-    )
+</style>`
 
-    const svg = DOMPurify.sanitize(
+    const svg =
       this.svgContent !== undefined
         ? this.svgContent
-        : `<svg viewBox="0 0 ${size} ${size}"></svg>`,
-      { USE_PROFILES: { svg: true, svgFilters: true } }
-    )
+        : `<svg viewBox="0 0 ${size} ${size}"></svg>`
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.shadowRoot!.innerHTML = style + svg
   }
 
   private async loadSvg(name: string) {
-    this.svgContent = await getIcon(name)
+    const iconResult = await getIcon(name)
+
+    if (iconResult.trusted) {
+      this.svgContent = iconResult.svgContent
+    } else {
+      const { default: DOMPurify } = await import('dompurify')
+      this.svgContent = DOMPurify.sanitize(iconResult.svgContent, {
+        USE_PROFILES: { svg: true, svgFilters: true },
+      })
+    }
     this.render()
   }
 

--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -178,9 +178,6 @@ export class PixivIcon extends HTMLElement {
   render() {
     const size = this.forceResizedSize ?? this.scaledSize
 
-    if (typeof size !== 'number') {
-      throw new TypeError(`icon size must be number but found ${typeof size}`)
-    }
     if (!Number.isFinite(size)) {
       throw new TypeError(`icon size must not be NaN`)
     }

--- a/packages/icons/src/loaders/CharcoalIconFilesLoader.ts
+++ b/packages/icons/src/loaders/CharcoalIconFilesLoader.ts
@@ -14,6 +14,10 @@ export class CharcoalIconFilesLoader implements Loadable {
     this._name = name
   }
 
+  get trusted() {
+    return true
+  }
+
   get importIconFile() {
     return charcoalIconFiles[this._name]
   }

--- a/packages/icons/src/loaders/CustomIconLoader.ts
+++ b/packages/icons/src/loaders/CustomIconLoader.ts
@@ -15,6 +15,10 @@ export class CustomIconLoader implements Loadable {
     this._filePathOrUrl = filePathOrUrl
   }
 
+  get trusted() {
+    return false
+  }
+
   async fetch(): Promise<string> {
     if (this._resultSvg !== undefined) {
       return this._resultSvg

--- a/packages/icons/src/loaders/Loadable.ts
+++ b/packages/icons/src/loaders/Loadable.ts
@@ -1,3 +1,4 @@
 export interface Loadable {
+  readonly trusted: boolean
   fetch(): Promise<string>
 }

--- a/packages/icons/src/loaders/index.ts
+++ b/packages/icons/src/loaders/index.ts
@@ -21,13 +21,16 @@ export async function getIcon(name: string) {
     throw new PixivIconLoadError(name, 'Loader was not found')
   }
 
-  return loader.fetch().catch((e) => {
-    if (e instanceof PixivIconLoadError) {
-      throw e
-    }
+  return loader
+    .fetch()
+    .then((svgContent) => ({ trusted: loader.trusted, svgContent }))
+    .catch((e) => {
+      if (e instanceof PixivIconLoadError) {
+        throw e
+      }
 
-    throw new PixivIconLoadError(name, e)
-  })
+      throw new PixivIconLoadError(name, e)
+    })
 }
 
 function resolveIconLoader(name: string) {


### PR DESCRIPTION
## やったこと

- Since style and known icons are fully controlled by us, it should be safe to skip dom purify in these cases.
- Lazy import and keep sanitizing custom icons so this should not be a breaking change. 

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] README やドキュメントに影響があることを確認した
