### PR TITLE
(v4) tokenが参照できない時、warnを出して処理を続けるようにする

### DIFF
--- a/packages/token-cli/src/createToken.ts
+++ b/packages/token-cli/src/createToken.ts
@@ -62,18 +62,36 @@ export const createToken = (
 
           if (!v) throw new Error(`can't find variable: ${it}`)
 
-          return {
-            [v.name]: {
-              value: resolveValue(
-                variableCollectionMap,
-                variableMap,
-                v.resolvedType,
-                v,
-                modeId
-              ),
-            },
+          try {
+            const value = resolveValue(
+              variableCollectionMap,
+              variableMap,
+              v.resolvedType,
+              v,
+              modeId
+            )
+            return {
+              [v.name]: {
+                value,
+              },
+            }
+          } catch (e) {
+            if (e instanceof Error) {
+              // eslint-disable-next-line no-console
+              console.warn(`[warn]: ${e.message}`)
+            }
+            return undefined
           }
         })
+        .filter(
+          (
+            it
+          ): it is {
+            [x: string]: {
+              value: string
+            }
+          } => it !== undefined
+        )
         .reduce((prev, current) => ({
           ...prev,
           ...current,

--- a/packages/token-cli/src/figma/index.ts
+++ b/packages/token-cli/src/figma/index.ts
@@ -106,13 +106,16 @@ export const resolveValue = (
   // if alias, look at it recursively.
   if (typeof value === 'object' && 'type' in value && 'id' in value) {
     const v = variableMap.get(value.id)
-    if (!v) throw new Error(`can't find variable ${value.id}`)
+    if (!v)
+      throw new Error(
+        `can't find variable alias "${variable.name}:${value.id}"`
+      )
 
     const variableCollection = variableCollectionMap.get(v.variableCollectionId)
 
     if (!variableCollection)
       throw new Error(
-        `can't find variable collection ${v.variableCollectionId}`
+        `can't find variable collection "${variable.name}:${v.variableCollectionId}"`
       )
 
     return `{${variableCollection.name}.${v.name}}`


### PR DESCRIPTION
## やったこと

- #660 のv4ブランチ版です

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
