### PR TITLE
docs(tailwind-config): tailwind-config/README.mdのリンク切れを修正

### DIFF
--- a/packages/tailwind-config/README.md
+++ b/packages/tailwind-config/README.md
@@ -158,4 +158,4 @@ https://tailwindcss.com/
 
 `@charcoal-ui/tailwind-config` が独自に定義しているクラスについては Storybook を見てください。
 
-https://pixiv.github.io/charcoal/?path=/docs/tailwind-config-colors-doc--colors
+https://pixiv.github.io/charcoal/?path=/docs/tailwind-config-colors-doc--docs


### PR DESCRIPTION
## やったこと

- `tailwind-config/README.md`のリンクが切れていたので修正しました。

## 動作確認環境

## チェックリスト

- [x] README やドキュメントに影響があることを確認した
