### PR TITLE
fix: revert remove multiSelect

### DIFF
--- a/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
@@ -1,153 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storybook Tests MultiSelect Basic 1`] = `
-.c1 {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  cursor: pointer;
-  gap: 4px;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled='false']) {
-  opacity: 0.32;
-  cursor: default;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 22px;
-  display: flow-root;
-  color: var(--charcoal-text2);
-}
-
-.c4::before {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-top: -4px;
-}
-
-.c4::after {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-bottom: -4px;
-}
-
-.c2[type='checkbox'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 20px;
-  height: 20px;
-  margin: 0;
-  background-color: var(--charcoal-text3);
-  border-radius: 999999px;
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
-}
-
-.c2[type='checkbox']:checked {
-  background-color: var(--charcoal-brand);
-}
-
-.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-hover);
-}
-
-.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-press);
-}
-
-.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-hover);
-}
-
-.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-press);
-}
-
-.c2[type='checkbox']:focus {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c2[type='checkbox']:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.c2[type='checkbox']:focus-visible {
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c3 {
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 999999px;
-  color: var(--charcoal-text5);
-  -webkit-transition: 0.2s box-shadow;
-  transition: 0.2s box-shadow;
-}
-
-.c0 {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
+exports[`Storybook Tests > react/MultiSelect > Basic 1`] = `
 <div
   data-dark={false}
 >
   <div
     aria-label="label"
-    className="c0"
     data-testid="SelectGroup"
+    style={
+      Object {
+        "display": "grid",
+        "gap": "8px",
+        "gridTemplateColumns": "1fr",
+      }
+    }
   >
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={true}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -156,7 +32,9 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -164,19 +42,20 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢1
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -185,7 +64,9 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -193,19 +74,20 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢2
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={true}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -214,7 +96,9 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -222,19 +106,20 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢3
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -243,7 +128,9 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -251,7 +138,7 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢4
       </div>
@@ -260,159 +147,30 @@ exports[`Storybook Tests MultiSelect Basic 1`] = `
 </div>
 `;
 
-exports[`Storybook Tests MultiSelect Invalid 1`] = `
-.c1 {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  cursor: pointer;
-  gap: 4px;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled='false']) {
-  opacity: 0.32;
-  cursor: default;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 22px;
-  display: flow-root;
-  color: var(--charcoal-text2);
-}
-
-.c4::before {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-top: -4px;
-}
-
-.c4::after {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-bottom: -4px;
-}
-
-.c2[type='checkbox'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 20px;
-  height: 20px;
-  margin: 0;
-  background-color: var(--charcoal-text3);
-  border-radius: 999999px;
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
-}
-
-.c2[type='checkbox']:checked {
-  background-color: var(--charcoal-brand);
-}
-
-.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-hover);
-}
-
-.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-press);
-}
-
-.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-hover);
-}
-
-.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-press);
-}
-
-.c2[type='checkbox']:focus {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c2[type='checkbox']:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.c2[type='checkbox']:focus-visible {
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c2[type='checkbox']:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox'][aria-disabled='false'] {
-  box-shadow: 0 0 0 4px rgba(255,43,0,0.32);
-}
-
-.c3 {
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 999999px;
-  color: var(--charcoal-text5);
-  -webkit-transition: 0.2s box-shadow;
-  transition: 0.2s box-shadow;
-}
-
-.c0 {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
+exports[`Storybook Tests > react/MultiSelect > Invalid 1`] = `
 <div
   data-dark={false}
 >
   <div
     aria-label="label"
-    className="c0"
     data-testid="SelectGroup"
+    style={
+      Object {
+        "display": "grid",
+        "gap": "8px",
+        "gridTemplateColumns": "1fr",
+      }
+    }
   >
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={true}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -421,7 +179,9 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={true}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -429,19 +189,20 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢1
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={true}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -450,7 +211,9 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={true}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -458,19 +221,20 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢2
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={true}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -479,7 +243,9 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={true}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -487,19 +253,20 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢3
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={true}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -508,7 +275,9 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={true}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -516,7 +285,7 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢4
       </div>
@@ -525,158 +294,30 @@ exports[`Storybook Tests MultiSelect Invalid 1`] = `
 </div>
 `;
 
-exports[`Storybook Tests MultiSelect Overlay 1`] = `
-.c1 {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  cursor: pointer;
-  gap: 4px;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled='false']) {
-  opacity: 0.32;
-  cursor: default;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 22px;
-  display: flow-root;
-  color: var(--charcoal-text2);
-}
-
-.c4::before {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-top: -4px;
-}
-
-.c4::after {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-bottom: -4px;
-}
-
-.c2[type='checkbox'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 20px;
-  height: 20px;
-  margin: 0;
-  background-color: var(--charcoal-text3);
-  border-radius: 999999px;
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
-  background-color: var(--charcoal-surface4);
-}
-
-.c2[type='checkbox']:checked {
-  background-color: var(--charcoal-brand);
-}
-
-.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-hover);
-}
-
-.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-press);
-}
-
-.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-hover);
-}
-
-.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-press);
-}
-
-.c2[type='checkbox']:focus {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c2[type='checkbox']:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.c2[type='checkbox']:focus-visible {
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c3 {
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 999999px;
-  color: var(--charcoal-text5);
-  -webkit-transition: 0.2s box-shadow;
-  transition: 0.2s box-shadow;
-  border-color: var(--charcoal-text5);
-  border-width: 2px;
-  border-style: solid;
-}
-
-.c0 {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
+exports[`Storybook Tests > react/MultiSelect > Overlay 1`] = `
 <div
   data-dark={false}
 >
   <div
     aria-label="label"
-    className="c0"
     data-testid="SelectGroup"
+    style={
+      Object {
+        "display": "grid",
+        "gap": "8px",
+        "gridTemplateColumns": "1fr",
+      }
+    }
   >
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={true}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -685,7 +326,9 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={true}
       >
         <pixiv-icon
           name="24/Check"
@@ -693,19 +336,20 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢1
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={true}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -714,7 +358,9 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={true}
       >
         <pixiv-icon
           name="24/Check"
@@ -722,19 +368,20 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢2
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={true}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -743,7 +390,9 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={true}
       >
         <pixiv-icon
           name="24/Check"
@@ -751,19 +400,20 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢3
       </div>
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={true}
         disabled={false}
         name="name"
         onChange={[Function]}
@@ -772,7 +422,9 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={true}
       >
         <pixiv-icon
           name="24/Check"
@@ -780,7 +432,7 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢4
       </div>
@@ -789,154 +441,30 @@ exports[`Storybook Tests MultiSelect Overlay 1`] = `
 </div>
 `;
 
-exports[`Storybook Tests MultiSelect Playground 1`] = `
-.c1 {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  cursor: pointer;
-  gap: 4px;
-}
-
-.c1:disabled,
-.c1[aria-disabled]:not([aria-disabled='false']) {
-  opacity: 0.32;
-  cursor: default;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-size: 14px;
-  line-height: 22px;
-  display: flow-root;
-  color: var(--charcoal-text2);
-}
-
-.c4::before {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-top: -4px;
-}
-
-.c4::after {
-  display: block;
-  width: 0;
-  height: 0;
-  content: '';
-  margin-bottom: -4px;
-}
-
-.c2[type='checkbox'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  display: block;
-  width: 20px;
-  height: 20px;
-  margin: 0;
-  background-color: var(--charcoal-text3);
-  border-radius: 999999px;
-  -webkit-transition: 0.2s background-color,0.2s box-shadow;
-  transition: 0.2s background-color,0.2s box-shadow;
-}
-
-.c2[type='checkbox']:checked {
-  background-color: var(--charcoal-brand);
-}
-
-.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-hover);
-}
-
-.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:checked:active[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-press);
-}
-
-.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-hover);
-}
-
-.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.c2[type='checkbox']:active[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-press);
-}
-
-.c2[type='checkbox']:focus {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c2[type='checkbox']:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.c2[type='checkbox']:focus-visible {
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
-}
-
-.c3 {
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 999999px;
-  color: var(--charcoal-text5);
-  -webkit-transition: 0.2s box-shadow;
-  transition: 0.2s box-shadow;
-}
-
-.c0 {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-}
-
+exports[`Storybook Tests > react/MultiSelect > Playground 1`] = `
 <div
   data-dark={false}
 >
   <div
     aria-label=""
-    className="c0"
     data-testid="SelectGroup"
+    style={
+      Object {
+        "display": "grid",
+        "gap": "8px",
+        "gridTemplateColumns": "1fr",
+      }
+    }
   >
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name=""
         onChange={[Function]}
@@ -945,7 +473,9 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -953,7 +483,7 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢
         1
@@ -961,12 +491,13 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name=""
         onChange={[Function]}
@@ -975,7 +506,9 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -983,7 +516,7 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢
         2
@@ -991,12 +524,13 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name=""
         onChange={[Function]}
@@ -1005,7 +539,9 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -1013,7 +549,7 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢
         3
@@ -1021,12 +557,13 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
     </label>
     <label
       aria-disabled={false}
-      className="c1"
+      className="charcoal-multi-select"
     >
       <input
         aria-invalid={false}
         checked={false}
-        className="c2"
+        className="charcoal-multi-select-input"
+        data-overlay={false}
         disabled={false}
         name=""
         onChange={[Function]}
@@ -1035,7 +572,9 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
       />
       <div
         aria-hidden={true}
-        className="c3"
+        aria-invalid={false}
+        className="charcoal-multi-select-overlay"
+        data-overlay={false}
       >
         <pixiv-icon
           name="24/Check"
@@ -1043,7 +582,7 @@ exports[`Storybook Tests MultiSelect Playground 1`] = `
         />
       </div>
       <div
-        className="c4"
+        className="charcoal-multi-select-label"
       >
         選択肢
         4

--- a/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
+++ b/packages/react/src/components/MultiSelect/__snapshots__/index.story.storyshot
@@ -1,0 +1,1054 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storybook Tests MultiSelect Basic 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c2[type='checkbox']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c2[type='checkbox']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c2[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label="label"
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={true}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={true}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢4
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests MultiSelect Invalid 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c2[type='checkbox']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c2[type='checkbox']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c2[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c2[type='checkbox']:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox'][aria-disabled='false'] {
+  box-shadow: 0 0 0 4px rgba(255,43,0,0.32);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label="label"
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢4
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests MultiSelect Overlay 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+  background-color: var(--charcoal-surface4);
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c2[type='checkbox']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c2[type='checkbox']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c2[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+  border-color: var(--charcoal-text5);
+  border-width: 2px;
+  border-style: solid;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label="label"
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name="name"
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢4
+      </div>
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests MultiSelect Playground 1`] = `
+.c1 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.c1:disabled,
+.c1[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.c4::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.c4::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.c2[type='checkbox'] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  -webkit-transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.c2[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.c2[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.c2[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.c2[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.c2[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.c2[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.c2[type='checkbox']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c2[type='checkbox']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c2[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.c3 {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  -webkit-transition: 0.2s box-shadow;
+  transition: 0.2s box-shadow;
+}
+
+.c0 {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+<div
+  data-dark={false}
+>
+  <div
+    aria-label=""
+    className="c0"
+    data-testid="SelectGroup"
+  >
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name=""
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢1"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        1
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name=""
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢2"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        2
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name=""
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢3"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        3
+      </div>
+    </label>
+    <label
+      aria-disabled={false}
+      className="c1"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="c2"
+        disabled={false}
+        name=""
+        onChange={[Function]}
+        type="checkbox"
+        value="選択肢4"
+      />
+      <div
+        aria-hidden={true}
+        className="c3"
+      >
+        <pixiv-icon
+          name="24/Check"
+          unsafe-non-guideline-scale={0.6666666666666666}
+        />
+      </div>
+      <div
+        className="c4"
+      >
+        選択肢
+        4
+      </div>
+    </label>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/MultiSelect/context.ts
+++ b/packages/react/src/components/MultiSelect/context.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react'
+
+type MultiSelectGroupContext = {
+  name: string
+  selected: string[]
+  disabled: boolean
+  readonly: boolean
+  invalid: boolean
+  onChange: ({ value, selected }: { value: string; selected: boolean }) => void
+}
+
+export const MultiSelectGroupContext = createContext<MultiSelectGroupContext>({
+  name: undefined as never,
+  selected: [],
+  disabled: false,
+  readonly: false,
+  invalid: false,
+  onChange() {
+    throw new Error(
+      'Cannot find `onChange()` handler. Perhaps you forgot to wrap it with `<MultiSelectGroup />` ?'
+    )
+  },
+})

--- a/packages/react/src/components/MultiSelect/index.css
+++ b/packages/react/src/components/MultiSelect/index.css
@@ -14,11 +14,10 @@
 }
 
 .charcoal-multi-select-label {
-  display: flex;
+  display: flow-root;
   align-items: center;
   font-size: 14px;
   line-height: 22px;
-  display: flow-root;
   color: var(--charcoal-text2);
 }
 
@@ -46,47 +45,57 @@
   margin: 0;
   background-color: var(--charcoal-text3);
   border-radius: 999999px;
-  transition: 0.2s background-color,0.2s box-shadow;
+  transition: 0.2s background-color, 0.2s box-shadow;
 }
 
 .charcoal-multi-select-input[type='checkbox']:checked {
   background-color: var(--charcoal-brand);
 }
 
-.charcoal-multi-select-input[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
-.charcoal-multi-select-input[type='checkbox']:checked:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-hover);
-}
-
-.charcoal-multi-select-input[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
-.charcoal-multi-select-input[type='checkbox']:checked:active[aria-disabled='false'] {
-  background-color: var(--charcoal-brand-press);
-}
-
-.charcoal-multi-select-input[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
-.charcoal-multi-select-input[type='checkbox']:hover[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-hover);
-}
-
-.charcoal-multi-select-input[type='checkbox']:active:not(:disabled):not([aria-disabled]),
-.charcoal-multi-select-input[type='checkbox']:active[aria-disabled='false'] {
-  background-color: var(--charcoal-text3-press);
-}
-
 .charcoal-multi-select-input[type='checkbox']:focus {
   outline: none;
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+  box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
+}
+
+.charcoal-multi-select-input[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
 }
 
 .charcoal-multi-select-input[type='checkbox']:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.charcoal-multi-select-input[type='checkbox']:focus-visible {
-  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+.charcoal-multi-select-input[type='checkbox']:hover:not(:disabled):not(
+    [aria-disabled]
+  ),
+.charcoal-multi-select-input[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
 }
 
-.charcoal-multi-select-input[aria-invalid='true'][data-overlay='false']:not(:disabled):not([aria-disabled]) {
+.charcoal-multi-select-input[type='checkbox']:active:not(:disabled):not(
+    [aria-disabled]
+  ),
+.charcoal-multi-select-input[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.charcoal-multi-select-input[type='checkbox']:checked:hover:not(:disabled):not(
+    [aria-disabled]
+  ),
+.charcoal-multi-select-input[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.charcoal-multi-select-input[type='checkbox']:checked:active:not(:disabled):not(
+    [aria-disabled]
+  ),
+.charcoal-multi-select-input[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.charcoal-multi-select-input[aria-invalid='true'][data-overlay='false']:not(
+    :disabled
+  ):not([aria-disabled]) {
   box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
 }
 
@@ -113,7 +122,9 @@
   transition: 0.2s box-shadow;
 }
 
-.charcoal-multi-select-overlay[aria-invalid='true'][data-overlay='true']:not(:disabled):not([aria-disabled]) {
+.charcoal-multi-select-overlay[aria-invalid='true'][data-overlay='true']:not(
+    :disabled
+  ):not([aria-disabled]) {
   box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
 }
 

--- a/packages/react/src/components/MultiSelect/index.css
+++ b/packages/react/src/components/MultiSelect/index.css
@@ -1,0 +1,128 @@
+.charcoal-multi-select {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: 4px;
+}
+
+.charcoal-multi-select:disabled,
+.charcoal-multi-select[aria-disabled]:not([aria-disabled='false']) {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.charcoal-multi-select-label {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+}
+
+.charcoal-multi-select-label::before {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-top: -4px;
+}
+
+.charcoal-multi-select-label::after {
+  display: block;
+  width: 0;
+  height: 0;
+  content: '';
+  margin-bottom: -4px;
+}
+
+.charcoal-multi-select-input[type='checkbox'] {
+  appearance: none;
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  background-color: var(--charcoal-text3);
+  border-radius: 999999px;
+  transition: 0.2s background-color,0.2s box-shadow;
+}
+
+.charcoal-multi-select-input[type='checkbox']:checked {
+  background-color: var(--charcoal-brand);
+}
+
+.charcoal-multi-select-input[type='checkbox']:checked:hover:not(:disabled):not([aria-disabled]),
+.charcoal-multi-select-input[type='checkbox']:checked:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-hover);
+}
+
+.charcoal-multi-select-input[type='checkbox']:checked:active:not(:disabled):not([aria-disabled]),
+.charcoal-multi-select-input[type='checkbox']:checked:active[aria-disabled='false'] {
+  background-color: var(--charcoal-brand-press);
+}
+
+.charcoal-multi-select-input[type='checkbox']:hover:not(:disabled):not([aria-disabled]),
+.charcoal-multi-select-input[type='checkbox']:hover[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-hover);
+}
+
+.charcoal-multi-select-input[type='checkbox']:active:not(:disabled):not([aria-disabled]),
+.charcoal-multi-select-input[type='checkbox']:active[aria-disabled='false'] {
+  background-color: var(--charcoal-text3-press);
+}
+
+.charcoal-multi-select-input[type='checkbox']:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.charcoal-multi-select-input[type='checkbox']:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.charcoal-multi-select-input[type='checkbox']:focus-visible {
+  box-shadow: 0 0 0 4px rgba(0,150,250,0.32);
+}
+
+.charcoal-multi-select-input[aria-invalid='true'][data-overlay='false']:not(:disabled):not([aria-disabled]) {
+  box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+}
+
+.charcoal-multi-select-input[aria-invalid='true'][data-overlay='false'][aria-disabled='false'] {
+  box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+}
+
+.charcoal-multi-select-input[data-overlay='true'] {
+  background-color: var(--charcoal-surface4);
+}
+
+.charcoal-multi-select-overlay {
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  transition: 0.2s box-shadow;
+}
+
+.charcoal-multi-select-overlay[aria-invalid='true'][data-overlay='true']:not(:disabled):not([aria-disabled]) {
+  box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+}
+
+.charcoal-multi-select-overlay[aria-invalid='true'][data-overlay='true'][aria-disabled='false'] {
+  box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+}
+
+.charcoal-multi-select-overlay[data-overlay='true'] {
+  border-color: var(--charcoal-text5);
+  border-width: 2px;
+  border-style: solid;
+}

--- a/packages/react/src/components/MultiSelect/index.story.tsx
+++ b/packages/react/src/components/MultiSelect/index.story.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { MultiSelectGroup, default as MultiSelect } from '.'
+import { Meta, StoryObj } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+const StyledMultiSelectGroup = styled(MultiSelectGroup)`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+`
+
+export default {
+  title: 'MultiSelect',
+  component: MultiSelect,
+  argTypes: {
+    variant: {
+      control: {
+        type: 'inline-radio',
+        options: ['default', 'overlay'],
+      },
+    },
+  },
+  args: {
+    variant: 'default',
+  },
+} as Meta<typeof MultiSelect>
+
+export const Basic: StoryObj<typeof MultiSelect> = {
+  render: function Render(args) {
+    const options = ['選択肢1', '選択肢2', '選択肢3', '選択肢4']
+    return (
+      <StyledMultiSelectGroup
+        name="name"
+        label="label"
+        onChange={action('click')}
+        selected={['選択肢1', '選択肢3']}
+      >
+        {options.map((option) => (
+          <MultiSelect {...args} value={option} key={option}>
+            {option}
+          </MultiSelect>
+        ))}
+      </StyledMultiSelectGroup>
+    )
+  },
+}
+
+export const Invalid: StoryObj<typeof MultiSelect> = {
+  render: function Render(args) {
+    const options = ['選択肢1', '選択肢2', '選択肢3', '選択肢4']
+    return (
+      <StyledMultiSelectGroup
+        name="name"
+        label="label"
+        onChange={action('click')}
+        selected={[]}
+        invalid
+      >
+        {options.map((option) => (
+          <MultiSelect {...args} value={option} key={option}>
+            {option}
+          </MultiSelect>
+        ))}
+      </StyledMultiSelectGroup>
+    )
+  },
+}
+
+export const Overlay: StoryObj<typeof MultiSelect> = {
+  render: function Render(args) {
+    const options = ['選択肢1', '選択肢2', '選択肢3', '選択肢4']
+    return (
+      <StyledMultiSelectGroup
+        name="name"
+        label="label"
+        onChange={action('click')}
+        selected={[]}
+      >
+        {options.map((option) => (
+          <MultiSelect {...args} value={option} key={option}>
+            {option}
+          </MultiSelect>
+        ))}
+      </StyledMultiSelectGroup>
+    )
+  },
+  args: {
+    variant: 'overlay',
+  },
+}
+
+export const Playground: StoryObj<typeof MultiSelect> = {
+  render: function Render(args) {
+    const [selected, setSelected] = useState<string[]>([])
+
+    return (
+      <StyledMultiSelectGroup
+        name=""
+        label=""
+        onChange={setSelected}
+        selected={selected}
+      >
+        {[1, 2, 3, 4].map((idx) => (
+          <MultiSelect {...args} value={`選択肢${idx}`} key={idx}>
+            選択肢{idx}
+          </MultiSelect>
+        ))}
+      </StyledMultiSelectGroup>
+    )
+  },
+}

--- a/packages/react/src/components/MultiSelect/index.story.tsx
+++ b/packages/react/src/components/MultiSelect/index.story.tsx
@@ -1,17 +1,23 @@
 import { useState } from 'react'
-import styled from 'styled-components'
-import { MultiSelectGroup, default as MultiSelect } from '.'
+import {
+  MultiSelectGroup,
+  default as MultiSelect,
+  MultiSelectGroupProps,
+} from '.'
 import { Meta, StoryObj } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 
-const StyledMultiSelectGroup = styled(MultiSelectGroup)`
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 8px;
-`
+const StyledMultiSelectGroup = (props: MultiSelectGroupProps) => {
+  return (
+    <MultiSelectGroup
+      style={{ display: 'grid', gridTemplateColumns: '1fr', gap: '8px' }}
+      {...props}
+    />
+  )
+}
 
 export default {
-  title: 'MultiSelect',
+  title: 'react/MultiSelect',
   component: MultiSelect,
   argTypes: {
     variant: {

--- a/packages/react/src/components/MultiSelect/index.test.tsx
+++ b/packages/react/src/components/MultiSelect/index.test.tsx
@@ -1,7 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { ThemeProvider } from 'styled-components'
 import { default as MultiSelect, MultiSelectGroup } from '.'
-import { light } from '@charcoal-ui/theme'
 
 describe('MultiSelect', () => {
   describe('in development mode', () => {
@@ -12,13 +10,9 @@ describe('MultiSelect', () => {
     describe('when `<MultiSelect />` is used without `<MultiSelectGroup />`', () => {
       beforeEach(() => {
         // eslint-disable-next-line no-console
-        console.error = jest.fn()
+        console.error = vi.fn()
 
-        render(
-          <ThemeProvider theme={light}>
-            <MultiSelect value="a" />
-          </ThemeProvider>
-        )
+        render(<MultiSelect value="a" />)
       })
 
       it('emits error message', () => {
@@ -38,8 +32,8 @@ describe('MultiSelect', () => {
     let option3: HTMLInputElement
     let allOptions: HTMLInputElement[]
     let parent: HTMLDivElement
-    const childOnChange = jest.fn()
-    const parentOnChange = jest.fn()
+    const childOnChange = vi.fn()
+    const parentOnChange = vi.fn()
 
     beforeEach(() => {
       render(
@@ -89,8 +83,8 @@ describe('MultiSelect', () => {
     let option1: HTMLInputElement
     let option2: HTMLInputElement
     let option3: HTMLInputElement
-    const childOnChange = jest.fn()
-    const parentOnChange = jest.fn()
+    const childOnChange = vi.fn()
+    const parentOnChange = vi.fn()
 
     beforeEach(() => {
       render(
@@ -236,28 +230,26 @@ const TestComponent = ({
   firstOptionDisabled?: boolean
 }) => {
   return (
-    <ThemeProvider theme={light}>
-      <MultiSelectGroup
-        name="defaultName"
-        label="defaultAriaLabel"
-        disabled={parentDisabled}
-        onChange={parentOnChange}
-        {...{ selected, readonly, invalid }}
+    <MultiSelectGroup
+      name="defaultName"
+      label="defaultAriaLabel"
+      disabled={parentDisabled}
+      onChange={parentOnChange}
+      {...{ selected, readonly, invalid }}
+    >
+      <MultiSelect
+        value="option1"
+        disabled={firstOptionDisabled}
+        onChange={childOnChange}
       >
-        <MultiSelect
-          value="option1"
-          disabled={firstOptionDisabled}
-          onChange={childOnChange}
-        >
-          Option 1
-        </MultiSelect>
-        <MultiSelect value="option2" onChange={childOnChange}>
-          Option 2
-        </MultiSelect>
-        <MultiSelect value="option3" onChange={childOnChange}>
-          Option 3
-        </MultiSelect>
-      </MultiSelectGroup>
-    </ThemeProvider>
+        Option 1
+      </MultiSelect>
+      <MultiSelect value="option2" onChange={childOnChange}>
+        Option 2
+      </MultiSelect>
+      <MultiSelect value="option3" onChange={childOnChange}>
+        Option 3
+      </MultiSelect>
+    </MultiSelectGroup>
   )
 }

--- a/packages/react/src/components/MultiSelect/index.test.tsx
+++ b/packages/react/src/components/MultiSelect/index.test.tsx
@@ -1,0 +1,263 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import { default as MultiSelect, MultiSelectGroup } from '.'
+import { light } from '@charcoal-ui/theme'
+
+describe('MultiSelect', () => {
+  describe('in development mode', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development'
+    })
+
+    describe('when `<MultiSelect />` is used without `<MultiSelectGroup />`', () => {
+      beforeEach(() => {
+        // eslint-disable-next-line no-console
+        console.error = jest.fn()
+
+        render(
+          <ThemeProvider theme={light}>
+            <MultiSelect value="a" />
+          </ThemeProvider>
+        )
+      })
+
+      it('emits error message', () => {
+        // eslint-disable-next-line no-console
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /Perhaps you forgot to wrap with <MultiSelectGroup>/u
+          )
+        )
+      })
+    })
+  })
+
+  describe('none of the options selected', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+    let option3: HTMLInputElement
+    let allOptions: HTMLInputElement[]
+    let parent: HTMLDivElement
+    const childOnChange = jest.fn()
+    const parentOnChange = jest.fn()
+
+    beforeEach(() => {
+      render(
+        <TestComponent
+          selected={[]}
+          childOnChange={childOnChange}
+          parentOnChange={parentOnChange}
+        />
+      )
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+      option3 = screen.getByDisplayValue('option3')
+      allOptions = [option1, option2, option3]
+      parent = screen.getByTestId('SelectGroup')
+    })
+
+    it('options have correct name', () => {
+      allOptions.forEach((element) => expect(element.name).toBe('defaultName'))
+    })
+
+    it('parent have correct aria-label', () => {
+      expect(parent.getAttribute('aria-label')).toBe('defaultAriaLabel')
+    })
+
+    it('none of the options are selected', () => {
+      allOptions.forEach((element) => expect(element.checked).toBeFalsy())
+    })
+
+    describe('selecting option1', () => {
+      it('childOnChange is called', () => {
+        fireEvent.click(option1)
+        expect(childOnChange).toHaveBeenCalledWith({
+          value: 'option1',
+          selected: true,
+        })
+      })
+
+      it('parentOnChange is called', () => {
+        fireEvent.click(option1)
+        expect(parentOnChange).toHaveBeenCalledWith(['option1'])
+      })
+    })
+  })
+
+  describe('option2 is selected', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+    let option3: HTMLInputElement
+    const childOnChange = jest.fn()
+    const parentOnChange = jest.fn()
+
+    beforeEach(() => {
+      render(
+        <TestComponent
+          selected={['option2']}
+          childOnChange={childOnChange}
+          parentOnChange={parentOnChange}
+        />
+      )
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+      option3 = screen.getByDisplayValue('option3')
+    })
+
+    it('only option2 is selected', () => {
+      expect(option2.checked).toBeTruthy()
+      ;[option1, option3].forEach((element) =>
+        expect(element.checked).toBeFalsy()
+      )
+    })
+
+    describe('selecting option1', () => {
+      it('parentOnChange is called', () => {
+        fireEvent.click(option1)
+        expect(parentOnChange).toHaveBeenCalledWith(['option2', 'option1'])
+      })
+    })
+
+    describe('de-selecting option2', () => {
+      it('childOnChange is called', () => {
+        fireEvent.click(option2)
+        expect(childOnChange).toHaveBeenCalledWith({
+          value: 'option2',
+          selected: false,
+        })
+      })
+
+      it('parentOnChange is called', () => {
+        fireEvent.click(option2)
+        expect(parentOnChange).toHaveBeenCalledWith([])
+      })
+    })
+  })
+
+  describe('the group is disabled', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+    let option3: HTMLInputElement
+    let allOptions: HTMLInputElement[]
+
+    beforeEach(() => {
+      render(<TestComponent selected={['option1']} parentDisabled={true} />)
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+      option3 = screen.getByDisplayValue('option3')
+      allOptions = [option1, option2, option3]
+    })
+
+    it('all the options are disabled', () => {
+      allOptions.forEach((element) => expect(element.disabled).toBeTruthy())
+    })
+  })
+
+  describe('the group is readonly', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+    let option3: HTMLInputElement
+    let allOptions: HTMLInputElement[]
+
+    beforeEach(() => {
+      render(<TestComponent selected={['option1']} readonly={true} />)
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+      option3 = screen.getByDisplayValue('option3')
+      allOptions = [option1, option2, option3]
+    })
+
+    it('all the options are disabled', () => {
+      allOptions.forEach((element) => expect(element.disabled).toBeTruthy())
+    })
+  })
+
+  describe('the group has error', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+    let option3: HTMLInputElement
+    let allOptions: HTMLInputElement[]
+
+    beforeEach(() => {
+      render(<TestComponent selected={['option1']} invalid={true} />)
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+      option3 = screen.getByDisplayValue('option3')
+      allOptions = [option1, option2, option3]
+    })
+
+    it('all the options have `aria-invalid="true"`', () => {
+      allOptions.forEach((element) =>
+        expect(element.getAttribute('aria-invalid')).toBeTruthy()
+      )
+    })
+  })
+
+  describe('option1 is disabled', () => {
+    let option1: HTMLInputElement
+    let option2: HTMLInputElement
+
+    beforeEach(() => {
+      render(<TestComponent selected={[]} firstOptionDisabled={true} />)
+
+      option1 = screen.getByDisplayValue('option1')
+      option2 = screen.getByDisplayValue('option2')
+    })
+
+    it('only option1 is disabled', () => {
+      expect(option1.disabled).toBeTruthy()
+      expect(option2.disabled).toBeFalsy()
+    })
+  })
+})
+
+const TestComponent = ({
+  selected,
+  parentOnChange = () => {
+    return
+  },
+  childOnChange,
+  parentDisabled = false,
+  readonly = false,
+  invalid = false,
+  firstOptionDisabled = false,
+}: {
+  selected: string[]
+  parentOnChange?: (selected: string[]) => void
+  childOnChange?: (payload: { value: string; selected: boolean }) => void
+  parentDisabled?: boolean
+  readonly?: boolean
+  invalid?: boolean
+  firstOptionDisabled?: boolean
+}) => {
+  return (
+    <ThemeProvider theme={light}>
+      <MultiSelectGroup
+        name="defaultName"
+        label="defaultAriaLabel"
+        disabled={parentDisabled}
+        onChange={parentOnChange}
+        {...{ selected, readonly, invalid }}
+      >
+        <MultiSelect
+          value="option1"
+          disabled={firstOptionDisabled}
+          onChange={childOnChange}
+        >
+          Option 1
+        </MultiSelect>
+        <MultiSelect value="option2" onChange={childOnChange}>
+          Option 2
+        </MultiSelect>
+        <MultiSelect value="option3" onChange={childOnChange}>
+          Option 3
+        </MultiSelect>
+      </MultiSelectGroup>
+    </ThemeProvider>
+  )
+}

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -60,10 +60,8 @@ const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       <label aria-disabled={isDisabled} className={classNames}>
         <input
           className="charcoal-multi-select-input"
-          {...{
-            name,
-            value,
-          }}
+          name={name}
+          value={value}
           type="checkbox"
           checked={isSelected}
           disabled={isDisabled}

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -1,12 +1,11 @@
 import { ChangeEvent, useCallback, useContext, forwardRef, memo } from 'react'
 import * as React from 'react'
-import styled, { css } from 'styled-components'
 import warning from 'warning'
-import { px } from '@charcoal-ui/utils'
 
 import { MultiSelectGroupContext } from './context'
-import { focusVisibleFocusRingCss } from '@charcoal-ui/styled'
 import Icon from '../Icon'
+import { useClassNames } from '../../_lib/useClassNames'
+import './index.css'
 
 export type MultiSelectProps = React.PropsWithChildren<{
   value: string
@@ -56,176 +55,44 @@ const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
       },
       [onChange, parentOnChange, value]
     )
-
+    const classNames = useClassNames('charcoal-multi-select', className)
     return (
-      <MultiSelectRoot aria-disabled={isDisabled} className={className}>
-        <MultiSelectInput
+      <label aria-disabled={isDisabled} className={classNames}>
+        <input
+          className="charcoal-multi-select-input"
           {...{
             name,
             value,
-            invalid,
           }}
+          type="checkbox"
           checked={isSelected}
           disabled={isDisabled}
           onChange={handleChange}
-          overlay={variant === 'overlay'}
+          data-overlay={variant === 'overlay'}
           aria-invalid={invalid}
           ref={ref}
         />
-        <MultiSelectInputOverlay
-          overlay={variant === 'overlay'}
-          invalid={invalid}
+        <div
+          className="charcoal-multi-select-overlay"
+          data-overlay={variant === 'overlay'}
+          aria-invalid={invalid}
           aria-hidden={true}
         >
           <Icon name="24/Check" unsafe-non-guideline-scale={16 / 24} />
-        </MultiSelectInputOverlay>
-        {Boolean(children) && <MultiSelectLabel>{children}</MultiSelectLabel>}
-      </MultiSelectRoot>
+        </div>
+        {Boolean(children) && (
+          <div className="charcoal-multi-select-label">{children}</div>
+        )}
+      </label>
     )
   }
 )
 
 export default memo(MultiSelect)
 
-const MultiSelectRoot = styled.label`
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  position: relative;
-  cursor: pointer;
-  gap: ${({ theme }) => px(theme.spacing[4])};
-  &:disabled,
-  &[aria-disabled]:not([aria-disabled='false']) {
-    opacity: 0.32;
-    cursor: default;
-  }
-`
-
-const MultiSelectLabel = styled.div`
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  line-height: 22px;
-  display: flow-root;
-  color: var(--charcoal-text2);
-
-  &::before {
-    display: block;
-    width: 0;
-    height: 0;
-    content: '';
-    margin-top: -4px;
-  }
-  &::after {
-    display: block;
-    width: 0;
-    height: 0;
-    content: '';
-    margin-bottom: -4px;
-  }
-`
-
-const MultiSelectInput = styled.input.attrs({ type: 'checkbox' })<{
-  invalid: boolean
-  overlay: boolean
-}>`
-  &[type='checkbox'] {
-    appearance: none;
-    display: block;
-    width: 20px;
-    height: 20px;
-    margin: 0;
-    background-color: var(--charcoal-text3);
-    border-radius: 999999px;
-    transition: 0.2s background-color, 0.2s box-shadow;
-
-    &:checked {
-      background-color: var(--charcoal-brand);
-      &:hover {
-        &:not(:disabled):not([aria-disabled]),
-        &[aria-disabled='false'] {
-          background-color: var(--charcoal-brand-hover);
-        }
-      }
-
-      &:active {
-        &:not(:disabled):not([aria-disabled]),
-        &[aria-disabled='false'] {
-          background-color: var(--charcoal-brand-press);
-        }
-      }
-    }
-
-    &:hover {
-      &:not(:disabled):not([aria-disabled]),
-      &[aria-disabled='false'] {
-        background-color: var(--charcoal-text3-hover);
-      }
-    }
-
-    &:active {
-      &:not(:disabled):not([aria-disabled]),
-      &[aria-disabled='false'] {
-        background-color: var(--charcoal-text3-press);
-      }
-    }
-
-    ${focusVisibleFocusRingCss}
-
-    ${({ invalid, overlay }) =>
-      invalid &&
-      !overlay &&
-      css`
-        &:not(:disabled):not([aria-disabled]),
-        &[aria-disabled='false'] {
-          box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
-        }
-      `}
-    ${({ overlay }) =>
-      overlay &&
-      css`
-        background-color: var(--charcoal-surface4);
-      `}
-  }
-`
-
-const MultiSelectInputOverlay = styled.div<{
-  overlay: boolean
-  invalid: boolean
-}>`
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 999999px;
-  color: var(--charcoal-text5);
-  transition: 0.2s box-shadow;
-  ${({ invalid, overlay }) =>
-    invalid &&
-    overlay &&
-    css`
-      &:not(:disabled):not([aria-disabled]),
-      &[aria-disabled='false'] {
-        box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
-      }
-    `}
-
-  ${({ overlay }) =>
-    overlay &&
-    css`
-      border-color: var(--charcoal-text5);
-      border-width: 2px;
-      border-style: solid;
-    `}
-`
-
 export type MultiSelectGroupProps = React.PropsWithChildren<{
   className?: string
+  style?: React.CSSProperties
   name: string
   label: string
   selected: string[]
@@ -237,6 +104,7 @@ export type MultiSelectGroupProps = React.PropsWithChildren<{
 
 export function MultiSelectGroup({
   className,
+  style,
   name,
   label,
   selected,
@@ -274,7 +142,12 @@ export function MultiSelectGroup({
         onChange: handleChange,
       }}
     >
-      <div className={className} aria-label={label} data-testid="SelectGroup">
+      <div
+        className={className}
+        style={style}
+        aria-label={label}
+        data-testid="SelectGroup"
+      >
         {children}
       </div>
     </MultiSelectGroupContext.Provider>

--- a/packages/react/src/components/MultiSelect/index.tsx
+++ b/packages/react/src/components/MultiSelect/index.tsx
@@ -1,0 +1,282 @@
+import { ChangeEvent, useCallback, useContext, forwardRef, memo } from 'react'
+import * as React from 'react'
+import styled, { css } from 'styled-components'
+import warning from 'warning'
+import { px } from '@charcoal-ui/utils'
+
+import { MultiSelectGroupContext } from './context'
+import { focusVisibleFocusRingCss } from '@charcoal-ui/styled'
+import Icon from '../Icon'
+
+export type MultiSelectProps = React.PropsWithChildren<{
+  value: string
+  disabled?: boolean
+  variant?: 'default' | 'overlay'
+  className?: string
+  onChange?: (payload: { value: string; selected: boolean }) => void
+}>
+
+const MultiSelect = forwardRef<HTMLInputElement, MultiSelectProps>(
+  function MultiSelectInner(
+    {
+      value,
+      disabled = false,
+      onChange,
+      variant = 'default',
+      className,
+      children,
+    },
+    ref
+  ) {
+    const {
+      name,
+      selected,
+      disabled: parentDisabled,
+      readonly,
+      invalid,
+      onChange: parentOnChange,
+    } = useContext(MultiSelectGroupContext)
+
+    warning(
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      name !== undefined,
+      `"name" is not Provided for <MultiSelect>. Perhaps you forgot to wrap with <MultiSelectGroup> ?`
+    )
+
+    const isSelected = selected.includes(value)
+    const isDisabled = disabled || parentDisabled || readonly
+
+    const handleChange = useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        if (!(event.currentTarget instanceof HTMLInputElement)) {
+          return
+        }
+        if (onChange) onChange({ value, selected: event.currentTarget.checked })
+        parentOnChange({ value, selected: event.currentTarget.checked })
+      },
+      [onChange, parentOnChange, value]
+    )
+
+    return (
+      <MultiSelectRoot aria-disabled={isDisabled} className={className}>
+        <MultiSelectInput
+          {...{
+            name,
+            value,
+            invalid,
+          }}
+          checked={isSelected}
+          disabled={isDisabled}
+          onChange={handleChange}
+          overlay={variant === 'overlay'}
+          aria-invalid={invalid}
+          ref={ref}
+        />
+        <MultiSelectInputOverlay
+          overlay={variant === 'overlay'}
+          invalid={invalid}
+          aria-hidden={true}
+        >
+          <Icon name="24/Check" unsafe-non-guideline-scale={16 / 24} />
+        </MultiSelectInputOverlay>
+        {Boolean(children) && <MultiSelectLabel>{children}</MultiSelectLabel>}
+      </MultiSelectRoot>
+    )
+  }
+)
+
+export default memo(MultiSelect)
+
+const MultiSelectRoot = styled.label`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  position: relative;
+  cursor: pointer;
+  gap: ${({ theme }) => px(theme.spacing[4])};
+  &:disabled,
+  &[aria-disabled]:not([aria-disabled='false']) {
+    opacity: 0.32;
+    cursor: default;
+  }
+`
+
+const MultiSelectLabel = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  line-height: 22px;
+  display: flow-root;
+  color: var(--charcoal-text2);
+
+  &::before {
+    display: block;
+    width: 0;
+    height: 0;
+    content: '';
+    margin-top: -4px;
+  }
+  &::after {
+    display: block;
+    width: 0;
+    height: 0;
+    content: '';
+    margin-bottom: -4px;
+  }
+`
+
+const MultiSelectInput = styled.input.attrs({ type: 'checkbox' })<{
+  invalid: boolean
+  overlay: boolean
+}>`
+  &[type='checkbox'] {
+    appearance: none;
+    display: block;
+    width: 20px;
+    height: 20px;
+    margin: 0;
+    background-color: var(--charcoal-text3);
+    border-radius: 999999px;
+    transition: 0.2s background-color, 0.2s box-shadow;
+
+    &:checked {
+      background-color: var(--charcoal-brand);
+      &:hover {
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          background-color: var(--charcoal-brand-hover);
+        }
+      }
+
+      &:active {
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          background-color: var(--charcoal-brand-press);
+        }
+      }
+    }
+
+    &:hover {
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        background-color: var(--charcoal-text3-hover);
+      }
+    }
+
+    &:active {
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        background-color: var(--charcoal-text3-press);
+      }
+    }
+
+    ${focusVisibleFocusRingCss}
+
+    ${({ invalid, overlay }) =>
+      invalid &&
+      !overlay &&
+      css`
+        &:not(:disabled):not([aria-disabled]),
+        &[aria-disabled='false'] {
+          box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+        }
+      `}
+    ${({ overlay }) =>
+      overlay &&
+      css`
+        background-color: var(--charcoal-surface4);
+      `}
+  }
+`
+
+const MultiSelectInputOverlay = styled.div<{
+  overlay: boolean
+  invalid: boolean
+}>`
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 999999px;
+  color: var(--charcoal-text5);
+  transition: 0.2s box-shadow;
+  ${({ invalid, overlay }) =>
+    invalid &&
+    overlay &&
+    css`
+      &:not(:disabled):not([aria-disabled]),
+      &[aria-disabled='false'] {
+        box-shadow: 0 0 0 4px rgba(255, 43, 0, 0.32);
+      }
+    `}
+
+  ${({ overlay }) =>
+    overlay &&
+    css`
+      border-color: var(--charcoal-text5);
+      border-width: 2px;
+      border-style: solid;
+    `}
+`
+
+export type MultiSelectGroupProps = React.PropsWithChildren<{
+  className?: string
+  name: string
+  label: string
+  selected: string[]
+  onChange: (selected: string[]) => void
+  disabled?: boolean
+  readonly?: boolean
+  invalid?: boolean
+}>
+
+export function MultiSelectGroup({
+  className,
+  name,
+  label,
+  selected,
+  onChange,
+  disabled = false,
+  readonly = false,
+  invalid = false,
+  children,
+}: MultiSelectGroupProps) {
+  const handleChange = useCallback(
+    (payload: { value: string; selected: boolean }) => {
+      const index = selected.indexOf(payload.value)
+
+      if (payload.selected) {
+        if (index < 0) {
+          onChange([...selected, payload.value])
+        }
+      } else {
+        if (index >= 0) {
+          onChange([...selected.slice(0, index), ...selected.slice(index + 1)])
+        }
+      }
+    },
+    [onChange, selected]
+  )
+
+  return (
+    <MultiSelectGroupContext.Provider
+      value={{
+        name,
+        selected: Array.from(new Set(selected)),
+        disabled,
+        readonly,
+        invalid,
+        onChange: handleChange,
+      }}
+    >
+      <div className={className} aria-label={label} data-testid="SelectGroup">
+        {children}
+      </div>
+    </MultiSelectGroupContext.Provider>
+  )
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -15,6 +15,12 @@ export {
 } from './components/IconButton'
 export { default as Radio, type RadioProps } from './components/Radio'
 export { RadioGroup, type RadioGroupProps } from './components/Radio/RadioGroup'
+export {
+  default as MultiSelect,
+  type MultiSelectProps,
+  MultiSelectGroup,
+  type MultiSelectGroupProps,
+} from './components/MultiSelect'
 export { default as Switch, type SwitchProps } from './components/Switch'
 export {
   default as TextField,


### PR DESCRIPTION
## やったこと

- Revert "feat: remove MultiSelect"
- feat: refactor multiSelect to css
- fix: css order by stylelint
- fix: remove extra props spreading

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
