### PR TITLE
fix(token-cli): primitive token named negative value case

### DIFF
--- a/packages/token-cli/src/transformer/index.js
+++ b/packages/token-cli/src/transformer/index.js
@@ -10,7 +10,7 @@ const transformer = (token) => {
     .toLowerCase()
     .replaceAll('/', '-')
     .replaceAll(' ', '-')
-    .replaceAll('--', '-')
+    .replace(/(--)(\D)/g, '-$2')
 }
 
 module.exports = {

--- a/packages/token-cli/src/transformer/index.test.js
+++ b/packages/token-cli/src/transformer/index.test.js
@@ -5,6 +5,16 @@ test('tests transformer real case', () => {
     'color-container-secondary-default-a'
   )
 })
+test('tests transformer negative primitive value case', () => {
+  expect(transformer({ path: ['Colors', 'Dark/Neutral/-10'] })).toBe(
+    'colors-dark-neutral--10'
+  )
+})
+test('tests transformer negative primitive value unreal case', () => {
+  expect(transformer({ path: ['Colors', 'dark/neutralABCDEF/-10'] })).toBe(
+    'colors-dark-neutral-a-b-c-d-e-f--10'
+  )
+})
 test('tests transformer unreal case', () => {
   expect(
     transformer({ path: ['Color', 'Container/Secondary/DefaultABCDEF'] })


### PR DESCRIPTION
## やったこと

- Fixed an issue where hyphens were being unnecessarily removed in primitive tokens that included negative values in the name.

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
