### PR TITLE
/reactのStorybook CSF3化 LoadingSpinner編

### DIFF
--- a/packages/react/src/components/LoadingSpinner/LoadingSpinnerIcon.story.tsx
+++ b/packages/react/src/components/LoadingSpinner/LoadingSpinnerIcon.story.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { LoadingSpinnerIcon } from '.'
+
+export default {
+  title: 'LoadingSpinnerIcon',
+  component: LoadingSpinnerIcon,
+  args: {
+    size: 12,
+    color: '#B1CC29',
+    once: false,
+  },
+} as Meta<typeof LoadingSpinnerIcon>
+
+export const Icon: StoryObj<typeof LoadingSpinnerIcon> = {}

--- a/packages/react/src/components/LoadingSpinner/LoadingSpinnerIcon.story.tsx
+++ b/packages/react/src/components/LoadingSpinner/LoadingSpinnerIcon.story.tsx
@@ -5,8 +5,6 @@ export default {
   title: 'LoadingSpinnerIcon',
   component: LoadingSpinnerIcon,
   args: {
-    size: 12,
-    color: '#B1CC29',
     once: false,
   },
 } as Meta<typeof LoadingSpinnerIcon>

--- a/packages/react/src/components/LoadingSpinner/index.story.tsx
+++ b/packages/react/src/components/LoadingSpinner/index.story.tsx
@@ -1,58 +1,15 @@
-import {
-  boolean,
-  button,
-  number,
-  text,
-  withKnobs,
-} from '@storybook/addon-knobs'
-import { useRef } from 'react'
-import LoadingSpinner, {
-  LoadingSpinnerIcon,
-  LoadingSpinnerIconHandler,
-} from '.'
+import { Meta, StoryObj } from '@storybook/react'
+import LoadingSpinner from '.'
 
 export default {
   title: 'LoadingSpinner',
   component: LoadingSpinner,
-  decorators: [withKnobs],
-}
+  args: {
+    size: 48,
+    padding: 16,
+    transparent: false,
+    className: 'basic',
+  },
+} as Meta<typeof LoadingSpinner>
 
-export function Basic() {
-  const size = number('size', 48)
-  const padding = number('padding', 16)
-  const transparent = boolean('transparent', false)
-  const className = text('className', 'basic')
-
-  return (
-    <LoadingSpinner
-      size={size}
-      padding={padding}
-      transparent={transparent}
-      className={className}
-    />
-  )
-}
-
-export function Icon() {
-  return <IconComponent />
-}
-
-function IconComponent() {
-  const size = number('size', 12)
-  const color = text('color', '#B1CC29')
-  const once = boolean('once', false)
-  button('restart', () => ref.current?.restart())
-
-  const ref = useRef<LoadingSpinnerIconHandler>(null)
-
-  return (
-    <div
-      css={`
-        font-size: ${size}px;
-        color: ${color};
-      `}
-    >
-      <LoadingSpinnerIcon once={once} ref={ref} />
-    </div>
-  )
-}
+export const Default: StoryObj<typeof LoadingSpinner> = {}

--- a/packages/react/src/components/LoadingSpinner/index.tsx
+++ b/packages/react/src/components/LoadingSpinner/index.tsx
@@ -72,7 +72,7 @@ const Icon = styled.div.attrs({ role: 'presentation' })<{ once: boolean }>`
   }
 `
 
-interface Props {
+type Props = {
   once?: boolean
 }
 


### PR DESCRIPTION
## やったこと

- LoadingSpinnerのstoryをCSF3にした
- IconLoadingSpinnerのPropsをinterfaceではなくtypeを使って宣言するようにした
   - よく分からないエラーが出たため
   - 
<img width="530" alt="image" src="https://github.com/pixiv/charcoal/assets/103708329/f71da09f-4774-473b-8089-e1387aa10365">


## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
