### PR TITLE
fix: restore ClickableElement type

### DIFF
--- a/packages/react/src/components/Clickable/index.tsx
+++ b/packages/react/src/components/Clickable/index.tsx
@@ -24,3 +24,9 @@ const Clickable = forwardRef(function Clickable<T extends React.ElementType>(
   p: ClickableProps<T>
 ) => JSX.Element
 export default Clickable
+
+/**
+ * @deprecated
+ * remained for v3 compatibility and will be removed in the future
+ */
+export type ClickableElement = HTMLButtonElement & HTMLAnchorElement

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,6 +8,7 @@ export { default as Button, type ButtonProps } from './components/Button'
 export {
   default as Clickable,
   type ClickableProps,
+  type ClickableElement,
 } from './components/Clickable'
 export {
   default as IconButton,


### PR DESCRIPTION
## やったこと

- fix: restore clickable element type

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
