### PR TITLE
fix: cursor to default when Radio and Checkbox are disabled

### DIFF
--- a/packages/react/src/components/Checkbox/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Checkbox/__snapshots__/index.story.storyshot
@@ -39,6 +39,14 @@ exports[`Storybook Tests Checkbox Invalid 1`] = `
   cursor: default;
 }
 
+.c2[type='checkbox']:-moz-read-only {
+  cursor: default;
+}
+
+.c2[type='checkbox']:read-only {
+  cursor: default;
+}
+
 .c2[type='checkbox']:checked {
   background-color: var(--charcoal-brand);
 }
@@ -140,6 +148,7 @@ exports[`Storybook Tests Checkbox Invalid 1`] = `
         onTouchEnd={[Function]}
         onTouchMove={[Function]}
         onTouchStart={[Function]}
+        readOnly={false}
         type="checkbox"
       />
       <div
@@ -198,6 +207,14 @@ exports[`Storybook Tests Checkbox Labelled 1`] = `
 }
 
 .c2[type='checkbox']:disabled {
+  cursor: default;
+}
+
+.c2[type='checkbox']:-moz-read-only {
+  cursor: default;
+}
+
+.c2[type='checkbox']:read-only {
   cursor: default;
 }
 
@@ -309,6 +326,7 @@ exports[`Storybook Tests Checkbox Labelled 1`] = `
             onTouchEnd={[Function]}
             onTouchMove={[Function]}
             onTouchStart={[Function]}
+            readOnly={false}
             type="checkbox"
           />
           <div
@@ -357,6 +375,7 @@ exports[`Storybook Tests Checkbox Labelled 1`] = `
             onTouchEnd={[Function]}
             onTouchMove={[Function]}
             onTouchStart={[Function]}
+            readOnly={false}
             type="checkbox"
           />
           <div
@@ -426,6 +445,14 @@ exports[`Storybook Tests Checkbox Unlabelled 1`] = `
 }
 
 .c2[type='checkbox']:disabled {
+  cursor: default;
+}
+
+.c2[type='checkbox']:-moz-read-only {
+  cursor: default;
+}
+
+.c2[type='checkbox']:read-only {
   cursor: default;
 }
 
@@ -525,6 +552,7 @@ exports[`Storybook Tests Checkbox Unlabelled 1`] = `
           onTouchEnd={[Function]}
           onTouchMove={[Function]}
           onTouchStart={[Function]}
+          readOnly={false}
           type="checkbox"
         />
         <div

--- a/packages/react/src/components/Checkbox/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Checkbox/__snapshots__/index.story.storyshot
@@ -12,12 +12,8 @@ exports[`Storybook Tests Checkbox Invalid 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
-}
-
-.c0:disabled,
 .c0[aria-disabled]:not([aria-disabled='false']) {
+  cursor: default;
   opacity: 0.32;
 }
 
@@ -37,6 +33,10 @@ exports[`Storybook Tests Checkbox Invalid 1`] = `
   border-radius: 4px;
   -webkit-transition: 0.2s box-shadow,0.2s background-color;
   transition: 0.2s box-shadow,0.2s background-color;
+}
+
+.c2[type='checkbox']:disabled {
+  cursor: default;
 }
 
 .c2[type='checkbox']:checked {
@@ -174,12 +174,8 @@ exports[`Storybook Tests Checkbox Labelled 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
-}
-
-.c0:disabled,
 .c0[aria-disabled]:not([aria-disabled='false']) {
+  cursor: default;
   opacity: 0.32;
 }
 
@@ -199,6 +195,10 @@ exports[`Storybook Tests Checkbox Labelled 1`] = `
   border-radius: 4px;
   -webkit-transition: 0.2s box-shadow,0.2s background-color;
   transition: 0.2s box-shadow,0.2s background-color;
+}
+
+.c2[type='checkbox']:disabled {
+  cursor: default;
 }
 
 .c2[type='checkbox']:checked {
@@ -402,12 +402,8 @@ exports[`Storybook Tests Checkbox Unlabelled 1`] = `
 }
 
 .c0:disabled,
-.c0[aria-disabled]:not([aria-disabled=false]) {
-  cursor: default;
-}
-
-.c0:disabled,
 .c0[aria-disabled]:not([aria-disabled='false']) {
+  cursor: default;
   opacity: 0.32;
 }
 
@@ -427,6 +423,10 @@ exports[`Storybook Tests Checkbox Unlabelled 1`] = `
   border-radius: 4px;
   -webkit-transition: 0.2s box-shadow,0.2s background-color;
   transition: 0.2s box-shadow,0.2s background-color;
+}
+
+.c2[type='checkbox']:disabled {
+  cursor: default;
 }
 
 .c2[type='checkbox']:checked {

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -82,13 +82,11 @@ const InputRoot = styled.label`
   display: flex;
 
   cursor: pointer;
-  ${disabledSelector} {
-    cursor: default;
-  }
 
   gap: 4px;
   &:disabled,
   &[aria-disabled]:not([aria-disabled='false']) {
+    cursor: default;
     opacity: 0.32;
   }
 `
@@ -107,6 +105,10 @@ const CheckboxInput = styled.input`
     height: 20px;
     border-radius: 4px;
     transition: 0.2s box-shadow, 0.2s background-color;
