### PR TITLE
chore(storybook): apply docs theming

### DIFF
--- a/.storybook/docs-container.tsx
+++ b/.storybook/docs-container.tsx
@@ -1,0 +1,16 @@
+import React, { ComponentPropsWithoutRef, FC } from 'react'
+import { DocsContainer as BaseContainer } from '@storybook/addon-docs'
+import { useDarkMode } from 'storybook-dark-mode'
+import { themes } from '@storybook/theming'
+
+export const DocsContainer: FC<
+  ComponentPropsWithoutRef<typeof BaseContainer>
+> = ({ children, ...rest }) => {
+  const dark = useDarkMode()
+
+  return (
+    <BaseContainer {...rest} theme={dark ? themes.dark : themes.light}>
+      {children}
+    </BaseContainer>
+  )
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,9 @@
 import themeDecorator from './theme-decorator'
+import { DocsContainer } from './docs-container'
+
 import './global.css'
 
+/** @type  */
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z0-9].*' },
   controls: {
@@ -8,6 +11,10 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  viewMode: 'docs',
+  docs: {
+    container: DocsContainer,
   },
 }
 


### PR DESCRIPTION
## やったこと

- docs の表示をテーマに合わせて変わるように変更

## 動作確認環境
- storybook

|light|dark|
|---|---|
|[![Image from Gyazo](https://i.gyazo.com/3f79a8a7e34d6860ff49d2cb9854bc87.png)](https://gyazo.com/3f79a8a7e34d6860ff49d2cb9854bc87)|[![Image from Gyazo](https://i.gyazo.com/1e386aca71d9794adcacdc4878c34eab.png)](https://gyazo.com/1e386aca71d9794adcacdc4878c34eab)|

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
