### PR TITLE
feat: update TextField and TextArea API

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextArea/apiData.tsx
@@ -1,22 +1,10 @@
 import { TextAreaProps } from '@charcoal-ui/react'
-import { TableItem } from '../_components/ApiTable'
+import { ApiTableData } from '../_components/ApiTable'
 
 export const apiData: Omit<
-  Record<
-    Exclude<
-      keyof TextAreaProps,
-      keyof React.InputHTMLAttributes<HTMLTextAreaElement>
-    >,
-    TableItem
-  >,
-  'type' | 'value' | 'cols' | 'dirName' | 'wrap'
+  ApiTableData<TextAreaProps, HTMLInputElement>,
+  keyof React.HTMLProps<HTMLInputElement> | 'dirName'
 > = {
-  label: {
-    default: '',
-    description: 'ラベル',
-    required: true,
-    type: 'string',
-  },
   assistiveText: {
     description: 'エラーのテキスト',
     type: 'string',
@@ -36,11 +24,6 @@ export const apiData: Omit<
     description: '必須を示すのテキスト',
     type: 'string',
   },
-  rows: {
-    default: '',
-    description: '表示する行数、multilineのみ有効',
-    type: 'number',
-  },
   showCount: {
     default: 'false',
     description: '入力文字数の表示',
@@ -54,5 +37,9 @@ export const apiData: Omit<
   subLabel: {
     description: '右側に表示されるラベル',
     type: 'string',
+  },
+  getCount: {
+    description: 'textの長さを計算する関数',
+    type: '(value: string) => number',
   },
 }

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -41,7 +41,7 @@ export const apiData: Omit<
     description: 'textの長さを計算する関数',
     type: '(value: string) => number',
   },
