### PR TITLE
feat(@charcoal-ui/react): add @layer charcoal output for css output

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,10 @@
     "./dist/index.css": {
       "import": "./dist/index.css",
       "require": "./dist/index.css"
+    },
+    "./dist/layered.css": {
+      "import": "./dist/layered.css",
+      "require": "./dist/layered.css"
     }
   },
   "types": "./dist/index.d.ts",

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'tsup'
 import { styledComponentsPlugin } from '@charcoal-ui/esbuild-plugin-styled-components'
+import postcss from 'postcss'
+import fs from 'node:fs/promises'
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -11,5 +13,56 @@ export default defineConfig({
   },
   target: 'esnext',
   sourcemap: true,
-  esbuildPlugins: [styledComponentsPlugin],
+  esbuildPlugins: [
+    styledComponentsPlugin,
+    {
+      name: 'at-layer-charcoal',
+      setup(build) {
+        // NOTE: this will be called twice for esm and cjs.
+        build.onEnd(async (result) => {
+          const originalCssOutput = result.outputFiles?.find((file) =>
+            file.path.endsWith('css')
+          )
+          if (!originalCssOutput) {
+            throw new Error('[at-layer-charcoal]: expect original css output')
+          }
+
+          const layeredCssFilePath = originalCssOutput.path.replace(
+            'index.css',
+            'layered.css'
+          )
+          const layeredCssOutput = await postcss({
+            postcssPlugin: 'at-layer-charcoal',
+            Once(_, { AtRule, result }) {
+              const atLayerNode = new AtRule({
+                name: 'layer',
+                params: 'charcoal',
+                nodes: result.root.nodes,
+              })
+              result.root.nodes = [atLayerNode]
+            },
+          }).process(originalCssOutput.text, {
+            from: originalCssOutput.path,
+            to: layeredCssFilePath,
+            map: {
+              inline: false,
+            },
+          })
+
+          await Promise.all([
+            fs.writeFile(layeredCssFilePath, layeredCssOutput.content),
+            fs.writeFile(
+              `${layeredCssFilePath}.map`,
+              layeredCssOutput.map.toString()
+            ),
+          ])
+
+          // eslint-disable-next-line no-console
+          console.log(
+            `${build.initialOptions.format?.toUpperCase()} dist/layered.css`
+          )
+        })
+      },
+    },
+  ],
 })

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'tsup'
 import { styledComponentsPlugin } from '@charcoal-ui/esbuild-plugin-styled-components'
 import postcss from 'postcss'
 import fs from 'node:fs/promises'
+import path from 'node:path'
 
 export default defineConfig({
   entry: ['src/index.ts'],
@@ -49,6 +50,9 @@ export default defineConfig({
             },
           })
 
+          // https://github.com/evanw/esbuild/issues/2999
+          // this will be called before dist is created
+          await fs.mkdir(path.dirname(layeredCssFilePath), { recursive: true })
           await Promise.all([
             fs.writeFile(layeredCssFilePath, layeredCssOutput.content),
             fs.writeFile(


### PR DESCRIPTION
## やったこと

- Added an `@layer charcoal { ... }` output in `@charcoal-ui/react` via esbuild plugin.
- Motivations:
  1. Easier management for css cascading
      - especially important for migrating from v3 with less breakage
      - more control on the user side for adjusting orders.
  2. Already good enough browser coverage
      - https://caniuse.com/?search=%40layer
      - https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
      - better than requiring users to do something similar via modifying their build setup.
      - better than `@import "index.css" layer(charcoal);`
 
## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
