### PR TITLE
chore: add firebase redirect settings for docs

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,68 @@
 {
   "hosting": {
     "public": "storybook-static",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "redirects": [
+      {
+        "source": "/@charcoal-ui/styled/quickstart/",
+        "destination": "/?path=/docs/styled-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/react/quickstart/",
+        "destination": "/?path=/docs/react-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/react/ssr/",
+        "destination": "/?path=/docs/react-ssr-guide--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/icons/quickstart/",
+        "destination": "/?path=/docs/icons-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/icons/react/",
+        "destination": "/?path=/docs/icons-readme--docs#react-と組み合わせて使う",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/icons/extend/",
+        "destination": "/?path=/docs/icons-custom--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/icons/ssr/",
+        "destination": "/?path=/docs/icons-ssr-guide--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/tailwind-config/quickstart/",
+        "destination": "/?path=/docs/tailwind-config-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/tailwind-config/customize/",
+        "destination": "/?path=/docs/tailwind-config-custom--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/tailwind-diff/quickstart/",
+        "destination": "/?path=/docs/tailwind-diff-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/foundation/quickstart/",
+        "destination": "/?path=/docs/foundation-readme--docs",
+        "type": 301
+      },
+      {
+        "source": "/@charcoal-ui/theme/quickstart/",
+        "destination": "/?path=/docs/theme-readme--docs",
+        "type": 301
+      }
+    ]
   }
 }


### PR DESCRIPTION
## やったこと

- firebase redirect 

## 動作確認環境
- `firebase emulator --only hosting`

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
