### PR TITLE
v4 でも VRT を実行するように

### DIFF
--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -4,6 +4,7 @@ on:
     types: [labeled, unlabeled, opened, edited, synchronize]
     branches:
       - main
+      - v4.0.0
 
 jobs:
   prepare-main-branch:


### PR DESCRIPTION
## やったこと

- v4 でも VRT を実行するように

## 動作確認環境
- ci

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
