### PR TITLE
fix!: adjust-icons-import-export

### DIFF
--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -5,10 +5,6 @@
   "type": "module",
   "main": "./src/index.cjs",
   "module": " ./src/index.js",
-  "exports": {
-    "require": "./src/index.cjs",
-    "default": "./src/index.js"
-  },
   "types": "./src/index.d.ts",
   "files": [
     "src",

--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import '@charcoal-ui/icons'
 import type { PixivIcon, Props } from '@charcoal-ui/icons'
 
 export interface OwnProps {


### PR DESCRIPTION
## やったこと

NOTE: this contains breaking change

- remove extra import from charcoal-ui/react
- remove exports field to enable import/export individual icon file 

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
