### PR TITLE
Feat/remove charcoal styled from multi select

### DIFF
--- a/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
@@ -14,13 +14,9 @@ exports[`Storyshots MultiSelect Default 1`] = `
 }
 
 .c1:disabled,
-.c1[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled=false]) {
+.c1[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c4 {
@@ -64,33 +60,31 @@ exports[`Storyshots MultiSelect Default 1`] = `
   margin: 0;
   background-color: var(--charcoal-text3);
   border-radius: 999999px;
-  -webkit-transition: 0.2s background-color;
-  transition: 0.2s background-color;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
 }
 
 .c2[type='checkbox']:checked {
   background-color: var(--charcoal-brand);
-  -webkit-transition: 0.2s background-color;
-  transition: 0.2s background-color;
 }
 
 .c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled=false] {
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
   background-color: var(--charcoal-brand-hover);
 }
 
 .c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled=false] {
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
   background-color: var(--charcoal-brand-press);
 }
 
 .c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled=false] {
+.c2[type='checkbox']:hover[aria-disabled='false'] {
   background-color: var(--charcoal-text3-hover);
 }
 
 .c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled=false] {
+.c2[type='checkbox']:active[aria-disabled='false'] {
   background-color: var(--charcoal-text3-press);
 }
 
@@ -115,6 +109,8 @@ exports[`Storyshots MultiSelect Default 1`] = `
   height: 24px;
   border-radius: 999999px;
   color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
 }
 
 .c0 {
@@ -255,7 +251,7 @@ exports[`Storyshots MultiSelect Default 1`] = `
 </div>
 `;
 
-exports[`Storyshots MultiSelect Playground 1`] = `
+exports[`Storyshots MultiSelect Invalid 1`] = `
 .c1 {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -269,13 +265,9 @@ exports[`Storyshots MultiSelect Playground 1`] = `
 }
 
 .c1:disabled,
