### PR TITLE
fix: TextFieldのprefixの余白を修正

### DIFF
--- a/packages/react/src/components/TextField/TextField.story.tsx
+++ b/packages/react/src/components/TextField/TextField.story.tsx
@@ -1,10 +1,10 @@
-import { action } from '@storybook/addon-actions'
 import styled from 'styled-components'
 import { Story } from '../../_lib/compat'
 import Clickable from '../Clickable'
 import TextField, { TextFieldProps } from '.'
 import { px } from '@charcoal-ui/utils'
 import IconButton from '../IconButton'
+import { useCallback, useState } from 'react'
 
 export default {
   title: 'TextField',
@@ -30,9 +30,7 @@ const Template: Story<Partial<TextFieldProps>> = (args) => (
     <TextField
       label="Label"
       requiredText="*必須"
-      subLabel={
-        <Clickable onClick={action('label-click')}>Text Link</Clickable>
-      }
+      subLabel={<Clickable>Text Link</Clickable>}
       placeholder="TextField"
       {...args}
     />
@@ -64,21 +62,40 @@ HasAffix.args = {
   suffix: '.png',
 }
 
-export const PrefixIcon: Story<Partial<TextFieldProps>> = (args) => (
-  <TextField
-    label="Label"
-    placeholder="作品を検索"
-    prefix={
-      <PrefixIconWrap>
-        <pixiv-icon name="16/Search" />
-      </PrefixIconWrap>
-    }
-    suffix={<IconButton variant="Overlay" icon={'16/Remove'} size="XS" />}
-    {...args}
-  />
-)
+export const PrefixIcon: Story<Partial<TextFieldProps>> = (args) => {
+  const [value, setValue] = useState('')
+  const handleChange = useCallback((value: string) => {
+    setValue(value)
+  }, [])
+  const handleClear = useCallback(() => {
+    setValue('')
+  }, [])
+  return (
+    <TextField
+      {...args}
+      label="Label"
+      placeholder="作品を検索"
+      value={value}
+      onChange={handleChange}
+      prefix={
+        <PrefixIconWrap>
+          <pixiv-icon name="16/Search" />
+        </PrefixIconWrap>
+      }
+      suffix={
+        <IconButton
+          variant="Overlay"
+          icon={'16/Remove'}
+          size="XS"
+          onClick={handleClear}
+        />
+      }
+    />
+  )
+}
 
 const PrefixIconWrap = styled.div`
-  height: 16px;
+  display: flex;
+  align-items: center;
   color: ${({ theme }) => theme.color.text3};
 `

--- a/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
@@ -264,7 +264,6 @@ exports[`Storyshots TextField Default 1`] = `
           <span>
             <button
               className="c7"
-              onClick={[Function]}
             >
               Text Link
             </button>
@@ -436,7 +435,6 @@ exports[`Storyshots TextField Has Affix 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding-left: 8px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -856,7 +854,6 @@ exports[`Storyshots TextField Has Count 1`] = `
           <span>
             <button
               className="c7"
-              onClick={[Function]}
             >
               Text Link
             </button>
@@ -1180,7 +1177,6 @@ exports[`Storyshots TextField Has Label 1`] = `
           <span>
             <button
               className="c9"
-              onClick={[Function]}
             >
               Text Link
             </button>
@@ -1456,7 +1452,6 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding-left: 8px;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1517,7 +1512,14 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
 }
 
 .c8 {
-  height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   color: #858585;
 }
 
@@ -1582,6 +1584,7 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
         placeholder="作品を検索"
         readOnly={false}
         type="text"
+        value=""
       />
       <span
         className="c10"
@@ -1589,6 +1592,7 @@ exports[`Storyshots TextField Prefix Icon 1`] = `
         <button
           className="c11 c12"
           height={20}
+          onClick={[Function]}
           size="XS"
           width={20}
         >

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -213,7 +213,6 @@ const StyledInputContainer = styled.div<{
 
 const PrefixContainer = styled.div`
   display: flex;
-  padding-left: 8px;
   align-items: center;
 `
 


### PR DESCRIPTION
## やったこと
- TextFieldのprefixの余白を修正
- storyを利用例に近い形式に更新
