### PR TITLE
fix token cli

### DIFF
--- a/packages/pullrequest-cli/package.json
+++ b/packages/pullrequest-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/pullrequest-cli",
-  "private": "true",
+  "private": true,
   "license": "Apache-2.0",
   "bin": "./dist/index.js",
   "scripts": {
@@ -26,9 +26,6 @@
     "src",
     "dist"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/pixiv/charcoal.git",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/yargs": "^17.0.32",
-    "jest": "^29.7.0",
+    "jest": "^29.6.0",
     "rimraf": "^3.0.2",
     "style-dictionary": "^3.9.2",
     "tsup": "^8.0.2",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "build": "FORCE_COLOR=1 tsup-node",
     "typecheck": "tsc --project tsconfig.build.json --pretty --noEmit",
-    "clean": "rimraf dist .tsbuildinfo"
+    "clean": "rimraf dist .tsbuildinfo",
+    "test": "jest"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/yargs": "^17.0.32",
+    "jest": "^29.7.0",
     "rimraf": "^3.0.2",
     "style-dictionary": "^3.9.2",
     "tsup": "^8.0.2",

--- a/packages/token-cli/pixiv-dark.config.js
+++ b/packages/token-cli/pixiv-dark.config.js
@@ -1,6 +1,6 @@
 /** @type { import('style-dictionary') } */
 module.exports = {
-  source: ['tokens/base.json', 'tokens/pixiv-light.json'],
+  source: ['tokens/base.json', 'tokens/pixiv-dark.json'],
   transform: {
     'name/cti/kebab': {
       type: 'name',

--- a/packages/token-cli/pixiv-dark.config.js
+++ b/packages/token-cli/pixiv-dark.config.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { transformer } = require('./src/transformer');
+const { transformer } = require('./src/transformer')
 
 /** @type { import('style-dictionary') } */
 module.exports = {

--- a/packages/token-cli/pixiv-dark.config.js
+++ b/packages/token-cli/pixiv-dark.config.js
@@ -7,6 +7,7 @@ module.exports = {
       transformer: (token) => {
         return token.path
           .join('-')
+          .replace(/(.)([A-Z])/g, '$1-$2')
           .toLowerCase()
           .replaceAll('/', '-')
           .replaceAll(' ', '-')

--- a/packages/token-cli/pixiv-dark.config.js
+++ b/packages/token-cli/pixiv-dark.config.js
@@ -1,17 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { transformer } = require('./src/transformer');
+
 /** @type { import('style-dictionary') } */
 module.exports = {
   source: ['tokens/base.json', 'tokens/pixiv-dark.json'],
   transform: {
     'name/cti/kebab': {
       type: 'name',
-      transformer: (token) => {
-        return token.path
-          .join('-')
-          .replace(/(.)([A-Z])/g, '$1-$2')
-          .toLowerCase()
-          .replaceAll('/', '-')
-          .replaceAll(' ', '-')
-      },
+      transformer: transformer,
     },
   },
   platforms: {

--- a/packages/token-cli/pixiv-light.config.js
+++ b/packages/token-cli/pixiv-light.config.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { transformer } = require('./src/transformer');
+const { transformer } = require('./src/transformer')
 
 /** @type { import('style-dictionary') } */
 module.exports = {

--- a/packages/token-cli/pixiv-light.config.js
+++ b/packages/token-cli/pixiv-light.config.js
@@ -1,17 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { transformer } = require('./src/transformer');
+
 /** @type { import('style-dictionary') } */
 module.exports = {
   source: ['tokens/base.json', 'tokens/pixiv-light.json'],
   transform: {
     'name/cti/kebab': {
       type: 'name',
-      transformer: (token) => {
-        return token.path
-          .join('-')
-          .replace(/(.)([A-Z])/g, '$1-$2')
-          .toLowerCase()
-          .replaceAll('/', '-')
-          .replaceAll(' ', '-')
-      },
+      transformer: transformer,
     },
   },
   platforms: {

--- a/packages/token-cli/pixiv-light.config.js
+++ b/packages/token-cli/pixiv-light.config.js
@@ -7,6 +7,7 @@ module.exports = {
       transformer: (token) => {
         return token.path
           .join('-')
+          .replace(/(.)([A-Z])/g, '$1-$2')
           .toLowerCase()
           .replaceAll('/', '-')
           .replaceAll(' ', '-')

--- a/packages/token-cli/src/createToken.ts
+++ b/packages/token-cli/src/createToken.ts
@@ -79,9 +79,6 @@ export const createToken = (
           ...current,
         }))
 
-      if (modeName != undefined && collection.defaultModeId != modeId)
-        return { [collection.name]: { [modeName]: variables } }
-
       return { [collection.name]: variables }
     })
     .reduce<{ [key: string]: object }>(

--- a/packages/token-cli/src/transformer/index.js
+++ b/packages/token-cli/src/transformer/index.js
@@ -1,0 +1,18 @@
+/**
+ * @param {import('style-dictionary').TransformedToken} token
+ * @return {string}
+ */
+const transformer = (token) => {
+  return token.path
+    .join('-')
+    .replace(/(.)([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replaceAll('/', '-')
+    .replaceAll(' ', '-')
+    .replaceAll('--', '-')
+}
+
+module.exports = {
+  transformer,
+}

--- a/packages/token-cli/src/transformer/index.test.js
+++ b/packages/token-cli/src/transformer/index.test.js
@@ -6,7 +6,7 @@ test('tests transformer real case', () => {
   )
 })
 test('tests transformer unreal case', () => {
-  expect(transformer({ path: ['Color', 'Container/Secondary/DefaultABCDEF'] })).toBe(
-    'color-container-secondary-default-a-b-c-d-e-f'
-  )
+  expect(
+    transformer({ path: ['Color', 'Container/Secondary/DefaultABCDEF'] })
+  ).toBe('color-container-secondary-default-a-b-c-d-e-f')
 })

--- a/packages/token-cli/src/transformer/index.test.js
+++ b/packages/token-cli/src/transformer/index.test.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { transformer } = require('.')
+test('tests transformer real case', () => {
+  expect(transformer({ path: ['Color', 'container/secondary/defaultA'] })).toBe(
+    'color-container-secondary-default-a'
+  )
+})
+test('tests transformer unreal case', () => {
+  expect(transformer({ path: ['Color', 'Container/Secondary/DefaultABCDEF'] })).toBe(
+    'color-container-secondary-default-a-b-c-d-e-f'
+  )
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,6 +2800,7 @@ __metadata:
     "@types/yargs": ^17.0.32
     axios: ^1.6.7
     fs-extra: ^11.2.0
+    jest: ^29.7.0
     rimraf: ^3.0.2
     style-dictionary: ^3.9.2
     tsup: ^8.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,7 +2800,7 @@ __metadata:
     "@types/yargs": ^17.0.32
     axios: ^1.6.7
     fs-extra: ^11.2.0
-    jest: ^29.7.0
+    jest: ^29.6.0
     rimraf: ^3.0.2
     style-dictionary: ^3.9.2
     tsup: ^8.0.2
@@ -19573,7 +19573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest@npm:^29.6.4":
+"jest@npm:^29.6.0, jest@npm:^29.6.4":
   version: 29.7.0
   resolution: "jest@npm:29.7.0"
   dependencies:


### PR DESCRIPTION
## やったこと

- fix `pixiv-dark.config.js`
- I used to include the mode name in the object name when the mode name is anything other than 'default'. However, I stopped doing that because it made name resolution with Style Dictionary impossible.

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
