### PR TITLE
v3用のリリースタグを選べるようにする

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
         options:
           - latest
           - beta
+          - v3
 
 jobs:
   build:


### PR DESCRIPTION
## やったこと

- publishのCIのrelease tag optionに `v3` を追加しました

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
