### PR TITLE
Fix for closeButtonAriaLabel in Modal docs

### DIFF
--- a/docs/src/pages/@charcoal-ui/react/Modal/apiData.tsx
+++ b/docs/src/pages/@charcoal-ui/react/Modal/apiData.tsx
@@ -50,4 +50,9 @@ export const apiData: Omit<
     description: 'z-index',
     type: 'number',
   },
+  closeButtonAriaLabel: {
+    default: '',
+    description: 'Pass to Modal close button `aria-label` attribute',
+    type: 'string',
+  },
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -169,38 +169,39 @@ __metadata:
   linkType: hard
 
 "@charcoal-ui/foundation@file:../packages/foundation::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=2bc4f8&locator=charcoal-web-docs%40workspace%3A."
-  checksum: a2c4fc8f02f2ee955f6270e0c0b60e7d54ad3d1ed076f6773a983915759b70b1bb5cd3e77e0ef796212cd0bcc977c0f0c23eac924a5543d184cd060e0451970b
+  version: 3.12.0
+  resolution: "@charcoal-ui/foundation@file:../packages/foundation#../packages/foundation::hash=0f6ac5&locator=charcoal-web-docs%40workspace%3A."
+  checksum: 8c7c67696bca731fa84b6b583d2e5bef02ba8695a6090fbdf650b2fd77600c46dbb4e2ec5a221df65085cd074603fb09ff16f81a0760bbf2f2518c17079030cb
   languageName: node
   linkType: hard
 
 "@charcoal-ui/icon-files@file:../packages/icon-files::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/icon-files@file:../packages/icon-files#../packages/icon-files::hash=055c1b&locator=charcoal-web-docs%40workspace%3A."
-  checksum: 304dccb40010afe0e9926c112a060398f8e1abb64bb955f00dbacbb46414169267c850ff3a59c9b6496c30833a64d0bf2b6da7516d2cd5b1374a67d5b052f7b5
+  version: 3.12.0
+  resolution: "@charcoal-ui/icon-files@file:../packages/icon-files#../packages/icon-files::hash=71dc0b&locator=charcoal-web-docs%40workspace%3A."
+  checksum: 600ad623d701a4acc340777e090b52900dbc2dc5855f1288043d89905154c575581b7e82dfae7a7591a1c5afde7533522c53e03b9979754a6614f9f143282fd7
   languageName: node
   linkType: hard
 
 "@charcoal-ui/icons@file:../packages/icons::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=7a8bb8&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/icons@file:../packages/icons#../packages/icons::hash=a90811&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/icon-files": ^3.9.1
+    "@charcoal-ui/icon-files": ^3.12.0
     dompurify: ^2.3.6
     warning: ^4.0.3
-  checksum: dd0c3b1c6e317560a0e628f0e8ef1a9143d66e550ed343a491ca5ca33c1ad01e1243c5741980badb07ed898988618b363afc1224977dcef6158fbd41bcfe97d0
+  checksum: 546af24ea2e31f1e3e73467a64d66c79cd18df8fce4961fbb8e88b81477f12d660957ce409780bd7626d0bf62b5b3693599ff009e1f6a587630da05112565ffc
   languageName: node
   linkType: hard
 
 "@charcoal-ui/react@file:../packages/react::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=8a0638&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/react@file:../packages/react#../packages/react::hash=4aa969&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/icons": ^3.9.1
-    "@charcoal-ui/styled": ^3.9.1
-    "@charcoal-ui/theme": ^3.9.1
-    "@charcoal-ui/utils": ^3.9.1
+    "@charcoal-ui/foundation": ^3.12.0
+    "@charcoal-ui/icons": ^3.12.0
+    "@charcoal-ui/styled": ^3.12.0
+    "@charcoal-ui/theme": ^3.12.0
+    "@charcoal-ui/utils": ^3.12.0
     "@react-aria/button": ^3.9.1
     "@react-aria/checkbox": ^3.13.0
     "@react-aria/dialog": ^3.5.10
@@ -212,6 +213,7 @@ __metadata:
     "@react-aria/textfield": ^3.14.1
     "@react-aria/utils": ^3.23.0
     "@react-aria/visually-hidden": ^3.8.8
