### PR TITLE
fix: update unsafe non guideline scale ssr guide

### DIFF
--- a/packages/icons/src/SSR.mdx
+++ b/packages/icons/src/SSR.mdx
@@ -40,9 +40,11 @@ pixiv-icon {
   --scale: 3;
 }
 
-/* NOTICE: 現状と attr(... number) ほぼ変とのブラウザも少ない */
-&[unsafe-non-guideline-scale] {
-  --scale: attr(unsafe-non-guideline-scale number);
+/* NOTICE: 現状とサポートブラウザが少ない */
+@supports (--scale: attr(unsafe-non-guideline-scale)) {
+  &[unsafe-non-guideline-scale] {
+    --scale: attr(unsafe-non-guideline-scale);
+  }
 }
 ```
 


### PR DESCRIPTION
## やったこと

chrome 133よりattr numberの挙動が変わってないほうが無難

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
