### PR TITLE
feat: textFieldの構造を更新

### DIFF
--- a/packages/react/src/components/TextField/TextField.story.tsx
+++ b/packages/react/src/components/TextField/TextField.story.tsx
@@ -67,7 +67,7 @@ HasAffix.args = {
 export const PrefixIcon: Story<Partial<TextFieldProps>> = (args) => (
   <TextField
     label="Label"
-    placeholder="Icon prefix"
+    placeholder="作品を検索"
     prefix={
       <PrefixIconWrap>
         <pixiv-icon name="16/Search" />
@@ -79,7 +79,6 @@ export const PrefixIcon: Story<Partial<TextFieldProps>> = (args) => (
 )
 
 const PrefixIconWrap = styled.div`
+  height: 16px;
   color: ${({ theme }) => theme.color.text3};
-  margin-top: 2px;
-  margin-right: 4px;
 `

--- a/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
@@ -147,46 +147,39 @@ exports[`Storyshots TextField Default 1`] = `
 }
 
 .c8 {
-  height: 40px;
-  display: grid;
-  position: relative;
-}
-
-.c9 {
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.c12 {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-}
-
-.c10 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-size: 14px;
-  line-height: 22px;
+  height: 40px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
   color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
 }
 
-.c11 {
+.c8:not(:disabled):not([aria-disabled]):hover,
+.c8 [aria-disabled='false']:hover {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c8:not(:disabled):not([aria-disabled]):active,
+.c8 [aria-disabled='false']:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c8:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c9 {
   border: none;
   box-sizing: border-box;
   outline: none;
@@ -201,57 +194,28 @@ exports[`Storyshots TextField Default 1`] = `
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + 0px) / 0.875);
-  padding-right: calc((8px + 0px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: var(--charcoal-surface3);
-  color: var(--charcoal-text2);
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
+  background: transparent;
 }
 
-.c11:hover:not(:disabled):not([aria-disabled]),
-.c11:hover[aria-disabled=false] {
-  background-color: var(--charcoal-surface3-hover);
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus,
-.c11[aria-disabled=false]:focus,
-.c11:not(:disabled):not([aria-disabled]):active,
-.c11[aria-disabled=false]:active {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c11[aria-disabled=false]:focus:not(:focus-visible),
-.c11:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c11[aria-disabled=false]:active:not(:focus-visible) {
-  outline: none;
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus-visible,
-.c11[aria-disabled=false]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c11::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11::placeholder {
+.c9::placeholder {
   color: var(--charcoal-text3);
 }
 
@@ -311,16 +275,9 @@ exports[`Storyshots TextField Default 1`] = `
       <div
         className="c8"
       >
-        <span
-          className="c9"
-        >
-          <span
-            className="c10"
-          />
-        </span>
         <input
           aria-labelledby="test-id"
-          className="c11"
+          className="c9"
           disabled={false}
           id="test-id"
           onChange={[Function]}
@@ -328,13 +285,6 @@ exports[`Storyshots TextField Default 1`] = `
           readOnly={false}
           type="text"
         />
-        <span
-          className="c12"
-        >
-          <span
-            className="c10"
-          />
-        </span>
       </div>
     </div>
   </div>
@@ -452,46 +402,63 @@ exports[`Storyshots TextField Has Affix 1`] = `
 }
 
 .c6 {
-  height: 40px;
-  display: grid;
-  position: relative;
-}
-
-.c7 {
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.c10 {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  height: 40px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+  color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
+}
+
+.c6:not(:disabled):not([aria-disabled]):hover,
+.c6 [aria-disabled='false']:hover {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c6:not(:disabled):not([aria-disabled]):active,
+.c6 [aria-disabled='false']:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c6:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-left: 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   gap: 8px;
 }
 
 .c8 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-size: 14px;
-  line-height: 22px;
-  color: var(--charcoal-text2);
-}
-
-.c9 {
   border: none;
   box-sizing: border-box;
   outline: none;
@@ -506,63 +473,34 @@ exports[`Storyshots TextField Has Affix 1`] = `
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + 0px) / 0.875);
-  padding-right: calc((8px + 0px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: var(--charcoal-surface3);
-  color: var(--charcoal-text2);
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
+  background: transparent;
 }
 
-.c9:hover:not(:disabled):not([aria-disabled]),
-.c9:hover[aria-disabled=false] {
-  background-color: var(--charcoal-surface3-hover);
-}
-
-.c9:not(:disabled):not([aria-disabled]):focus,
-.c9[aria-disabled=false]:focus,
-.c9:not(:disabled):not([aria-disabled]):active,
-.c9[aria-disabled=false]:active {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c9:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c9[aria-disabled=false]:focus:not(:focus-visible),
-.c9:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c9[aria-disabled=false]:active:not(:focus-visible) {
-  outline: none;
-}
-
-.c9:not(:disabled):not([aria-disabled]):focus-visible,
-.c9[aria-disabled=false]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c9::-webkit-input-placeholder {
+.c8::-webkit-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c9::-moz-placeholder {
+.c8::-moz-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c9:-ms-input-placeholder {
+.c8:-ms-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c9::placeholder {
+.c8::placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11 {
-  font-size: 14px;
+.c10 {
   line-height: 22px;
+  font-size: 14px;
   color: var(--charcoal-text3);
 }
 
@@ -607,18 +545,14 @@ exports[`Storyshots TextField Has Affix 1`] = `
     <div
       className="c6"
     >
-      <span
+      <div
         className="c7"
       >
-        <span
-          className="c8"
-        >
-          /home/john/
-        </span>
-      </span>
+        /home/john/
+      </div>
       <input
         aria-labelledby="test-id"
-        className="c9"
+        className="c8"
         disabled={false}
         id="test-id"
         maxLength={200}
@@ -628,15 +562,11 @@ exports[`Storyshots TextField Has Affix 1`] = `
         type="text"
       />
       <span
-        className="c10"
+        className="c9"
       >
+        .png
         <span
-          className="c8"
-        >
-          .png
-        </span>
-        <span
-          className="c11"
+          className="c10"
         >
           0/200
         </span>
@@ -793,46 +723,51 @@ exports[`Storyshots TextField Has Count 1`] = `
 }
 
 .c8 {
-  height: 40px;
-  display: grid;
-  position: relative;
-}
-
-.c9 {
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.c12 {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
+  height: 40px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+  color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
+}
+
+.c8:not(:disabled):not([aria-disabled]):hover,
+.c8 [aria-disabled='false']:hover {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c8:not(:disabled):not([aria-disabled]):active,
+.c8 [aria-disabled='false']:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c8:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
 .c10 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-size: 14px;
-  line-height: 22px;
-  color: var(--charcoal-text2);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
 }
 
-.c11 {
+.c9 {
   border: none;
   box-sizing: border-box;
   outline: none;
@@ -847,63 +782,34 @@ exports[`Storyshots TextField Has Count 1`] = `
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + 0px) / 0.875);
-  padding-right: calc((8px + 0px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: var(--charcoal-surface3);
-  color: var(--charcoal-text2);
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
+  background: transparent;
 }
 
-.c11:hover:not(:disabled):not([aria-disabled]),
-.c11:hover[aria-disabled=false] {
-  background-color: var(--charcoal-surface3-hover);
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus,
-.c11[aria-disabled=false]:focus,
-.c11:not(:disabled):not([aria-disabled]):active,
-.c11[aria-disabled=false]:active {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c11[aria-disabled=false]:focus:not(:focus-visible),
-.c11:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c11[aria-disabled=false]:active:not(:focus-visible) {
-  outline: none;
-}
-
-.c11:not(:disabled):not([aria-disabled]):focus-visible,
-.c11[aria-disabled=false]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c11::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11::-moz-placeholder {
+.c9::-moz-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c11::placeholder {
+.c9::placeholder {
   color: var(--charcoal-text3);
 }
 
-.c13 {
-  font-size: 14px;
+.c11 {
   line-height: 22px;
+  font-size: 14px;
   color: var(--charcoal-text3);
 }
 
@@ -963,16 +869,9 @@ exports[`Storyshots TextField Has Count 1`] = `
       <div
         className="c8"
       >
-        <span
-          className="c9"
-        >
-          <span
-            className="c10"
-          />
-        </span>
         <input
           aria-labelledby="test-id"
-          className="c11"
+          className="c9"
           disabled={false}
           id="test-id"
           maxLength={100}
@@ -982,13 +881,10 @@ exports[`Storyshots TextField Has Count 1`] = `
           type="text"
         />
         <span
-          className="c12"
+          className="c10"
         >
           <span
-            className="c10"
-          />
-          <span
-            className="c13"
+            className="c11"
           >
             0/100
           </span>
@@ -1173,46 +1069,39 @@ exports[`Storyshots TextField Has Label 1`] = `
 }
 
 .c10 {
-  height: 40px;
-  display: grid;
-  position: relative;
-}
-
-.c11 {
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.c14 {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
-}
-
-.c12 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-size: 14px;
-  line-height: 22px;
+  height: 40px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
   color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
 }
 
-.c13 {
+.c10:not(:disabled):not([aria-disabled]):hover,
+.c10 [aria-disabled='false']:hover {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c10:not(:disabled):not([aria-disabled]):active,
+.c10 [aria-disabled='false']:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c10:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c11 {
   border: none;
   box-sizing: border-box;
   outline: none;
@@ -1227,83 +1116,37 @@ exports[`Storyshots TextField Has Label 1`] = `
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + 0px) / 0.875);
-  padding-right: calc((8px + 0px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: var(--charcoal-surface3);
-  color: var(--charcoal-text2);
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
+  background: transparent;
 }
 
-.c13:hover:not(:disabled):not([aria-disabled]),
-.c13:hover[aria-disabled=false] {
-  background-color: var(--charcoal-surface3-hover);
-}
-
-.c13:not(:disabled):not([aria-disabled]):focus,
-.c13[aria-disabled=false]:focus,
-.c13:not(:disabled):not([aria-disabled]):active,
-.c13[aria-disabled=false]:active {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c13:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c13[aria-disabled=false]:focus:not(:focus-visible),
-.c13:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c13[aria-disabled=false]:active:not(:focus-visible) {
-  outline: none;
-}
-
-.c13:not(:disabled):not([aria-disabled]):focus-visible,
-.c13[aria-disabled=false]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c13::-webkit-input-placeholder {
+.c11::-webkit-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c13::-moz-placeholder {
+.c11::-moz-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c13:-ms-input-placeholder {
+.c11:-ms-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c13::placeholder {
+.c11::placeholder {
   color: var(--charcoal-text3);
 }
 
-.c15 {
+.c12 {
   font-size: 14px;
   line-height: 22px;
-  display: flow-root;
-  margin-top: 8px;
-  margin-bottom: 0px;
-  color: var(--charcoal-text1);
-}
-
-.c15::before {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-top: -4px;
-}
-
-.c15::after {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
+  margin-top: 4px;
   margin-bottom: -4px;
+  color: var(--charcoal-text1);
 }
 
 .c0 {
@@ -1351,17 +1194,10 @@ exports[`Storyshots TextField Has Label 1`] = `
       <div
         className="c10"
       >
-        <span
-          className="c11"
-        >
-          <span
-            className="c12"
-          />
-        </span>
         <input
           aria-labelledby="test-id"
           aria-required={true}
-          className="c13"
+          className="c11"
           disabled={false}
           id="test-id"
           onChange={[Function]}
@@ -1369,16 +1205,9 @@ exports[`Storyshots TextField Has Label 1`] = `
           readOnly={false}
           type="text"
         />
-        <span
-          className="c14"
-        >
-          <span
-            className="c12"
-          />
-        </span>
       </div>
       <p
-        className="c15"
+        className="c12"
       >
         Assistive text
       </p>
@@ -1388,7 +1217,7 @@ exports[`Storyshots TextField Has Label 1`] = `
 `;
 
 exports[`Storyshots TextField Prefix Icon 1`] = `
-.c12 {
+.c11 {
   cursor: pointer;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -1410,16 +1239,16 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   text-transform: none;
 }
 
-.c12:disabled,
-.c12[aria-disabled]:not([aria-disabled=false]) {
+.c11:disabled,
+.c11[aria-disabled]:not([aria-disabled=false]) {
   cursor: default;
 }
 
-.c12:focus {
+.c11:focus {
   outline: none;
 }
 
-.c12::-moz-focus-inner {
+.c11::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -1519,7 +1348,7 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   margin-left: auto;
 }
 
-.c13 {
+.c12 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1545,38 +1374,38 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   transition: 0.2s background-color,0.2s box-shadow;
 }
 
-.c13:hover:not(:disabled):not([aria-disabled]),
-.c13:hover[aria-disabled=false] {
+.c12:hover:not(:disabled):not([aria-disabled]),
+.c12:hover[aria-disabled=false] {
   background-color: var(--charcoal-surface4-hover);
 }
 
-.c13:active:not(:disabled):not([aria-disabled]),
-.c13:active[aria-disabled=false] {
+.c12:active:not(:disabled):not([aria-disabled]),
+.c12:active[aria-disabled=false] {
   background-color: var(--charcoal-surface4-press);
 }
 
-.c13:disabled,
-.c13[aria-disabled]:not([aria-disabled=false]) {
+.c12:disabled,
+.c12[aria-disabled]:not([aria-disabled=false]) {
   opacity: 0.32;
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus,
-.c13[aria-disabled=false]:focus,
-.c13:not(:disabled):not([aria-disabled]):active,
-.c13[aria-disabled=false]:active {
+.c12:not(:disabled):not([aria-disabled]):focus,
+.c12[aria-disabled=false]:focus,
+.c12:not(:disabled):not([aria-disabled]):active,
+.c12[aria-disabled=false]:active {
   outline: none;
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c13[aria-disabled=false]:focus:not(:focus-visible),
-.c13:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c13[aria-disabled=false]:active:not(:focus-visible) {
+.c12:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c12[aria-disabled=false]:focus:not(:focus-visible),
+.c12:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
+.c12[aria-disabled=false]:active:not(:focus-visible) {
   outline: none;
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus-visible,
-.c13[aria-disabled=false]:focus-visible {
+.c12:not(:disabled):not([aria-disabled]):focus-visible,
+.c12[aria-disabled=false]:focus-visible {
   outline: none;
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
@@ -1596,46 +1425,63 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
 }
 
 .c6 {
-  height: 40px;
-  display: grid;
-  position: relative;
-}
-
-.c7 {
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  z-index: 1;
-}
-
-.c11 {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  gap: 8px;
+  height: 40px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+  color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
 }
 
-.c8 {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-size: 14px;
-  line-height: 22px;
-  color: var(--charcoal-text2);
+.c6:not(:disabled):not([aria-disabled]):hover,
+.c6 [aria-disabled='false']:hover {
+  background-color: var(--charcoal-surface3-hover);
+}
+
+.c6:not(:disabled):not([aria-disabled]):active,
+.c6 [aria-disabled='false']:active {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c6:focus-within {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding-left: 8px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  gap: 8px;
+}
+
+.c9 {
   border: none;
   box-sizing: border-box;
   outline: none;
@@ -1650,64 +1496,34 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + 0px) / 0.875);
-  padding-right: calc((8px + 0px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  background-color: var(--charcoal-surface3);
-  color: var(--charcoal-text2);
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
+  background: transparent;
 }
 
-.c10:hover:not(:disabled):not([aria-disabled]),
-.c10:hover[aria-disabled=false] {
-  background-color: var(--charcoal-surface3-hover);
-}
-
-.c10:not(:disabled):not([aria-disabled]):focus,
-.c10[aria-disabled=false]:focus,
-.c10:not(:disabled):not([aria-disabled]):active,
-.c10[aria-disabled=false]:active {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c10:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c10[aria-disabled=false]:focus:not(:focus-visible),
-.c10:not(:disabled):not([aria-disabled]):active:not(:focus-visible),
-.c10[aria-disabled=false]:active:not(:focus-visible) {
-  outline: none;
-}
-
-.c10:not(:disabled):not([aria-disabled]):focus-visible,
-.c10[aria-disabled=false]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c10::-webkit-input-placeholder {
+.c9::-webkit-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c10::-moz-placeholder {
+.c9::-moz-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c10:-ms-input-placeholder {
+.c9:-ms-input-placeholder {
   color: var(--charcoal-text3);
 }
 
-.c10::placeholder {
+.c9::placeholder {
   color: var(--charcoal-text3);
 }
 
-.c9 {
+.c8 {
+  height: 16px;
   color: #858585;
-  margin-top: 2px;
-  margin-right: 4px;
 }
 
 <div
@@ -1751,48 +1567,40 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
     <div
       className="c6"
     >
-      <span
+      <div
         className="c7"
       >
-        <span
+        <div
           className="c8"
         >
-          <div
-            className="c9"
-          >
-            <pixiv-icon
-              name="16/Search"
-            />
-          </div>
-        </span>
-      </span>
+          <pixiv-icon
+            name="16/Search"
+          />
+        </div>
+      </div>
       <input
         aria-labelledby="test-id"
-        className="c10"
+        className="c9"
         disabled={false}
         id="test-id"
         onChange={[Function]}
-        placeholder="Icon prefix"
+        placeholder="作品を検索"
         readOnly={false}
         type="text"
       />
       <span
-        className="c11"
+        className="c10"
       >
-        <span
-          className="c8"
+        <button
+          className="c11 c12"
+          height={20}
+          size="XS"
+          width={20}
         >
-          <button
-            className="c12 c13"
-            height={20}
-            size="XS"
-            width={20}
-          >
-            <pixiv-icon
-              name="16/Remove"
-            />
-          </button>
-        </span>
+          <pixiv-icon
+            name="16/Remove"
+          />
+        </button>
       </span>
     </div>
   </div>

--- a/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
@@ -201,6 +201,7 @@ exports[`Storyshots TextField Default 1`] = `
   -moz-appearance: none;
   appearance: none;
   background: transparent;
+  color: var(--charcoal-text2);
 }
 
 .c9::-webkit-input-placeholder {
@@ -480,6 +481,7 @@ exports[`Storyshots TextField Has Affix 1`] = `
   -moz-appearance: none;
   appearance: none;
   background: transparent;
+  color: var(--charcoal-text2);
 }
 
 .c8::-webkit-input-placeholder {
@@ -789,6 +791,7 @@ exports[`Storyshots TextField Has Count 1`] = `
   -moz-appearance: none;
   appearance: none;
   background: transparent;
+  color: var(--charcoal-text2);
 }
 
 .c9::-webkit-input-placeholder {
@@ -1123,6 +1126,7 @@ exports[`Storyshots TextField Has Label 1`] = `
   -moz-appearance: none;
   appearance: none;
   background: transparent;
+  color: var(--charcoal-text2);
 }
 
 .c11::-webkit-input-placeholder {
@@ -1503,6 +1507,7 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   -moz-appearance: none;
   appearance: none;
   background: transparent;
+  color: var(--charcoal-text2);
 }
 
 .c9::-webkit-input-placeholder {

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -7,6 +7,7 @@ import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { theme } from '../../styled'
 import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
+import { useFocusWithClick } from './useFocusWithClick'
 
 type DOMProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -64,13 +65,9 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
 
     const { visuallyHiddenProps } = useVisuallyHidden()
     const ariaRef = useRef<HTMLInputElement>(null)
-    const prefixRef = useRef<HTMLSpanElement>(null)
-    const suffixRef = useRef<HTMLSpanElement>(null)
     const [count, setCount] = useState(
       countCodePointsInString(props.value ?? '')
     )
-    const [prefixWidth, setPrefixWidth] = useState(0)
-    const [suffixWidth, setSuffixWidth] = useState(0)
 
     const nonControlled = props.value === undefined
     const handleChange = useCallback(
@@ -106,26 +103,9 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         ariaRef
       )
 
-    useEffect(() => {
-      const prefixObserver = new ResizeObserver((entries) => {
-        setPrefixWidth(entries[0].contentRect.width)
-      })
-      const suffixObserver = new ResizeObserver((entries) => {
-        setSuffixWidth(entries[0].contentRect.width)
-      })
+    const containerRef = useRef(null)
 
-      if (prefixRef.current !== null) {
-        prefixObserver.observe(prefixRef.current)
-      }
-      if (suffixRef.current !== null) {
-        suffixObserver.observe(suffixRef.current)
-      }
-
-      return () => {
-        suffixObserver.disconnect()
-        prefixObserver.disconnect()
-      }
-    }, [])
+    useFocusWithClick(containerRef, ariaRef)
 
     return (
       <TextFieldRoot className={className} isDisabled={disabled}>
@@ -137,25 +117,23 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           {...labelProps}
           {...(!showLabel ? visuallyHiddenProps : {})}
         />
-        <StyledInputContainer>
-          <PrefixContainer ref={prefixRef}>
-            <Affix>{prefix}</Affix>
-          </PrefixContainer>
+        <StyledInputContainer ref={containerRef} invalid={invalid}>
+          {prefix && <PrefixContainer>{prefix}</PrefixContainer>}
           <StyledInput
             ref={mergeRefs(forwardRef, ariaRef)}
             invalid={invalid}
-            extraLeftPadding={prefixWidth}
-            extraRightPadding={suffixWidth}
             {...inputProps}
           />
-          <SuffixContainer ref={suffixRef}>
-            <Affix>{suffix}</Affix>
-            {showCount && (
-              <SingleLineCounter>
-                {maxLength !== undefined ? `${count}/${maxLength}` : count}
-              </SingleLineCounter>
-            )}
-          </SuffixContainer>
+          {(suffix || showCount) && (
+            <SuffixContainer>
+              {suffix}
+              {showCount && (
+                <SingleLineCounter>
+                  {maxLength !== undefined ? `${count}/${maxLength}` : count}
+                </SingleLineCounter>
+              )}
+            </SuffixContainer>
+          )}
         </StyledInputContainer>
         {assistiveText != null && assistiveText.length !== 0 && (
           <AssistiveText
@@ -180,43 +158,57 @@ const TextFieldRoot = styled.div<{ isDisabled: boolean }>`
 `
 
 const TextFieldLabel = styled(FieldLabel)`
-  ${theme((o) => o.margin.bottom(8))}
+  margin-bottom: 8px;
 `
 
-const StyledInputContainer = styled.div`
+const StyledInputContainer = styled.div<{
+  invalid: boolean
+}>`
+  display: flex;
   height: 40px;
-  display: grid;
-  position: relative;
+
+  transition: 0.2s background-color, 0.2s box-shadow;
+  color: var(--charcoal-text2);
+  background-color: var(--charcoal-surface3);
+
+  :not(:disabled):not([aria-disabled]):hover,
+  [aria-disabled='false']:hover {
+    background-color: var(--charcoal-surface3-hover);
+  }
+
+  :not(:disabled):not([aria-disabled]):active,
+  [aria-disabled='false']:active {
+    outline: none;
+    box-shadow: 0 0 0 4px
+      ${(p) => (p.invalid ? `rgba(255,43,0,0.32)` : `rgba(0, 150, 250, 0.32);`)};
+  }
+
+  :focus-within {
+    outline: none;
+    box-shadow: 0 0 0 4px
+      ${(p) => (p.invalid ? `rgba(255,43,0,0.32)` : `rgba(0, 150, 250, 0.32);`)};
+  }
+  border-radius: 4px;
+  gap: 4px;
+  padding: 0 8px;
+  line-height: 22px;
+  font-size: 14px;
 `
 
-const PrefixContainer = styled.span`
-  position: absolute;
-  top: 50%;
-  left: 8px;
-  transform: translateY(-50%);
-  z-index: 1;
+const PrefixContainer = styled.div`
+  display: flex;
+  padding-left: 8px;
+  align-items: center;
 `
 
 const SuffixContainer = styled.span`
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  transform: translateY(-50%);
-
   display: flex;
+  align-items: center;
   gap: 8px;
-`
-
-const Affix = styled.span`
-  user-select: none;
-
-  ${theme((o) => [o.typography(14).preserveHalfLeading, o.font.text2])}
 `
 
 const StyledInput = styled.input<{
   invalid: boolean
-  extraLeftPadding: number
-  extraRightPadding: number
 }>`
   border: none;
   box-sizing: border-box;
@@ -230,20 +222,13 @@ const StyledInput = styled.input<{
   height: calc(100% / 0.875);
   font-size: calc(14px / 0.875);
   line-height: calc(22px / 0.875);
-  padding-left: calc((8px + ${(p) => p.extraLeftPadding}px) / 0.875);
-  padding-right: calc((8px + ${(p) => p.extraRightPadding}px) / 0.875);
+  padding-left: 0;
+  padding-right: 0;
   border-radius: calc(4px / 0.875);
 
   /* Display box-shadow for iOS Safari */
   appearance: none;
-
-  ${(p) =>
-    theme((o) => [
-      o.bg.surface3.hover,
-      o.outline.default.focus,
-      p.invalid && o.outline.assertive,
-      o.font.text2,
-    ])}
+  background: transparent;
 
   &::placeholder {
     ${theme((o) => o.font.text3)}
@@ -251,15 +236,15 @@ const StyledInput = styled.input<{
 `
 
 const SingleLineCounter = styled.span`
-  ${theme((o) => [o.typography(14).preserveHalfLeading, o.font.text3])}
+  line-height: 22px;
+  font-size: 14px;
+  color: var(--charcoal-text3);
 `
 
 const AssistiveText = styled.p<{ invalid: boolean }>`
-  ${(p) =>
-    theme((o) => [
-      o.typography(14),
-      o.margin.top(8),
-      o.margin.bottom(0),
-      o.font[p.invalid ? 'assertive' : 'text1'],
-    ])}
+  font-size: 14px;
+  line-height: 22px;
+  margin-top: 4px;
+  margin-bottom: -4px;
+  color: ${(p) => `var(--charcoal-${p.invalid ? `assertive` : `text1`})`};
 `

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import styled from 'styled-components'
 import FieldLabel, { FieldLabelProps } from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
-import { theme } from '../../styled'
 import { ReactAreaUseTextFieldCompat } from '../../_lib/compat'
 import { useFocusWithClick } from './useFocusWithClick'
 
@@ -230,8 +229,9 @@ const StyledInput = styled.input<{
   appearance: none;
   background: transparent;
 
+  color: var(--charcoal-text2);
   &::placeholder {
-    ${theme((o) => o.font.text3)}
+    color: var(--charcoal-text3);
   }
 `
 

--- a/packages/react/src/components/TextField/useFocusWithClick.tsx
+++ b/packages/react/src/components/TextField/useFocusWithClick.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import * as React from 'react'
+
+export function useFocusWithClick(
+  containerRef: React.RefObject<HTMLDivElement>,
+  inputRef: React.RefObject<HTMLInputElement>
+) {
+  useEffect(() => {
+    const el = containerRef.current
+    if (el) {
+      const handleDown = (e: MouseEvent) => {
+        if (e.target !== inputRef.current) {
+          inputRef.current?.focus()
+        }
+      }
+      el.addEventListener('click', handleDown)
+      return () => {
+        el.removeEventListener('click', handleDown)
+      }
+    }
+  })
+}


### PR DESCRIPTION
## やったこと

- textFieldのprefix, suffix構造を更新
- prefix, suffixの幅をResizeObserverで計算しないように変更
- theme()を利用しないように変更
- prefixをクリック時にfocusするように修正
- デザイン修正