+    "@react-stately/radio": ^3.10.2
     polished: ^4.1.4
     react-spring: ^9.0.0
     react-stately: ^3.26.0
@@ -219,58 +221,58 @@ __metadata:
   peerDependencies:
     react: ">=17.0.0"
     styled-components: ">=5.1.1"
-  checksum: 2a055287f747d1787554ce8d371c2638cd62a5d6d7b31064b87f3f6590692f768b88c05365ec3ddbebb25c7aedf8699c790b225f438070d1950ef4bdeaa94049
+  checksum: b102add505337058e1d2f733a7366e504db5997e025f8cf2d6bdf9819d9fb35717a2e490e22db5963415a5b823f716cea2b1e4d45d5b355e6aa27d7c2c726451
   languageName: node
   linkType: hard
 
 "@charcoal-ui/styled@file:../packages/styled::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=f46ce8&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/styled@file:../packages/styled#../packages/styled::hash=6e3708&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/foundation": ^3.9.1
-    "@charcoal-ui/theme": ^3.9.1
-    "@charcoal-ui/utils": ^3.9.1
+    "@charcoal-ui/foundation": ^3.12.0
+    "@charcoal-ui/theme": ^3.12.0
+    "@charcoal-ui/utils": ^3.12.0
     warning: ^4.0.3
   peerDependencies:
     react: ">=17.0.0"
     styled-components: ">=5.1.1"
-  checksum: a44192e6de80e2fb03ebd13b1d7139739a8b0adba380bb4dcafb1ebac49c592c658d24c45a9b967e39f7520c49643389ed51ee5f82fe3e2345314977fe0fcddb
+  checksum: ef3e20f6904bbbc7d0ac701af6a741885ae4af3bc84bf1a4e308fb91722a78e2c79249347867dda400410a7ab3788ab0e14f9d4bb802503c810617484079f24a
   languageName: node
   linkType: hard
 
 "@charcoal-ui/tailwind-config@file:../packages/tailwind-config::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/tailwind-config@file:../packages/tailwind-config#../packages/tailwind-config::hash=94afc5&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/tailwind-config@file:../packages/tailwind-config#../packages/tailwind-config::hash=de3c83&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/foundation": ^3.9.1
-    "@charcoal-ui/theme": ^3.9.1
-    "@charcoal-ui/utils": ^3.9.1
+    "@charcoal-ui/foundation": ^3.12.0
+    "@charcoal-ui/theme": ^3.12.0
+    "@charcoal-ui/utils": ^3.12.0
   peerDependencies:
     csstype: ">=3.0.0"
     postcss: ">=7.0.32"
     tailwindcss: ">=1.4.6"
-  checksum: 62f5073591e5bc3ceec0a370a697479543756ccd0f278e49ad5488ea159f7cf912ad1fc4e67c8c3ab259ae36c50cf94bc573550eba0f6ec0569a16ec4ceb6ed8
+  checksum: 674ab9152d98ff89be92557961b6850b65b86ea3e1a5d8c888e75aed3173261d593bfd8f3aaf7fd1bab95cd2df881279ac49c755b7f80c6e24a6b6d213bb2bfa
   languageName: node
   linkType: hard
 
 "@charcoal-ui/theme@file:../packages/theme::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=297234&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/theme@file:../packages/theme#../packages/theme::hash=67be88&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/foundation": ^3.9.1
-    "@charcoal-ui/utils": ^3.9.1
+    "@charcoal-ui/foundation": ^3.12.0
+    "@charcoal-ui/utils": ^3.12.0
     polished: ^4.1.4
-  checksum: 210ee0b380a35da4010ec119bf7f7a91f98806c5262442100375082560bb14febcb60bce7971d48c7cfab07cc3d222c4fc02334966d8b79cce4a1394d9eedb02
+  checksum: 14347705aa521c0cac884e746a2a8ea0b92daedb3587b7f78c0997769b281c74117dca3c61cbdcbdc25eff7ebe096bb2b0a51a2923c0f494f7c06c9fc3847aa6
   languageName: node
   linkType: hard
 
 "@charcoal-ui/utils@file:../packages/utils::locator=charcoal-web-docs%40workspace%3A.":