+
+    &:disabled {
+      cursor: default;
+    }
 
     &:checked {
       background-color: var(--charcoal-brand);

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -4,7 +4,6 @@ import styled, { css } from 'styled-components'
 import { useCheckbox } from '@react-aria/checkbox'
 import { useObjectRef } from '@react-aria/utils'
 import { useToggleState } from 'react-stately'
-import { disabledSelector } from '@charcoal-ui/utils'
 
 import type { AriaCheckboxProps } from '@react-types/checkbox'
 import Icon from '../Icon'

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -58,7 +58,11 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     return (
       <InputRoot aria-disabled={isDisabled} className={props.className}>
         <CheckboxRoot>
-          <CheckboxInput type="checkbox" {...inputProps} />
+          <CheckboxInput
+            type="checkbox"
+            {...inputProps}
+            readOnly={props.readonly}
+          />
           <CheckboxInputOverlay aria-hidden={true} checked={inputProps.checked}>
             <Icon name="24/Check" unsafeNonGuidelineScale={2 / 3} />
           </CheckboxInputOverlay>
@@ -106,6 +110,9 @@ const CheckboxInput = styled.input`
     transition: 0.2s box-shadow, 0.2s background-color;
 
     &:disabled {
+      cursor: default;
+    }
+    &:read-only {
       cursor: default;
     }
 

--- a/packages/react/src/components/Radio/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Radio/__snapshots__/index.story.storyshot
@@ -12,9 +12,9 @@ exports[`Storybook Tests Radio Basic 1`] = `
   cursor: pointer;
 }
 
-.c2:disabled,
 .c2[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3[type='radio'] {
@@ -32,6 +32,10 @@ exports[`Storybook Tests Radio Basic 1`] = `
   background-color: var(--charcoal-surface1);
   -webkit-transition: 0.2s background-color,0.2s box-shadow;
   transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c3[type='radio']:disabled {
+  cursor: default;
 }
 
 .c3[type='radio']:not(:disabled):not([aria-disabled]):hover,
@@ -244,9 +248,9 @@ exports[`Storybook Tests Radio Disabled 1`] = `
   cursor: pointer;
 }
 
-.c2:disabled,
 .c2[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3[type='radio'] {
@@ -264,6 +268,10 @@ exports[`Storybook Tests Radio Disabled 1`] = `
   background-color: var(--charcoal-surface1);
   -webkit-transition: 0.2s background-color,0.2s box-shadow;
   transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c3[type='radio']:disabled {
+  cursor: default;
 }
 
 .c3[type='radio']:not(:disabled):not([aria-disabled]):hover,
@@ -476,9 +484,9 @@ exports[`Storybook Tests Radio Invalid 1`] = `
   cursor: pointer;
 }
 
-.c2:disabled,
 .c2[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3[type='radio'] {
@@ -496,6 +504,10 @@ exports[`Storybook Tests Radio Invalid 1`] = `
   background-color: var(--charcoal-surface1);
   -webkit-transition: 0.2s background-color,0.2s box-shadow;
   transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c3[type='radio']:disabled {
+  cursor: default;
 }
 
 .c3[type='radio']:not(:disabled):not([aria-disabled]):hover,
@@ -709,9 +721,9 @@ exports[`Storybook Tests Radio PartialDisabled 1`] = `
   cursor: pointer;
 }
 
-.c2:disabled,
 .c2[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3[type='radio'] {
@@ -729,6 +741,10 @@ exports[`Storybook Tests Radio PartialDisabled 1`] = `
   background-color: var(--charcoal-surface1);
   -webkit-transition: 0.2s background-color,0.2s box-shadow;
   transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c3[type='radio']:disabled {
+  cursor: default;
 }
 
 .c3[type='radio']:not(:disabled):not([aria-disabled]):hover,
@@ -941,9 +957,9 @@ exports[`Storybook Tests Radio Readonly 1`] = `
   cursor: pointer;
 }
 
-.c2:disabled,
 .c2[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
+  cursor: default;
 }
 
 .c3[type='radio'] {
@@ -961,6 +977,10 @@ exports[`Storybook Tests Radio Readonly 1`] = `
   background-color: var(--charcoal-surface1);
   -webkit-transition: 0.2s background-color,0.2s box-shadow;
   transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c3[type='radio']:disabled {
+  cursor: default;
 }
 
 .c3[type='radio']:not(:disabled):not([aria-disabled]):hover,

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -65,9 +65,9 @@ const RadioRoot = styled.label`
   align-items: center;
   cursor: pointer;
 
-  &:disabled,
   &[aria-disabled]:not([aria-disabled='false']) {
     opacity: 0.32;
+    cursor: default;
   }
 `
 
@@ -87,6 +87,10 @@ export const RadioInput = styled.input.attrs({ type: 'radio' })`
     border-radius: 999999px;
     background-color: var(--charcoal-surface1);
     transition: 0.2s background-color, 0.2s box-shadow;
+
+    :disabled {
+      cursor: default;
+    }
 
     &:not(:disabled):not([aria-disabled]),
     &[aria-disabled='false'] {


### PR DESCRIPTION
## やったこと

- Changed the cursor style to default for Radio and Checkbox when disabled.
- This change was made to provide a user experience similar to that of buttons.
- Correctly applied the readonly attribute to the Checkbox input.