### PR TITLE
Replace multiselect icon with icon component

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -13,8 +13,6 @@ const config: TestRunnerConfig = {
       customSnapshotIdentifier: context.id,
       customDiffDir: `${process.cwd()}/__diff_output__`,
       customSnapshotsDir: `${process.cwd()}/__image_snapshots__`,
-      failureThresholdType: 'percent',
-      failureThreshold: 0.0001,
     })
   },
   tags: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,6 +8,15 @@ globalThis.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }))
 
+global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+  observe() {
+    return null
+  },
+  disconnect() {
+    return null
+  },
+}))
+
 window.matchMedia = jest.fn().mockImplementation((query: string) => ({
   matches: false,
   media: query,

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -6,6 +6,7 @@ import { px } from '@charcoal-ui/utils'
 
 import { MultiSelectGroupContext } from './context'
 import { focusVisibleFocusRingCss } from '@charcoal-ui/styled'
+import Icon from '../Icon'
 
 export type MultiSelectProps = React.PropsWithChildren<{
   value: string
@@ -76,7 +77,7 @@ const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
           invalid={invalid}
           aria-hidden={true}
         >
-          <pixiv-icon name="24/Check" unsafe-non-guideline-scale={16 / 24} />
+          <Icon name="24/Check" unsafe-non-guideline-scale={16 / 24} />
         </MultiSelectInputOverlay>
         {Boolean(children) && <MultiSelectLabel>{children}</MultiSelectLabel>}
       </MultiSelectRoot>


### PR DESCRIPTION
## やったこと

- Replace multiselect icon with icon component from `<pixiv-icon>`

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