-  htmlPrefix: {
+  rdfaPredix: {
     description: 'input要素のprefix',
     type: 'string',
   },

--- a/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/TextField/apiData.tsx
@@ -1,22 +1,10 @@
 import { TextFieldProps } from '@charcoal-ui/react'
-import { TableItem } from '../_components/ApiTable'
+import { ApiTableData } from '../_components/ApiTable'
 
 export const apiData: Omit<
-  Record<
-    Exclude<
-      keyof TextFieldProps,
-      keyof React.InputHTMLAttributes<HTMLInputElement>
-    >,
-    TableItem
-  >,
-  'type' | 'value'
+  ApiTableData<TextFieldProps, HTMLInputElement>,
+  keyof React.HTMLProps<HTMLInputElement> | 'enterKeyHint'
 > = {
-  label: {
-    default: '',
-    description: 'ラベル',
-    required: true,
-    type: 'string',
-  },
   assistiveText: {
     description: 'エラーのテキスト',
     type: 'string',
@@ -48,5 +36,13 @@ export const apiData: Omit<
   suffix: {
     description: 'フィールドの末尾の要素、multilineでは無効',
     type: 'ReactNode',
+  },
+  getCount: {
+    description: 'textの長さを計算する関数',
+    type: '(value: string) => number',
+  },
+  htmlPrefix: {
+    description: 'input要素のprefix',
+    type: 'string',
   },
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -195,7 +195,7 @@ __metadata:
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
   version: 4.0.0-beta.4
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=eb9106&locator=charcoal-web-docs%40workspace%3A."
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=ad4272&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
     "@charcoal-ui/foundation": ^4.0.0-beta.4
     "@charcoal-ui/icons": ^4.0.0-beta.4
@@ -210,7 +210,6 @@ __metadata:
     "@react-aria/radio": ^3.10.0
     "@react-aria/ssr": ^3.9.1
     "@react-aria/switch": ^3.6.0
-    "@react-aria/textfield": ^3.14.1
     "@react-aria/utils": ^3.23.0
     "@react-aria/visually-hidden": ^3.8.8
     "@react-stately/radio": ^3.10.2
@@ -221,7 +220,7 @@ __metadata:
   peerDependencies:
     react: ">=17.0.0"
     styled-components: ">=5.1.1"
-  checksum: 0e37c93ee4867d748196b48a5b7c6780d8cddfcb4051bb60d42f93364883bc1f94efa7df1bf148d768a1c8b2a3e4ce795ea54aeafa2f1f7ad85859cebbd52d60
+  checksum: 16f091a0e3faddb16826416c1cd961323842348bb1ba61264dd841cdfd17b54d8cc6c80bd88ee8b6d45c8dc03be215301edbfb33edca10d7fe3816861d391794
   languageName: node
   linkType: hard
 
@@ -903,25 +902,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 7f08e52c28ba5f61263b507c8f2d472d2661695f884fcb80ae7a8de58deed38d2dd011b1c2079180ce49ccaf279171345ba5be56844ed10bc233e9fec73756ed
-  languageName: node
-  linkType: hard
-
-"@react-aria/textfield@npm:^3.14.1":
-  version: 3.14.1
-  resolution: "@react-aria/textfield@npm:3.14.1"
-  dependencies:
-    "@react-aria/focus": ^3.16.0
-    "@react-aria/form": ^3.0.1
-    "@react-aria/label": ^3.7.4
-    "@react-aria/utils": ^3.23.0
-    "@react-stately/form": ^3.0.0
-    "@react-stately/utils": ^3.9.0
-    "@react-types/shared": ^3.22.0
-    "@react-types/textfield": ^3.9.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: c1750b02fb0376726385ef4f8c62494bc911f75d6ee69789597ac656028743385a96e38569956090700d71355f25423a46c3bb25f8442d74ade9077353d1547b
   languageName: node
   linkType: hard
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -70,7 +70,6 @@
     "@react-aria/radio": "^3.10.0",
     "@react-aria/ssr": "^3.9.1",
     "@react-aria/switch": "^3.6.0",
-    "@react-aria/textfield": "^3.14.1",
     "@react-aria/utils": "^3.23.0",
     "@react-aria/visually-hidden": "^3.8.8",
     "@react-stately/radio": "^3.10.2",

--- a/packages/react/src/components/DropdownSelector/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/DropdownSelector/__snapshots__/index.story.storyshot
@@ -1784,21 +1784,18 @@ exports[`Storybook Tests DropdownSelector InModal 1`] = `
                 className="c20"
               >
                 <input
+                  aria-describedby="test-id"
                   aria-labelledby="test-id"
-                  aria-required={true}
                   className="c21"
-                  disabled={false}
                   id="test-id"
                   onChange={[Function]}
                   placeholder="placeholder"
-                  readOnly={false}
-                  required={false}
                   type="text"
-                  value=""
                 />
               </div>
               <p
                 className="c22"
+                id="test-id"
               >
                 assistiveText
               </p>
@@ -1811,7 +1808,6 @@ exports[`Storybook Tests DropdownSelector InModal 1`] = `
               >
                 <label
                   className="c9"
-                  htmlFor="test-id"
                   id="test-id"
                 >
                   TextArea
@@ -1832,21 +1828,18 @@ exports[`Storybook Tests DropdownSelector InModal 1`] = `
                 rows={4}
               >
                 <textarea
+                  aria-describedby="test-id"
                   aria-labelledby="test-id"
-                  aria-required={true}
                   className="c25"
-                  disabled={false}
                   id="test-id"
                   onChange={[Function]}
                   placeholder="placeholder"
-                  readOnly={false}
-                  required={false}
                   rows={4}
-                  value=""
                 />
               </div>
               <p
                 className="c22"
+                id="test-id"
               >
                 assistiveText
               </p>

--- a/packages/react/src/components/DropdownSelector/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/DropdownSelector/__snapshots__/index.story.storyshot
@@ -1808,6 +1808,7 @@ exports[`Storybook Tests DropdownSelector InModal 1`] = `
               >
                 <label
                   className="c9"
+                  htmlFor="test-id"
                   id="test-id"
                 >
                   TextArea

--- a/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
@@ -594,14 +594,10 @@ exports[`Storybook Tests Modal BackgroundScroll 1`] = `
                   <input
                     aria-labelledby="test-id"
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Nagisa"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>
@@ -635,14 +631,10 @@ exports[`Storybook Tests Modal BackgroundScroll 1`] = `
                     aria-labelledby="test-id"
                     autoFocus={true}
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Tokyo"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>
@@ -1694,14 +1686,10 @@ exports[`Storybook Tests Modal Default 1`] = `
                   <input
                     aria-labelledby="test-id"
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Nagisa"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>
@@ -1735,14 +1723,10 @@ exports[`Storybook Tests Modal Default 1`] = `
                     aria-labelledby="test-id"
                     autoFocus={true}
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Tokyo"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>
@@ -2373,14 +2357,10 @@ exports[`Storybook Tests Modal FullBottomSheet 1`] = `
                   <input
                     aria-labelledby="test-id"
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Nagisa"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>
@@ -2413,14 +2393,10 @@ exports[`Storybook Tests Modal FullBottomSheet 1`] = `
                   <input
                     aria-labelledby="test-id"
                     className="c16"
-                    disabled={false}
                     id="test-id"
                     onChange={[Function]}
                     placeholder="Tokyo"
-                    readOnly={false}
-                    required={false}
                     type="text"
-                    value=""
                   />
                 </div>
               </div>

--- a/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
+++ b/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
@@ -428,7 +428,6 @@ exports[`Storybook Tests TextArea AutoHeight 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -648,7 +647,6 @@ exports[`Storybook Tests TextArea Default 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-invalid={false}
         aria-labelledby="test-id"
         className="c7"
@@ -866,7 +864,6 @@ exports[`Storybook Tests TextArea Disabled 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -1294,7 +1291,6 @@ exports[`Storybook Tests TextArea Label 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -1507,7 +1503,6 @@ exports[`Storybook Tests TextArea Placeholder 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -1721,7 +1716,6 @@ exports[`Storybook Tests TextArea ReadOnly 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -1968,7 +1962,6 @@ exports[`Storybook Tests TextArea Required 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c9"
         id="test-id"
@@ -2190,7 +2183,6 @@ exports[`Storybook Tests TextArea ShowCount 1`] = `
       rows={5}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"
@@ -2401,7 +2393,6 @@ exports[`Storybook Tests TextArea SubLabel 1`] = `
       rows={4}
     >
       <textarea
-        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
         id="test-id"

--- a/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
+++ b/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
@@ -193,6 +193,7 @@ exports[`Storybook Tests TextArea AssistiveText 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -411,6 +412,7 @@ exports[`Storybook Tests TextArea AutoHeight 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -661,6 +663,7 @@ exports[`Storybook Tests TextArea Default 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -884,6 +887,7 @@ exports[`Storybook Tests TextArea Disabled 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1106,6 +1110,7 @@ exports[`Storybook Tests TextArea Invalid 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1311,6 +1316,7 @@ exports[`Storybook Tests TextArea Label 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1523,6 +1529,7 @@ exports[`Storybook Tests TextArea Placeholder 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1736,6 +1743,7 @@ exports[`Storybook Tests TextArea ReadOnly 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1977,6 +1985,7 @@ exports[`Storybook Tests TextArea Required 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -2203,6 +2212,7 @@ exports[`Storybook Tests TextArea ShowCount 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -2445,6 +2455,7 @@ exports[`Storybook Tests TextArea SubLabel 1`] = `
     >
       <label
         className="c3"
+        htmlFor="test-id"
         id="test-id"
       >
         Label

--- a/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
+++ b/packages/react/src/components/TextArea/__snapshots__/TextArea.story.storyshot
@@ -193,7 +193,6 @@ exports[`Storybook Tests TextArea AssistiveText 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -209,19 +208,17 @@ exports[`Storybook Tests TextArea AssistiveText 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
     <p
       className="c8"
+      id="test-id"
     >
       説明が入ります
     </p>
@@ -414,7 +411,6 @@ exports[`Storybook Tests TextArea AutoHeight 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -430,15 +426,12 @@ exports[`Storybook Tests TextArea AutoHeight 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -668,7 +661,6 @@ exports[`Storybook Tests TextArea Default 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -691,16 +683,15 @@ exports[`Storybook Tests TextArea Default 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
+        aria-invalid={false}
         aria-labelledby="test-id"
         className="c8"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         placeholder="Text Area"
         readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -893,7 +884,6 @@ exports[`Storybook Tests TextArea Disabled 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -910,15 +900,12 @@ exports[`Storybook Tests TextArea Disabled 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={true}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -1119,7 +1106,6 @@ exports[`Storybook Tests TextArea Invalid 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1135,20 +1121,18 @@ exports[`Storybook Tests TextArea Invalid 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-invalid={true}
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
     <p
       className="c8"
+      id="test-id"
     >
       エラーメッセージ
     </p>
@@ -1327,7 +1311,6 @@ exports[`Storybook Tests TextArea Label 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1343,15 +1326,12 @@ exports[`Storybook Tests TextArea Label 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -1543,7 +1523,6 @@ exports[`Storybook Tests TextArea Placeholder 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1559,16 +1538,13 @@ exports[`Storybook Tests TextArea Placeholder 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         placeholder="Placeholder"
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -1760,7 +1736,6 @@ exports[`Storybook Tests TextArea ReadOnly 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -1776,13 +1751,12 @@ exports[`Storybook Tests TextArea ReadOnly 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         readOnly={true}
-        required={false}
         rows={4}
         value="読み取り専用"
       />
@@ -2003,7 +1977,6 @@ exports[`Storybook Tests TextArea Required 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -2024,16 +1997,12 @@ exports[`Storybook Tests TextArea Required 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
-        aria-required={true}
         className="c9"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>
@@ -2234,7 +2203,6 @@ exports[`Storybook Tests TextArea ShowCount 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -2250,16 +2218,13 @@ exports[`Storybook Tests TextArea ShowCount 1`] = `
       rows={5}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         maxLength={100}
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
       <span
         className="c8"
@@ -2480,7 +2445,6 @@ exports[`Storybook Tests TextArea SubLabel 1`] = `
     >
       <label
         className="c3"
-        htmlFor="test-id"
         id="test-id"
       >
         Label
@@ -2502,15 +2466,12 @@ exports[`Storybook Tests TextArea SubLabel 1`] = `
       rows={4}
     >
       <textarea
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c8"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         rows={4}
-        value=""
       />
     </div>
   </div>

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -118,7 +118,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           rows={showCount ? rows + 1 : rows}
         >
           <StyledTextarea
-            aria-describedby={describedbyId}
+            aria-describedby={showAssistiveText ? describedbyId : undefined}
             aria-invalid={props.invalid}
             aria-labelledby={labelledbyId}
             id={textAreaId}

--- a/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
+++ b/packages/react/src/components/TextField/__snapshots__/TextField.story.storyshot
@@ -235,13 +235,9 @@ exports[`Storybook Tests TextField Affix 1`] = `
       <input
         aria-labelledby="test-id"
         className="c8"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
       <span
         className="c9"
@@ -466,19 +462,17 @@ exports[`Storybook Tests TextField AssistiveText 1`] = `
       className="c6"
     >
       <input
+        aria-describedby="test-id"
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
     <p
       className="c8"
+      id="test-id"
     >
       説明が入ります
     </p>
@@ -735,16 +729,14 @@ exports[`Storybook Tests TextField Default 1`] = `
       className="c7"
     >
       <input
+        aria-invalid={false}
         aria-labelledby="test-id"
         className="c8"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         placeholder="TextField"
         readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -960,13 +952,9 @@ exports[`Storybook Tests TextField Disabled 1`] = `
       <input
         aria-labelledby="test-id"
         className="c7"
-        disabled={true}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -1187,20 +1175,18 @@ exports[`Storybook Tests TextField Invalid 1`] = `
       className="c6"
     >
       <input
+        aria-describedby="test-id"
         aria-invalid={true}
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
     <p
       className="c8"
+      id="test-id"
     >
       エラーメッセージ
     </p>
@@ -1401,13 +1387,9 @@ exports[`Storybook Tests TextField Label 1`] = `
       <input
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -1604,7 +1586,11 @@ exports[`Storybook Tests TextField Number 1`] = `
     >
       <label
         className="c3"
-      />
+        htmlFor="test-id"
+        id="test-id"
+      >
+        
+      </label>
       <div
         className="c4 c5"
       >
@@ -1615,13 +1601,11 @@ exports[`Storybook Tests TextField Number 1`] = `
       className="c6"
     >
       <input
+        aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         onWheel={[Function]}
-        readOnly={false}
-        required={false}
         type="number"
         value="0"
       />
@@ -1837,14 +1821,10 @@ exports[`Storybook Tests TextField Placeholder 1`] = `
       <input
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         placeholder="Placeholder"
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -2092,13 +2072,9 @@ exports[`Storybook Tests TextField Prefix 1`] = `
       <input
         aria-labelledby="test-id"
         className="c9"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -2312,11 +2288,9 @@ exports[`Storybook Tests TextField ReadOnly 1`] = `
       <input
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
         readOnly={true}
-        required={false}
         type="text"
         value="読み取り専用"
       />
@@ -2549,15 +2523,10 @@ exports[`Storybook Tests TextField RequiredText 1`] = `
     >
       <input
         aria-labelledby="test-id"
-        aria-required={true}
         className="c9"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>
@@ -2789,14 +2758,10 @@ exports[`Storybook Tests TextField ShowCount 1`] = `
       <input
         aria-labelledby="test-id"
         className="c7"
-        disabled={false}
         id="test-id"
         maxLength={100}
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
       <span
         className="c8"
@@ -3063,13 +3028,9 @@ exports[`Storybook Tests TextField SubLabel 1`] = `
       <input
         aria-labelledby="test-id"
         className="c8"
-        disabled={false}
         id="test-id"
         onChange={[Function]}
-        readOnly={false}
-        required={false}
         type="text"
-        value=""
       />
     </div>
   </div>

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -23,7 +23,7 @@ export type TextFieldProps = {
   requiredText?: string
   disabled?: boolean
   subLabel?: React.ReactNode
-  htmlPrefix?: string
+  rdfaPredix?: string
 
   getCount?: (value: string) => number
 } & Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix' | 'onChange'>
@@ -112,7 +112,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             invalid={props.invalid === true}
             maxLength={maxLength}
             onChange={handleChange}
-            prefix={props.htmlPrefix}
+            prefix={props.rdfaPredix}
             ref={mergeRefs(forwardRef, inputRef)}
             type={type}
             value={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,7 +2674,6 @@ __metadata:
     "@react-aria/radio": ^3.10.0
     "@react-aria/ssr": ^3.9.1
     "@react-aria/switch": ^3.6.0
-    "@react-aria/textfield": ^3.14.1
     "@react-aria/utils": ^3.23.0
     "@react-aria/visually-hidden": ^3.8.8
     "@react-stately/radio": ^3.10.2
@@ -6087,25 +6086,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 7f08e52c28ba5f61263b507c8f2d472d2661695f884fcb80ae7a8de58deed38d2dd011b1c2079180ce49ccaf279171345ba5be56844ed10bc233e9fec73756ed
-  languageName: node
-  linkType: hard
-
-"@react-aria/textfield@npm:^3.14.1":
-  version: 3.14.1
-  resolution: "@react-aria/textfield@npm:3.14.1"
-  dependencies:
-    "@react-aria/focus": ^3.16.0
-    "@react-aria/form": ^3.0.1
-    "@react-aria/label": ^3.7.4
-    "@react-aria/utils": ^3.23.0
-    "@react-stately/form": ^3.0.0
-    "@react-stately/utils": ^3.9.0
-    "@react-types/shared": ^3.22.0
-    "@react-types/textfield": ^3.9.0
-    "@swc/helpers": ^0.5.0
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-  checksum: c1750b02fb0376726385ef4f8c62494bc911f75d6ee69789597ac656028743385a96e38569956090700d71355f25423a46c3bb25f8442d74ade9077353d1547b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## やったこと

### Textfield, TextArea
- Modify props to inherit properties from the native element.
  - Added a getCount prop to calculate text length using a custom function.
- Removed useTextField.

## 動作確認環境
- Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
