### PR TITLE
feat(icon-workflow): Enable creation of PRs to the base branch

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -8,13 +8,17 @@ on:
 
 env:
   OUTPUT_ROOT_DIR: packages/icon-files/
+  TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'main' }}
 
 jobs:
   icons:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.node-version'
@@ -49,5 +53,5 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
-          GITHUB_DEFAULT_BRANCH: main
+          GITHUB_DEFAULT_BRANCH: ${{ env.TARGET_BRANCH }}
         run: yarn icons-cli github:pr


### PR DESCRIPTION
## やったこと

- icons-cliをmain以外のブランチで動かした時、PRのベースブランチが適切に変わるように変更しました

## 動作確認環境
#638 
https://github.com/pixiv/charcoal/actions/runs/11358427793

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
