### PR TITLE
docs: fix switch layout

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/Switch/index.page.tsx
+++ b/docs/src/pages/@charcoal-ui/react/Switch/index.page.tsx
@@ -35,7 +35,9 @@ const SwitchPage: NextPage<{ src: string }> = (props) => {
 
       <h2>BASIC</h2>
       <PreviewDivColumn>
-        <ExampleSwitch />
+        <div>
+          <ExampleSwitch />
+        </div>
         <SSRHighlight lang="typescript" code={props.src} />
       </PreviewDivColumn>
 


### PR DESCRIPTION
## やったこと

- fix: #467 
  - The exact cause is unclear, but as a temporary workaround, we have enclosed it in a div.