### PR TITLE
chore(react): fix text field prefix, suffix visible condition

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -108,9 +108,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           data-invalid={invalid === true}
           ref={containerRef}
         >
-          {prefix !== null && (
-            <div className="charcoal-text-field-prefix">{prefix}</div>
-          )}
+          {prefix && <div className="charcoal-text-field-prefix">{prefix}</div>}
           <input
             className="charcoal-text-field-input"
             aria-describedby={showAssistiveText ? describedbyId : undefined}
@@ -126,7 +124,7 @@ const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             value={value}
             {...props}
           />
-          {(suffix !== null || showCount) && (
+          {(suffix || showCount) && (
             <div className="charcoal-text-field-suffix">
               {suffix}
               {showCount && (

--- a/packages/react/src/components/TextField/text-field.test.tsx
+++ b/packages/react/src/components/TextField/text-field.test.tsx
@@ -1,0 +1,72 @@
+import { render } from '@testing-library/react'
+import TextField from '.'
+
+import '@testing-library/jest-dom'
+
+describe('TextField component', () => {
+  it('should not render prefix and suffix when not provided', () => {
+    const { container } = render(<TextField />)
+
+    // prefix and suffix elements should not be rendered
+    const prefixElement = container.querySelector('.charcoal-text-field-prefix')
+    const suffixElement = container.querySelector('.charcoal-text-field-suffix')
+
+    expect(prefixElement).toBeNull()
+    expect(suffixElement).toBeNull()
+  })
+
+  test.each([
+    [null, 'null'],
+    [undefined, 'undefined'],
+    ['', 'empty string'],
+    [false, 'boolean false'],
+    [0, 'zero'],
+  ])(
+    'should not render prefix when value is falsy (%s: %s)',
+    (prefixValue, _desc) => {
+      const { container } = render(<TextField prefix={prefixValue} />)
+      const prefixElement = container.querySelector('.charcoal-text-prefix')
+      expect(prefixElement).toBeNull()
+    }
+  )
+
+  test.each([
+    [null, 'null'],
+    [undefined, 'undefined'],
+    ['', 'empty string'],
+    [false, 'boolean false'],
+    [0, 'zero'],
+  ])(
+    'should not render suffix when value is falsy (%s: %s) and showCount is false',
+    (suffixValue, _desc) => {
+      const { container } = render(
+        <TextField suffix={suffixValue} showCount={false} />
+      )
+      const suffixElement = container.querySelector(
+        '.charcoal-text-field-suffix'
+      )
+      expect(suffixElement).toBeNull()
+    }
+  )
+
+  it('should render prefix and suffix when provided as truthy values', () => {
+    const prefixContent = 'Test Prefix'
+    const suffixContent = 'Test Suffix'
+    const { container, getByText } = render(
+      <TextField
+        prefix={<span>{prefixContent}</span>}
+        suffix={<span>{suffixContent}</span>}
+      />
+    )
+
+    const prefixElement = container.querySelector('.charcoal-text-field-prefix')
+    const suffixElement = container.querySelector('.charcoal-text-field-suffix')
+
+    expect(prefixElement).not.toBeNull()
+    expect(suffixElement).not.toBeNull()
+
+    // Verify text content
+    expect(getByText(prefixContent)).toBeInTheDocument()
+    expect(getByText(suffixContent)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## やったこと

- TextField component の prefix, suffix の表示条件を基に戻した

## 動作確認環境
- test
- storybook

## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
