### PR TITLE
fix: textarea focus with proper padding

### DIFF
--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -132,7 +132,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <StyledTextarea
             ref={mergeRefs(textareaRef, forwardRef, ariaRef)}
             rows={rows}
-            noBottomPadding={showCount}
+            withCountPadding={showCount}
             {...inputProps}
           />
           {showCount && (
@@ -170,7 +170,6 @@ const TextFieldLabel = styled(FieldLabel)`
 const StyledTextareaContainer = styled.div<{ rows: number; invalid: boolean }>`
   position: relative;
   overflow: hidden;
-  padding: 0 8px;
 
   ${(p) =>
     theme((o) => [
@@ -191,7 +190,7 @@ const StyledTextareaContainer = styled.div<{ rows: number; invalid: boolean }>`
   `};
 `
 
-const StyledTextarea = styled.textarea<{ noBottomPadding: boolean }>`
+const StyledTextarea = styled.textarea<{ withCountPadding: boolean }>`
   border: none;
   outline: none;
   resize: none;
@@ -201,10 +200,15 @@ const StyledTextarea = styled.textarea<{ noBottomPadding: boolean }>`
   /* Prevent zooming for iOS Safari */
   transform-origin: top left;
   transform: scale(0.875);
-  width: calc(100% / 0.875);
+  width: calc((100% - 16px) / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding: calc(9px / 0.875) 0 ${(p) => (p.noBottomPadding ? 0 : '')};
+  padding: calc(9px / 0.875) calc(8px / 0.875)
+    ${(p) => (p.withCountPadding ? 0 : '')};
+  /* Using padding on textarea will cause text overflow */
+  /*                                             v_________________ (one row (22px) + padding (9px)) / scale (0.875) */
+  border-bottom: ${(p) => (p.withCountPadding ? 'calc(31px / 0.875)' : '0')}
+    transparent solid;
 
   ${({ rows = 1 }) => css`
     height: calc(22px / 0.875 * ${rows});


### PR DESCRIPTION
## やったこと

fix textarea focus issue especially when count is shown.

### before

![image](https://github.com/pixiv/charcoal/assets/26110087/886cee89-7274-4208-b025-6f98119a07d2)

https://github.com/pixiv/charcoal/assets/26110087/2bf6b97a-8996-498e-a416-82c1af2d1d06


### after

![image](https://github.com/pixiv/charcoal/assets/26110087/05bf9afe-7f72-46a2-bb49-f3038206cee7)

https://github.com/pixiv/charcoal/assets/26110087/7ddcfcd3-769f-4343-a090-7d6c8c64a278


## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
