### PR TITLE
Feat/remove-charcoal-styled-from-switch

### DIFF
--- a/packages/react/src/components/DropdownSelector/ListItem/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/DropdownSelector/ListItem/__snapshots__/index.story.storyshot
@@ -13,17 +13,13 @@ exports[`Storyshots DropdownSelector/ListItem Basic 1`] = `
 }
 
 .c3:disabled,
-.c3[aria-disabled]:not([aria-disabled=false]) {
+.c3[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3:active > input {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c3:disabled,
-.c3[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
 }
 
 .c4 {

--- a/packages/react/src/components/Switch/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Switch/__snapshots__/index.story.storyshot
@@ -13,17 +13,13 @@ exports[`Storyshots Switch Labelled 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
+.c0[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c0:active > input {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
 }
 
 .c2 {
@@ -168,17 +164,13 @@ exports[`Storyshots Switch Playground 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
+.c0[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c0:active > input {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
 }
 
 .c2 {
@@ -322,17 +314,13 @@ exports[`Storyshots Switch Unlabelled 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
+.c0[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c0:active > input {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
 }
 
 .c1 {

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -80,21 +80,10 @@ const Label = styled.label`
 `
 
 const LabelInner = styled.div`
-  /* font-size: 14px;
+  font-size: 14px;
   line-height: 22px;
-  display: flow-root;
-  &:before {
-    display: block;
-    content: "";
-  }
-  &:after {
-  } */
-
-  ${theme((o) => [
-    o.typography(14).preserveHalfLeading,
-    o.font.text2,
-    o.margin.left(4),
-  ])}
+  color: var(--charcoal-text2);
+  margin-left: 4px;
 `
 
 const SwitchInput = styled.input.attrs({

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -68,18 +68,28 @@ const Label = styled.label`
   cursor: pointer;
   outline: 0;
 
-  ${theme((o) => o.disabled)}
+  &:disabled,
+  &[aria-disabled]:not([aria-disabled='false']) {
+    opacity: 0.32;
+    cursor: default;
+  }
 
   :active > input {
     box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
   }
-
-  ${disabledSelector} {
-    cursor: default;
-  }
 `
 
 const LabelInner = styled.div`
+  /* font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  &:before {
+    display: block;
+    content: "";
+  }
+  &:after {
+  } */
+
   ${theme((o) => [
     o.typography(14).preserveHalfLeading,
     o.font.text2,

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -4,8 +4,6 @@ import { useMemo, memo, forwardRef } from 'react'
 import * as React from 'react'
 import { useToggleState } from 'react-stately'
 import styled from 'styled-components'
-import { theme } from '../../styled'
-import { disabledSelector } from '@charcoal-ui/utils'
 import { useObjectRef } from '@react-aria/utils'
 
 export type SwitchProps = {
@@ -86,9 +84,7 @@ const LabelInner = styled.div`
   margin-left: 4px;
 `
 
-const SwitchInput = styled.input.attrs({
-  type: 'checkbox',
-})`
+const SwitchInput = styled.input.attrs({ type: 'checkbox' })`
   appearance: none;
   display: inline-flex;
   position: relative;


### PR DESCRIPTION
## やったこと

- Switch から styled 記法を抜く

## 動作確認環境
- snapshot
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
