### PR TITLE
feat: add modal button aria label and export ModalCloseButton

### DIFF
--- a/packages/react/src/components/IconButton/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/IconButton/__snapshots__/index.story.storyshot
@@ -106,6 +106,7 @@ exports[`Storybook Tests react/IconButton Default 1`] = `
     title="add"
   >
     <pixiv-icon
+      aria-hidden="true"
       name="16/Add"
     />
   </button>
@@ -211,6 +212,7 @@ exports[`Storybook Tests react/IconButton IsActive 1`] = `
     className="c0 c1"
   >
     <pixiv-icon
+      aria-hidden="true"
       name="16/Add"
     />
   </button>
@@ -322,6 +324,7 @@ exports[`Storybook Tests react/IconButton Overlay 1`] = `
     className="c0 c1"
   >
     <pixiv-icon
+      aria-hidden="true"
       name="16/Add"
     />
   </button>

--- a/packages/react/src/components/IconButton/index.tsx
+++ b/packages/react/src/components/IconButton/index.tsx
@@ -36,7 +36,7 @@ const IconButton = forwardRef<ClickableElement, IconButtonProps>(
         $variant={variant}
         $isActive={isActive}
       >
-        <pixiv-icon name={icon} />
+        <pixiv-icon aria-hidden="true" name={icon} />
       </StyledIconButton>
     )
   }

--- a/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
@@ -940,10 +940,13 @@ exports[`Storybook Tests react/Modal BackgroundScroll 1`] = `
           </div>
         </div>
         <button
+          aria-label="Close"
           className="c0 c27 c28"
           onClick={[Function]}
+          type="button"
         >
           <pixiv-icon
+            aria-hidden="true"
             name="24/Close"
           />
         </button>
@@ -1420,10 +1423,13 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
           </div>
         </div>
         <button
+          aria-label="Close"
           className="c0 c13 c14"
           onClick={[Function]}
+          type="button"
         >
           <pixiv-icon
+            aria-hidden="true"
             name="24/Close"
           />
         </button>
@@ -2365,10 +2371,13 @@ exports[`Storybook Tests react/Modal Default 1`] = `
           </div>
         </div>
         <button
+          aria-label="Close"
           className="c0 c27 c28"
           onClick={[Function]}
+          type="button"
         >
           <pixiv-icon
+            aria-hidden="true"
             name="24/Close"
           />
         </button>
@@ -3162,10 +3171,13 @@ exports[`Storybook Tests react/Modal FullBottomSheet 1`] = `
           </div>
         </div>
         <button
+          aria-label="Close"
           className="c0 c22 c23"
           onClick={[Function]}
+          type="button"
         >
           <pixiv-icon
+            aria-hidden="true"
             name="24/Close"
           />
         </button>

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -164,7 +164,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
                 >
                   {children}
                   {isDismissable === true && (
-                    <ModalCrossButton
+                    <ModalCloseButton
                       size="S"
                       icon="24/Close"
                       type="button"
@@ -228,7 +228,7 @@ const ModalBackground = animated(styled.div<{
   }
 `)
 
-const ModalCrossButton = styled(IconButton)`
+export const ModalCloseButton = styled(IconButton)`
   position: absolute;
   top: 8px;
   right: 8px;

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -26,6 +26,7 @@ export type ModalProps = AriaModalOverlayProps &
     isOpen: boolean
     onClose: () => void
     className?: string
+    closeButtonAriaLabel?: string
 
     /**
      * https://github.com/adobe/react-spectrum/issues/3787
@@ -74,6 +75,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
     onClose,
     className,
     isOpen = false,
+    closeButtonAriaLabel = 'Close',
   } = props
 
   const ref = useObjectRef<HTMLDivElement>(external)
@@ -165,6 +167,8 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
                     <ModalCrossButton
                       size="S"
                       icon="24/Close"
+                      type="button"
+                      aria-label={closeButtonAriaLabel}
                       onClick={onClose}
                     />
                   )}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -38,7 +38,11 @@ export {
 } from './components/TextField'
 export { default as TextArea, type TextAreaProps } from './components/TextArea'
 export { default as Icon, type IconProps } from './components/Icon'
-export { default as Modal, type ModalProps } from './components/Modal'
+export {
+  default as Modal,
+  type ModalProps,
+  ModalCloseButton,
+} from './components/Modal'
 export {
   ModalHeader,
   ModalAlign,


### PR DESCRIPTION
## やったこと

- add `closeButtonAriaLabel` for `Modal` and `aria-hidden` for pixiv-icon inside.
- rename and export `ModalCloseButton`

Before:
![Screenshot 2024-06-02 at 23 22 15](https://github.com/pixiv/charcoal/assets/26110087/adcece8b-f1c4-48ee-a1c6-90e9e23da478)

After:

![Screenshot 2024-06-02 at 23 21 58](https://github.com/pixiv/charcoal/assets/26110087/b5155b28-7e4c-4a59-a15e-148fdf322145)


## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
