### PR TITLE
docsにtailwindcssを設定してpreflightを無効

### DIFF
--- a/docs/src/pages/_app.page.tsx
+++ b/docs/src/pages/_app.page.tsx
@@ -13,6 +13,8 @@ import { AppProvider } from '../components/AppProvider'
 import { SideMenuDiv } from '../components/SideMenuDiv'
 import Head from 'next/head'
 
+import '../tailwind.css'
+
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>

--- a/docs/tailwind.config.js
+++ b/docs/tailwind.config.js
@@ -14,4 +14,7 @@ module.exports = {
     }),
   ],
   safelist: [{ pattern: /.*/ }],
+  corePlugins: {
+    preflight: false,
+  },
 }


### PR DESCRIPTION
## やったこと

- tailwindをdocsで効くようにした
- preflightを無効にした
    - リセットCSSが全てのページに効いてしまうため

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
