### PR TITLE
fix: assistiveTextの色をtext1からtext2に変更

### DIFF
--- a/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
+++ b/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
@@ -1183,7 +1183,7 @@ exports[`Storyshots TextArea Has Label 1`] = `
   display: flow-root;
   margin-top: 8px;
   margin-bottom: 0px;
-  color: var(--charcoal-text1);
+  color: var(--charcoal-text2);
 }
 
 .c13::before {

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -242,6 +242,6 @@ const AssistiveText = styled.p<{ invalid: boolean }>`
       o.typography(14),
       o.margin.top(8),
       o.margin.bottom(0),
-      o.font[p.invalid ? 'assertive' : 'text1'],
+      o.font[p.invalid ? 'assertive' : 'text2'],
     ])}
 `

--- a/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
@@ -1287,7 +1287,7 @@ exports[`Storyshots TextField Has Label 1`] = `
   display: flow-root;
   margin-top: 8px;
   margin-bottom: 0px;
-  color: var(--charcoal-text1);
+  color: var(--charcoal-text2);
 }
 
 .c15::before {

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -260,6 +260,6 @@ const AssistiveText = styled.p<{ invalid: boolean }>`
       o.typography(14),
       o.margin.top(8),
       o.margin.bottom(0),
-      o.font[p.invalid ? 'assertive' : 'text1'],
+      o.font[p.invalid ? 'assertive' : 'text2'],
     ])}
 `


### PR DESCRIPTION
## やったこと

- 仕様に合わせてTextFieldおよびTextAreaのassistiveTextの色をtext1からtext2に変更
