### PR TITLE
fix: dark themeのsurface7の色が間違っている

### DIFF
--- a/packages/theme/src/default.ts
+++ b/packages/theme/src/default.ts
@@ -143,7 +143,7 @@ export const dark: CharcoalTheme = {
     surface3: rgba('#ffffff', 0.12),
     surface4: light.color.surface4,
     surface6: rgba('#ffffff', 0.12),
-    surface7: light.color.surface7,
+    surface7: rgba('#000000', 0),
     surface8: light.color.surface8,
     surface9: '#333333',
     surface10: rgba('#ffffff', 0.2),


### PR DESCRIPTION
## やったこと
- dark themeのsurface7の色を透明にした

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