-.c1[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled=false]) {
+.c1[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c4 {
@@ -319,33 +311,288 @@ exports[`Storyshots MultiSelect Playground 1`] = `
   margin: 0;
   background-color: var(--charcoal-text3);
   border-radius: 999999px;
-  -webkit-transition: 0.2s background-color;
-  transition: 0.2s background-color;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
 }
 
 .c2[type='checkbox']:checked {
   background-color: var(--charcoal-brand);
-  -webkit-transition: 0.2s background-color;
-  transition: 0.2s background-color;
 }
 
 .c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled=false] {
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
   background-color: var(--charcoal-brand-hover);
 }
 
 .c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled=false] {
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
   background-color: var(--charcoal-brand-press);
 }
 
 .c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled=false] {
+.c2[type='checkbox']:hover[aria-disabled='false'] {
   background-color: var(--charcoal-text3-hover);
 }
 
 .c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled=false] {
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c2[type='checkbox']:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox'][aria-disabled='false'] {
+  box-shadow: 0 0 0 4px rgba(255,43,0,0.32);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label=""
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        4
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storyshots MultiSelect Overlay 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+  background-color: var(--charcoal-surface4);
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
   background-color: var(--charcoal-text3-press);
 }
 
@@ -370,6 +617,262 @@ exports[`Storyshots MultiSelect Playground 1`] = `
   height: 24px;
   border-radius: 999999px;
   color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+  border-color: var(--charcoal-text5);
+  border-width: 2px;
+  border-style: solid;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label=""
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="defaultName"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        4
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storyshots MultiSelect Playground 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
 }
 
 .c0 {

--- a/packages/react/src/components/MultiSelect/index.story.tsx
+++ b/packages/react/src/components/MultiSelect/index.story.tsx
@@ -154,3 +154,63 @@ Playground.args = {
   invalid: false,
   variant: 'default',
 }
+
+export const Invalid: Story<PlaygroundProps> = ({ className, ...props }) => {
+  const [selected, setSelected] = useState<string[]>([])
+
+  return (
+    <StyledMultiSelectGroup
+      {...props}
+      selected={selected}
+      onChange={setSelected}
+      invalid
+    >
+      {[1, 2, 3, 4].map((idx) => (
+        <MultiSelect
+          value={`選択肢${idx}`}
+          variant={props.variant}
+          key={idx}
+          className={className}
+        >
+          選択肢{idx}
+        </MultiSelect>
+      ))}
+    </StyledMultiSelectGroup>
+  )
+}
+Invalid.args = {
+  name: 'defaultName',
+  label: '',
+  disabled: false,
+  readonly: false,
+  variant: 'default',
+}
+
+export const Overlay: Story<PlaygroundProps> = ({ className, ...props }) => {
+  const [selected, setSelected] = useState<string[]>([])
+
+  return (
+    <StyledMultiSelectGroup
+      {...props}
+      selected={selected}
+      onChange={setSelected}
+    >
+      {[1, 2, 3, 4].map((idx) => (
+        <MultiSelect
+          value={`選択肢${idx}`}
+          variant="overlay"
+          key={idx}
+          className={className}
+        >
+          選択肢{idx}
+        </MultiSelect>
+      ))}
+    </StyledMultiSelectGroup>
+  )
+}
+Overlay.args = {
+  name: 'defaultName',
+  label: '',
+  disabled: false,
+  readonly: false,
+}

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -2,8 +2,7 @@ import { ChangeEvent, useCallback, useContext, forwardRef, memo } from 'react'
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 import warning from 'warning'
-import { theme } from '../../styled'
-import { disabledSelector, px } from '@charcoal-ui/utils'
+import { px } from '@charcoal-ui/utils'
 
 import { MultiSelectGroupContext } from './context'
 
@@ -92,17 +91,36 @@ const MultiSelectRoot = styled.label`
   align-items: center;
   position: relative;
   cursor: pointer;
-  ${disabledSelector} {
+  gap: ${({ theme }) => px(theme.spacing[4])};
+  &:disabled,
+  &[aria-disabled]:not([aria-disabled='false']) {
+    opacity: 0.32;
     cursor: default;
   }
-  gap: ${({ theme }) => px(theme.spacing[4])};
-  ${theme((o) => o.disabled)}
 `
 
 const MultiSelectLabel = styled.div`
   display: flex;
   align-items: center;
-  ${theme((o) => [o.typography(14), o.font.text2])}
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+
+  &::before {
+    display: block;
+    width: 0;
+    height: 0;
+    content: '';
+    margin-top: -4px;
+  }
+  &::after {
+    display: block;
+    width: 0;
+    height: 0;
+    content: '';
+    margin-bottom: -4px;
+  }
 `
 
 const MultiSelectInput = styled.input.attrs({ type: 'checkbox' })<{
@@ -115,18 +133,55 @@ const MultiSelectInput = styled.input.attrs({ type: 'checkbox' })<{
     width: 20px;
     height: 20px;
     margin: 0;
+    background-color: var(--charcoal-text3);
+    border-radius: 999999px;
+    transition: 0.2s background-color, 0.2s box-shadow;
 
     &:checked {
-      ${theme((o) => o.bg.brand.hover.press)}
+      background-color: var(--charcoal-brand);
+      &:hover {
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          background-color: var(--charcoal-brand-hover);
+        }
+      }
+
+      &:active {
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          background-color: var(--charcoal-brand-press);
+        }
+      }
+    }
+
+    &:hover {
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        background-color: var(--charcoal-text3-hover);
+      }
+    }
+
+    &:active {
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        background-color: var(--charcoal-text3-press);
+      }
     }
 
     ${({ invalid, overlay }) =>
-      theme((o) => [
-        o.bg.text3.hover.press,
-        o.borderRadius('oval'),
-        invalid && !overlay && o.outline.assertive,
-        overlay && o.bg.surface4,
-      ])};
+      invalid &&
+      !overlay &&
+      css`
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+        }
+      `}
+    ${({ overlay }) =>
+      overlay &&
+      css`
+        background-color: var(--charcoal-surface4);
+      `}
   }
 `
 
@@ -141,20 +196,25 @@ const MultiSelectInputOverlay = styled.div<{
   display: flex;
   align-items: center;
   justify-content: center;
-
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  transition: 0.2s box-shadow;
   ${({ invalid, overlay }) =>
-    theme((o) => [
-      o.width.px(24),
-      o.height.px(24),
-      o.borderRadius('oval'),
-      o.font.text5,
-      invalid && overlay && o.outline.assertive,
-    ])}
+    invalid &&
+    overlay &&
+    css`
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+      }
+    `}
 
   ${({ overlay }) =>
     overlay &&
     css`
-      border-color: ${({ theme }) => theme.color.text5};
+      border-color: var(--charcoal-text5);
       border-width: 2px;
       border-style: solid;
     `}


### PR DESCRIPTION
## やったこと

- invalid な storybook を追加
- variant が overlay な storybook を追加
- MultiSelect から `@charcoal/styled` 記法を抜いた

## 動作確認環境
- storybook
- snapshot

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
