### PR TITLE
fix: ThemeColor doc display

### DIFF
--- a/packages/theme/src/docs/ThemeColors.tsx
+++ b/packages/theme/src/docs/ThemeColors.tsx
@@ -1,5 +1,5 @@
 import { light, dark, ThemeColor } from '..'
-import { useDarkMode } from 'storybook-dark-mode'
+import { useDarkMode } from '../../../../.storybook/use-dark-mode'
 
 type ColorProps = keyof ThemeColor
 


### PR DESCRIPTION
## やったこと

- fix Storybook preview hooks can only be called inside decorators and story functions.

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
