### PR TITLE
fix: pixiv-icon waitUntilVisible condition

### DIFF
--- a/packages/icons/src/PixivIcon.ts
+++ b/packages/icons/src/PixivIcon.ts
@@ -213,8 +213,11 @@ export class PixivIcon extends HTMLElement {
   private waitUntilVisible() {
     return new Promise<void>((resolve) => {
       this.observer = new IntersectionObserver(
-        ([first]) => {
-          if (first.isIntersecting) {
+        (entries) => {
+          // In Chromium based browsers, multiple entries can be returned even only observe once.
+          // Here, we don't care about the entry time but only if isIntersecting happened.
+          const isIntersecting = entries.some((entry) => entry.isIntersecting)
+          if (isIntersecting) {
             this.observer?.disconnect()
             this.observer = undefined
             resolve()

--- a/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/Modal/__snapshots__/index.story.storyshot
@@ -1060,7 +1060,7 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
   opacity: 0.32;
 }
 
-.c12 {
+.c17 {
   width: -webkit-fill-available;
   width: -moz-available;
   width: stretch;
@@ -1092,40 +1092,156 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
   height: 40px;
 }
 
-.c12:not(:disabled):not([aria-disabled]):focus,
-.c12[aria-disabled='false']:focus {
+.c17:not(:disabled):not([aria-disabled]):focus,
+.c17[aria-disabled='false']:focus {
   outline: none;
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
-.c12:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c12[aria-disabled='false']:focus:not(:focus-visible) {
+.c17:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c17[aria-disabled='false']:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.c12:not(:disabled):not([aria-disabled]):focus-visible,
-.c12[aria-disabled='false']:focus-visible {
+.c17:not(:disabled):not([aria-disabled]):focus-visible,
+.c17[aria-disabled='false']:focus-visible {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
-.c12:not(:disabled):not([aria-disabled]):hover,
-.c12[aria-disabled='false']:hover {
+.c17:not(:disabled):not([aria-disabled]):hover,
+.c17[aria-disabled='false']:hover {
   color: var(--charcoal-text5-hover);
   background-color: var(--charcoal-assertive-hover);
 }
 
-.c12:not(:disabled):not([aria-disabled]):active,
-.c12[aria-disabled='false']:active {
+.c17:not(:disabled):not([aria-disabled]):active,
+.c17[aria-disabled='false']:active {
   color: var(--charcoal-text5-press);
   background-color: var(--charcoal-assertive-press);
 }
 
+.c17:disabled,
+.c17[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+}
+
+.c12 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c12:has(input[readonly]) {
+  cursor: default;
+}
+
 .c12:disabled,
 .c12[aria-disabled]:not([aria-disabled='false']) {
+  cursor: default;
   opacity: 0.32;
 }
 
 .c13 {
+  position: relative;
+}
+
+.c14[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  cursor: pointer;
+  margin: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  -webkit-transition: 0.2s box-shadow,0.2s background-color;
+  transition: 0.2s box-shadow,0.2s background-color;
+}
+
+.c14[type='checkbox']:disabled {
+  cursor: default;
+}
+
+.c14[type='checkbox'][readonly] {
+  cursor: default;
+  opacity: 0.32;
+}
+
+.c14[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c14[type='checkbox']:checked:not(:disabled):not([aria-disabled]):hover,
+.c14[type='checkbox']:checked[aria-disabled='false']:hover {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c14[type='checkbox']:checked:not(:disabled):not([aria-disabled]):active,
+.c14[type='checkbox']:checked[aria-disabled='false']:active {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c14[type='checkbox']:not(:disabled):not([aria-disabled]):focus,
+.c14[type='checkbox'][aria-disabled='false']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c14[type='checkbox']:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c14[type='checkbox'][aria-disabled='false']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c14[type='checkbox']:not(:disabled):not([aria-disabled]):focus-visible,
+.c14[type='checkbox'][aria-disabled='false']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c14[type='checkbox']:not(:disabled):not([aria-disabled])[aria-invalid='true'],
+.c14[type='checkbox'][aria-disabled='false'][aria-invalid='true'] {
+  box-shadow: 0 0 0 4px rgba(255,43,0,0.32);
+}
+
+.c14[type='checkbox']:not(:checked) {
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--charcoal-text4);
+}
+
+.c15 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--charcoal-text5);
+}
+
+.c16 {
+  color: var(--charcoal-text2);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.c18 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1151,36 +1267,36 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
   transition: 0.2s background-color,0.2s box-shadow;
 }
 
-.c13:not(:disabled):not([aria-disabled]):hover,
-.c13[aria-disabled='false']:hover {
+.c18:not(:disabled):not([aria-disabled]):hover,
+.c18[aria-disabled='false']:hover {
   color: var(--charcoal-text3-hover);
   background-color: var(--charcoal-transparent-hover);
 }
 
-.c13:not(:disabled):not([aria-disabled]):active,
-.c13[aria-disabled='false']:active {
+.c18:not(:disabled):not([aria-disabled]):active,
+.c18[aria-disabled='false']:active {
   color: var(--charcoal-text3-press);
   background-color: var(--charcoal-transparent-press);
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus,
-.c13[aria-disabled='false']:focus {
+.c18:not(:disabled):not([aria-disabled]):focus,
+.c18[aria-disabled='false']:focus {
   outline: none;
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
-.c13[aria-disabled='false']:focus:not(:focus-visible) {
+.c18:not(:disabled):not([aria-disabled]):focus:not(:focus-visible),
+.c18[aria-disabled='false']:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.c13:not(:disabled):not([aria-disabled]):focus-visible,
-.c13[aria-disabled='false']:focus-visible {
+.c18:not(:disabled):not([aria-disabled]):focus-visible,
+.c18[aria-disabled='false']:focus-visible {
   box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
 }
 
-.c13:disabled,
-.c13[aria-disabled]:not([aria-disabled='false']) {
+.c18:disabled,
+.c18[aria-disabled]:not([aria-disabled='false']) {
   opacity: 0.32;
 }
 
@@ -1221,7 +1337,7 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
   background-color: var(--charcoal-surface4);
 }
 
-.c14 {
+.c19 {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -1230,13 +1346,13 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
   transition: 0.2s color;
 }
 
-.c14:not(:disabled):not([aria-disabled]):hover,
-.c14[aria-disabled='false']:hover {
+.c19:not(:disabled):not([aria-disabled]):hover,
+.c19[aria-disabled='false']:hover {
   color: var(--charcoal-text3-hover);
 }
 
-.c14:not(:disabled):not([aria-disabled]):active,
-.c14[aria-disabled='false']:active {
+.c19:not(:disabled):not([aria-disabled]):active,
+.c19[aria-disabled='false']:active {
   color: var(--charcoal-text3-press);
 }
 
@@ -1413,8 +1529,51 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
           <div
             className="c11"
           >
+            <label
+              aria-disabled={false}
+              className="c12"
+            >
+              <div
+                className="c13"
+              >
+                <input
+                  checked={true}
+                  className="c14"
+                  disabled={false}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onDragStart={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  aria-hidden={true}
+                  checked={true}
+                  className="c15"
+                >
+                  <pixiv-icon
+                    name="24/Check"
+                    unsafe-non-guideline-scale={0.6666666666666666}
+                  />
+                </div>
+              </div>
+              <div
+                className="c16"
+              >
+                test checkbox
+              </div>
+            </label>
             <button
-              className="c0 c12"
+              className="c0 c17"
               disabled={false}
               onClick={[Function]}
             >
@@ -1424,7 +1583,7 @@ exports[`Storybook Tests react/Modal BottomSheet 1`] = `
         </div>
         <button
           aria-label="Close"
-          className="c0 c13 c14"
+          className="c0 c18 c19"
           onClick={[Function]}
           type="button"
         >

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 import { theme } from '../../styled'
 import TextField from '../TextField'
 import DropdownSelector from '../DropdownSelector'
+import Checkbox from '../Checkbox'
 import DropdownMenuItem from '../DropdownSelector/DropdownMenuItem'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -201,6 +202,7 @@ export const BottomSheet: StoryObj<typeof Modal> = {
               </StyledModalText>
             </ModalVStack>
             <ModalButtons>
+              <Checkbox checked>test checkbox</Checkbox>
               <Button variant="Danger" onClick={() => state.close()} fullWidth>
                 削除する
               </Button>


### PR DESCRIPTION
## やったこと

- fix `waitUntilVisible` to contain the fix in https://github.com/vueuse/vueuse/pull/3365
- In Chromium based browsers, multiple entries can be returned in a single callback even only called `observe()` once.
  - Found this is more likely to happen if the element's parent has css transform somehow? e.g. Modal/Sidebar
  - Related implementation but not found so mush useful info. https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/intersection_observer/intersection_observation.cc;l=36

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