-  version: 3.9.1
-  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=c76a94&locator=charcoal-web-docs%40workspace%3A."
+  version: 3.12.0
+  resolution: "@charcoal-ui/utils@file:../packages/utils#../packages/utils::hash=5c00f3&locator=charcoal-web-docs%40workspace%3A."
   dependencies:
-    "@charcoal-ui/foundation": ^3.9.1
+    "@charcoal-ui/foundation": ^3.12.0
     polished: ^4.1.4
-  checksum: f401e2a434abe0b63338c79a78cf69f0ac5a50ee800a895c0d7a4d45b36c4057b1ba59e81978e7e539cd4aa24b366ed6d2f85d4d4b5b24ccdd7e0ad9902cd72f
+  checksum: f0bf2b06d40f04feadb40cb2b6e203cbf7653554d2674e5652b85f161a66cf187c52a7da6f1bc2e21db43b9aa1dd356c3d604f2ff3cc24c82b73c104b7b47f5d
   languageName: node
   linkType: hard
 
@@ -1239,6 +1241,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-stately/form@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@react-stately/form@npm:3.0.3"
+  dependencies:
+    "@react-types/shared": ^3.23.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 667a34eb0d8edb66ebb93df00c70283954cd12568f0d017f7d40a5005cb7ab840a82b7e66d8edde1f26b268ccb674e26fbb102cbbd05deca7c21d924bc77eb96
+  languageName: node
+  linkType: hard
+
 "@react-stately/grid@npm:^3.8.3":
   version: 3.8.3
   resolution: "@react-stately/grid@npm:3.8.3"
@@ -1338,6 +1352,21 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 93ad0c31b00bf7fbe7c71c892d72e4e7b20fe053d454b04bcb96b52fd1309dd624964dc10b5fc62a53d1e6d3563f049692d66e007645f1beccdfea84c653d6d2
+  languageName: node
+  linkType: hard
+
+"@react-stately/radio@npm:^3.10.2":
+  version: 3.10.4
+  resolution: "@react-stately/radio@npm:3.10.4"
+  dependencies:
+    "@react-stately/form": ^3.0.3
+    "@react-stately/utils": ^3.10.1
+    "@react-types/radio": ^3.8.1
+    "@react-types/shared": ^3.23.1
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: 73283d79a4d35351361b19438bd8ba59f3afa5fac3a4ebac4ff00c42ce38bea61f05ff5e161107dbaec6dd270e530430b1462c97e4a987b4b6eabfb289331bc5
   languageName: node
   linkType: hard
 
@@ -1469,6 +1498,17 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 7aeeb32b29e2c9184bcda5dd4c9573dd17d43a7d8b1cd1863a6e75aa7ce0e6185e856edd2330836a6a460a7cf239e7f5a1499e6dcc14a34a84be6b79dd45636e
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "@react-stately/utils@npm:3.10.1"
+  dependencies:
+    "@swc/helpers": ^0.5.0
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: b5252fcab7a6c5fe413030613a5891e2893070b6d65e318b3233e5d96af7f122045329a9b3754f47ceab5a652d51e2fb95e256a7060e595638f2b045741f2258
   languageName: node
   linkType: hard
 
@@ -1621,6 +1661,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-types/radio@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@react-types/radio@npm:3.8.1"
+  dependencies:
+    "@react-types/shared": ^3.23.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: acdb76043990a1965ff6f85d5a5420f1493496e69131dc07ebc75b11476a77ab16814368cca902a39f212609b57ea417002ea8a7f621c9cb470499effcf83f38
+  languageName: node
+  linkType: hard
+
 "@react-types/searchfield@npm:^3.5.2":
   version: 3.5.2
   resolution: "@react-types/searchfield@npm:3.5.2"
@@ -1650,6 +1701,15 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
   checksum: 108d171c006ee86d01418bb2ca0e54915e8cdb276ecd82cad43bd8aa3a360654a95983b60dbf196c7b004e0307690ae7b0315d051b015277699a552619ec2b29
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.23.1":
+  version: 3.23.1
+  resolution: "@react-types/shared@npm:3.23.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+  checksum: a180d8b34b1ccf98f9d50bbbb0451090444aa576e1fecc46a769b24cf827658e1a77e5affb17407cfac25897ba461fb4234a160e5c8efa484880fcb4f230c2fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## やったこと
- Fix for `closeButtonAriaLabel` in Modal docs

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
