### PR TITLE
fix: rename use theme key and update type

### DIFF
--- a/packages/styled/src/helper.ts
+++ b/packages/styled/src/helper.ts
@@ -81,7 +81,8 @@ export const useTheme = (localStorageKey: string = LOCAL_STORAGE_KEY) => {
   assertKeyString(localStorageKey)
   const isDark = useMedia('(prefers-color-scheme: dark)')
   const media = isDark !== undefined ? (isDark ? 'dark' : 'light') : undefined
-  const [local, setTheme, ready] = useLocalStorage<typeof media>(localStorageKey)
+  const [local, setTheme, ready] =
+    useLocalStorage<typeof media>(localStorageKey)
   const theme = !ready || media === undefined ? undefined : local ?? media
   const system = local === undefined
   return [theme, setTheme, system] as const

--- a/packages/styled/src/helper.ts
+++ b/packages/styled/src/helper.ts
@@ -77,11 +77,11 @@ export function getThemeSync(key: string = LOCAL_STORAGE_KEY) {
  *
  * `dark` `light` という名前だけは特別扱いされていて、prefers-color-schemeにマッチした場合に返ります
  */
-export const useTheme = (key: string = LOCAL_STORAGE_KEY) => {
-  assertKeyString(key)
+export const useTheme = (localStorageKey: string = LOCAL_STORAGE_KEY) => {
+  assertKeyString(localStorageKey)
   const isDark = useMedia('(prefers-color-scheme: dark)')
   const media = isDark !== undefined ? (isDark ? 'dark' : 'light') : undefined
-  const [local, setTheme, ready] = useLocalStorage<string>(key)
+  const [local, setTheme, ready] = useLocalStorage<typeof media>(localStorageKey)
   const theme = !ready || media === undefined ? undefined : local ?? media
   const system = local === undefined
   return [theme, setTheme, system] as const


### PR DESCRIPTION
## やったこと

- rename useTheme parama from key to localstorageKey
- modify theme type to be `"light" | "dark" | undefined`

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
