### PR TITLE
playwrightのinstallでこけてるの直す

### DIFF
--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -11,7 +11,7 @@ jobs:
   prepare-base-branch:
     name: Prepare base branch image snapshots
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
   test-storybook:
     name: Build Storybook
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-base-branch
     steps:
       - name: Checkout branch


### PR DESCRIPTION
## やったこと

- ubuntu-latestが24.04になったことにより必要な依存がなくなってこけるようになったようなので、22.04固定に変更しました
  - success: https://github.com/pixiv/charcoal/actions/runs/12803670787/job/35696732205?pr=692
  - failure: https://github.com/pixiv/charcoal/actions/runs/12803602132/job/35696546248

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
