### PR TITLE
fix!(tailwind-config): カスタムスタイルをtheme.extend以下に移動

### DIFF
--- a/packages/tailwind-config/src/index.test.ts
+++ b/packages/tailwind-config/src/index.test.ts
@@ -25,7 +25,10 @@ describe('tailwind.config.js', () => {
   })
 
   test('list of classes', () => {
-    expect(result.classNames).toMatchSnapshot()
+    expect(result.classNames).toContain('rounded-4')
+    expect(result.classNames).toContain('bg-surface5-top')
+    expect(result.classNames).toContain('p-0')
+    expect(result.classNames).toContain('typography-12')
   })
 
   test('list of css variables', () => {

--- a/packages/tailwind-config/src/index.ts
+++ b/packages/tailwind-config/src/index.ts
@@ -39,69 +39,71 @@ export function createTailwindConfig({
 
   return {
     theme: {
-      screens: {
-        screen1: px(0),
-        screen2: px(defaultTheme.breakpoint.screen1),
-        screen3: px(defaultTheme.breakpoint.screen2),
-        screen4: px(defaultTheme.breakpoint.screen3),
-        screen5: px(defaultTheme.breakpoint.screen4),
-      },
-      colors: {
-        // @deprecated
-        black: '#000',
+      extend: {
+        screens: {
+          screen1: px(0),
+          screen2: px(defaultTheme.breakpoint.screen1),
+          screen3: px(defaultTheme.breakpoint.screen2),
+          screen4: px(defaultTheme.breakpoint.screen3),
+          screen5: px(defaultTheme.breakpoint.screen4),
+        },
+        colors: {
+          // @deprecated
+          black: '#000',
 
-        // @deprecated
-        white: '#fff',
+          // @deprecated
+          white: '#fff',
 
-        transparent: 'transparent',
-        current: 'currentColor',
-        ...colorsToTailwindConfig(version, defaultTheme.color, effects),
-      },
-      borderColor: {
-        ...colorsToTailwindConfig(
-          version,
-          mapObject(defaultTheme.border, (k, v) => [k, v.color]),
-          effects
-        ),
-      },
-      spacing: mapObject(SPACING, (name, pixel) => [name, px(pixel)]),
-      width: {
-        full: '100%',
-        screen: '100vw',
-        auto: 'auto',
-        fit: 'fit-content',
+          transparent: 'transparent',
+          current: 'currentColor',
+          ...colorsToTailwindConfig(version, defaultTheme.color, effects),
+        },
+        borderColor: {
+          ...colorsToTailwindConfig(
+            version,
+            mapObject(defaultTheme.border, (k, v) => [k, v.color]),
+            effects
+          ),
+        },
+        spacing: mapObject(SPACING, (name, pixel) => [name, px(pixel)]),
+        width: {
+          full: '100%',
+          screen: '100vw',
+          auto: 'auto',
+          fit: 'fit-content',
 
-        /**
-         * generates classes like "w-col-span-1"
-         */
-        ...Array.from({ length: GRID_COUNT }, (_, i) => i + 1).reduce(
-          (styles, i) => ({
-            ...styles,
-            [`col-span-${i}`]: px(COLUMN_UNIT * i + GUTTER_UNIT * (i - 1)),
-          }),
-          {}
-        ),
+          /**
+           * generates classes like "w-col-span-1"
+           */
+          ...Array.from({ length: GRID_COUNT }, (_, i) => i + 1).reduce(
+            (styles, i) => ({
+              ...styles,
+              [`col-span-${i}`]: px(COLUMN_UNIT * i + GUTTER_UNIT * (i - 1)),
+            }),
+            {}
+          ),
 
-        /**
-         * generates classes like "w-1/12" (except for 12/12, which just equals to w-full)
-         */
-        ...Array.from({ length: GRID_COUNT - 1 }, (_, i) => i + 1).reduce(
-          (styles, i) => ({
-            ...styles,
-            [`${i}/${GRID_COUNT}`]: `${(i / GRID_COUNT) * 100}%`,
-          }),
-          {}
-        ),
-      },
-      gap: {
-        fixed: px(GUTTER_UNIT),
-      },
-      borderRadius: mapObject(BORDER_RADIUS, (name, value) => [
-        name,
-        px(value),
-      ]),
-      transitionDuration: {
-        [DEFAULT]: '0.2s',
+          /**
+           * generates classes like "w-1/12" (except for 12/12, which just equals to w-full)
+           */
+          ...Array.from({ length: GRID_COUNT - 1 }, (_, i) => i + 1).reduce(
+            (styles, i) => ({
+              ...styles,
+              [`${i}/${GRID_COUNT}`]: `${(i / GRID_COUNT) * 100}%`,
+            }),
+            {}
+          ),
+        },
+        gap: {
+          fixed: px(GUTTER_UNIT),
+        },
+        borderRadius: mapObject(BORDER_RADIUS, (name, value) => [
+          name,
+          px(value),
+        ]),
+        transitionDuration: {
+          [DEFAULT]: '0.2s',
+        },
       },
     },
 


### PR DESCRIPTION
## やったこと

- 下記Issueのフォローアップです。
  - #645 
- 従来のスナップショットと比較するテストでは対応が難しかったため、tailwind-configで生成された一部のカスタムクラスを検知するテストに変更しました。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] README やドキュメントに影響があることを確認した
