### PR TITLE
icon更新をmain以外のブランチに対しても行えるようにする

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -49,5 +49,5 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
-          GITHUB_DEFAULT_BRANCH: main
+          GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
         run: yarn icons-cli github:pr


### PR DESCRIPTION
## やったこと

- icons-cliを動かすActionで、PRを作るときのtarget branchをActionを実行したブランチになるようにしました
- v4とv3の両方でiconsを更新するため
- 実行例: #687 

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
