### PR TITLE
fix: modalがサーバーサイドで利用できない問題を修正

### DIFF
--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -95,7 +95,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
     ref
   )
 
-  const isMobile = useWindowWidth() < 744
+  const isMobile = (useWindowWidth() ?? Infinity) < 744
   const transitionEnabled = isMobile && bottomSheet !== false
   const showDismiss = !isMobile || bottomSheet !== true
 

--- a/packages/react/src/components/Modal/useCustomModalOverlay.tsx
+++ b/packages/react/src/components/Modal/useCustomModalOverlay.tsx
@@ -47,8 +47,14 @@ export function useCharcoalModalOverlay(
   }
 }
 
+function isWindowDefined() {
+  return typeof window !== 'undefined'
+}
+
 export function useWindowWidth() {
-  const [width, setWidth] = React.useState(window.innerWidth)
+  const [width, setWidth] = React.useState(
+    isWindowDefined() ? window.innerWidth : null
+  )
   React.useEffect(() => {
     const handleResize = () => {
       setWidth(window.innerWidth)


### PR DESCRIPTION
## やったこと

- `Modal`がサーバーサイドで利用できない問題を修正しました。

## なぜやるか

- Next.jsなどのフレームワークでSSRできるようにするためです。