### PR TITLE
fix: move push command after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,12 +53,14 @@ jobs:
       - name: Set package version
         run: pnpm lerna version ${{ github.event.inputs.version }} --no-push --force-publish --yes
 
-      - name: git push version up commits
-        run: |
-          git push origin ${{ github.ref_name }}
-
       - name: Build & Publish to npmjs
         run: pnpm release --tag ${{ github.event.inputs.release_tag }}
         env:
           NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # push tag only when publish success
+      - name: git push version up commits
+        run: |
+          git tag ${{ github.event.inputs.release_tag }}
+          git push origin ${{ github.ref_name }} --tags


### PR DESCRIPTION
## やったこと

- tagの作成追加してpushと一緒にpublish後に移動した

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
