### PR TITLE
fix: pnpm exec icons-cli

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -37,13 +37,13 @@ jobs:
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
-        run: pnpm icons-cli figma:export
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export
 
       - name: Optimize icons
-        run: pnpm icons-cli svg:optimize --ignoreFile ./misc/icons-cli-denylist
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons svg:optimize --ignoreFile ./misc/icons-cli-denylist
 
       - name: Generate icon files
-        run: pnpm icons-cli files:generate
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons files:generate
 
       - name: Generate github token
         id: generate_token
@@ -58,4 +58,4 @@ jobs:
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: ${{ env.TARGET_BRANCH }}
-        run: pnpm icons-cli github:pr
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons github:pr

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "FORCE_COLOR=1 tsup-node",
     "typecheck": "tsc --project tsconfig.build.json --pretty --noEmit",
-    "clean": "rimraf dist .tsbuildinfo"
+    "clean": "rimraf dist .tsbuildinfo",
+    "cli:icons": "./dist/index.js"
   },
   "devDependencies": {
     "@gitbeaker/core": "^25.6.0",


### PR DESCRIPTION
## やったこと

- `pnpm exec icons-cli` のように、icons-cliがpnpm環境下で正常に実行されるよう、workflowファイルを修正しました。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
