### PR TITLE
fix/disable postpublish for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fmt:stylelint": "stylelint '**/*.{css,jsx,tsx}' --fix -f verbose",
     "release": "pnpm install && pnpm run clean && pnpm run build && lerna publish --no-changelog --no-private",
     "release:alpha": "pnpm run release --conventional-prerelease --dist-tag alpha",
-    "postpublish": "zx ./misc/fix-versioning.mjs && ./misc/postpublish.sh",
+    "_postpublish": "zx ./misc/fix-versioning.mjs && ./misc/postpublish.sh",
     "website": "vite docs --base=charcoal/docs --port 5000",
     "prepare": "husky"
   },


### PR DESCRIPTION

## やったこと

- `misc/fix-versioning`はworkspace以外のバージョンをfixしているが、現状そういうものがないので一旦無効化してみます。確認取れたら消します

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
