### PR TITLE
fix: skip build story and test dts

### DIFF
--- a/packages/react-sandbox/tsconfig.build.json
+++ b/packages/react-sandbox/tsconfig.build.json
@@ -5,5 +5,11 @@
     "outDir": "./dist",
     "tsBuildInfoFile": "./.tsbuildinfo"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": [
+    "./src/**/*.story.ts",
+    "./src/**/*.story.tsx",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ]
 }

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -5,5 +5,11 @@
     "outDir": "./dist",
     "tsBuildInfoFile": "./.tsbuildinfo"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": [
+    "./src/**/*.story.ts",
+    "./src/**/*.story.tsx",
+    "./src/**/*.test.ts",
+    "./src/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## やったこと

- exclude dts generation of stories and tests

Currently stories and tests dts are generated and distributed inside the package but it's not necessary. 
It 
1. makes review harder to do (https://app.renovatebot.com/package-diff?name=@charcoal-ui%2freact&from=3.9.1&to=3.10.0) 

2. mess the import suggestions

<img width="844" alt="Screenshot 2024-04-08 at 14 37 04" src="https://github.com/pixiv/charcoal/assets/26110087/902a22ab-02d4-4b85-b539-81f30054db64">

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
