### PR TITLE
feat: allow type radio group value

### DIFF
--- a/packages/react/src/components/Radio/index.story.tsx
+++ b/packages/react/src/components/Radio/index.story.tsx
@@ -17,15 +17,16 @@ const LayoutDiv = styled.div`
   flex-direction: column;
   gap: ${({ theme }) => px(theme.spacing[24])};
 `
+const options = ['1', '2', '3'] as const
+type Option = typeof options[number];
 
 export const Default: StoryObj<typeof Radio> = {
   render: function Render(args) {
-    const options = ['1', '2', '3']
-    const [value, setValue] = useState(options[0])
+    const [value, setValue] = useState<Option>(options[0])
 
     return (
       <LayoutDiv>
-        <RadioGroup
+        <RadioGroup<Option>
           label={'label'}
           name={'name'}
           {...args}
@@ -45,11 +46,11 @@ export const Default: StoryObj<typeof Radio> = {
 
 export const Disabled: StoryObj<typeof Radio> = {
   render: function Render() {
-    const options = ['1', '2', '3']
-    const [value, setValue] = useState(options[0])
+    const [value, setValue] = useState<Option>(options[0])
+
     return (
       <LayoutDiv>
-        <RadioGroup
+        <RadioGroup<Option>
           label={'label'}
           name={'name'}
           value={value}
@@ -69,11 +70,11 @@ export const Disabled: StoryObj<typeof Radio> = {
 
 export const PartialDisabled: StoryObj<typeof Radio> = {
   render: function Render() {
-    const options = ['1', '2', '3']
-    const [value, setValue] = useState(options[0])
+    const [value, setValue] = useState<Option>(options[0])
+
     return (
       <LayoutDiv>
-        <RadioGroup
+        <RadioGroup<Option>
           label={'label'}
           name={'name'}
           value={value}
@@ -92,11 +93,11 @@ export const PartialDisabled: StoryObj<typeof Radio> = {
 
 export const Readonly: StoryObj<typeof Radio> = {
   render: function Render() {
-    const options = ['1', '2', '3']
-    const [value, setValue] = useState(options[0])
+    const [value, setValue] = useState<Option>(options[0])
+
     return (
       <LayoutDiv>
-        <RadioGroup
+        <RadioGroup<Option>
           label={'label'}
           name={'name'}
           value={value}
@@ -116,11 +117,11 @@ export const Readonly: StoryObj<typeof Radio> = {
 
 export const Invalid: StoryObj<typeof Radio> = {
   render: function Render() {
-    const options = ['1', '2', '3']
-    const [value, setValue] = useState(options[0])
+    const [value, setValue] = useState<Option>(options[0])
+
     return (
       <LayoutDiv>
-        <RadioGroup
+        <RadioGroup<Option>
           label={'label'}
           name={'name'}
           value={value}

--- a/packages/react/src/components/Radio/index.story.tsx
+++ b/packages/react/src/components/Radio/index.story.tsx
@@ -18,7 +18,7 @@ const LayoutDiv = styled.div`
   gap: ${({ theme }) => px(theme.spacing[24])};
 `
 const options = ['1', '2', '3'] as const
-type Option = typeof options[number];
+type Option = (typeof options)[number]
 
 export const Default: StoryObj<typeof Radio> = {
   render: function Render(args) {

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -169,12 +169,12 @@ const RadioLabel = styled.div`
   }
 `
 
-export type RadioGroupProps = React.PropsWithChildren<{
+export type RadioGroupProps<Value extends string = string> = React.PropsWithChildren<{
   className?: string
-  value?: string
+  value?: Value
   label: string
   name: string
-  onChange(next: string): void
+  onChange(next: Value): void
   disabled?: boolean
   readonly?: boolean
   invalid?: boolean
@@ -209,7 +209,7 @@ const RadioGroupContext = React.createContext<RadioGroupContext>({
   },
 })
 
-export function RadioGroup({
+export function RadioGroup<Value extends string = string>({
   className,
   value,
   label,
@@ -219,10 +219,10 @@ export function RadioGroup({
   readonly,
   invalid,
   children,
-}: RadioGroupProps) {
+}: RadioGroupProps<Value>) {
   const handleChange = useCallback(
     (next: string) => {
-      onChange(next)
+      onChange(next as Value)
     },
     [onChange]
   )

--- a/packages/react/src/components/Radio/index.tsx
+++ b/packages/react/src/components/Radio/index.tsx
@@ -169,16 +169,17 @@ const RadioLabel = styled.div`
   }
 `
 
-export type RadioGroupProps<Value extends string = string> = React.PropsWithChildren<{
-  className?: string
-  value?: Value
-  label: string
-  name: string
-  onChange(next: Value): void
-  disabled?: boolean
-  readonly?: boolean
-  invalid?: boolean
-}>
+export type RadioGroupProps<Value extends string = string> =
+  React.PropsWithChildren<{
+    className?: string
+    value?: Value
+    label: string
+    name: string
+    onChange(next: Value): void
+    disabled?: boolean
+    readonly?: boolean
+    invalid?: boolean
+  }>
 
 // TODO: use (or polyfill) flex gap
 const StyledRadioGroup = styled.div`


### PR DESCRIPTION
## やったこと

- allow `RadioGroup` to accept generic `Value`type for `value` and `onChange` typing. I didn't find a easy way to infer type for this without generic. This should be backward compatible.

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
