### PR TITLE
icons-cli: fix pdf export

### DIFF
--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -34,15 +34,6 @@ function isIconNode(node: Figma.Node) {
 
 type ExportFormat = 'svg' | 'pdf'
 
-function getContentType(exportFormat: ExportFormat) {
-  switch (exportFormat) {
-    case 'svg':
-      return 'image/svg+xml'
-    case 'pdf':
-      return 'application/pdf'
-  }
-}
-
 interface Component {
   id: string
   name: string
@@ -141,13 +132,10 @@ export class FigmaFileClient {
           return
         }
 
-        const response = await got.get(component.image, {
-          headers: {
-            'Content-Type': getContentType(this.exportFormat),
-          },
-          encoding: 'utf8',
-          ...(this.exportFormat == 'pdf' ? { responseType: 'buffer' } : {}),
-        })
+        const response = await got.get(
+          component.image,
+          this.exportFormat == 'pdf' ? { responseType: 'buffer' } : {}
+        )
 
         const filename = `${filenamify(component.name)}.${this.exportFormat}`
         const fullname = path.join(outputDir, filename)

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -34,6 +34,15 @@ function isIconNode(node: Figma.Node) {
 
 type ExportFormat = 'svg' | 'pdf'
 
+function getContentType(exportFormat: ExportFormat) {
+  switch (exportFormat) {
+    case 'svg':
+      return 'image/svg+xml'
+    case 'pdf':
+      return 'application/pdf'
+  }
+}
+
 interface Component {
   id: string
   name: string
@@ -131,7 +140,12 @@ export class FigmaFileClient {
           return
         }
 
-        const svg = await got(component.image).text()
+        const response = await got.get(component.image, {
+          headers: {
+            'Content-Type': getContentType(this.exportFormat),
+          },
+          encoding: 'utf8',
+        })
 
         const filename = `${filenamify(component.name)}.${this.exportFormat}`
         const fullname = path.join(outputDir, filename)
@@ -141,7 +155,7 @@ export class FigmaFileClient {
 
         // eslint-disable-next-line no-console
         console.log(`found: ${filename} => ✅ writing...`)
-        await writeFile(fullname, svg, 'utf8')
+        await writeFile(fullname, response.body, 'utf8')
       })
     )
   }

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -126,6 +126,7 @@ export class FigmaFileClient {
       format: this.exportFormat,
       ids: Object.keys(this.components),
       scale: 1,
+      ...(this.exportFormat == 'pdf' ? { use_absolute_bounds: true } : {}),
     })
 
     for (const [id, image] of Object.entries(data.images)) {
@@ -145,6 +146,7 @@ export class FigmaFileClient {
             'Content-Type': getContentType(this.exportFormat),
           },
           encoding: 'utf8',
+          ...(this.exportFormat == 'pdf' ? { responseType: 'buffer' } : {}),
         })
 
         const filename = `${filenamify(component.name)}.${this.exportFormat}`


### PR DESCRIPTION
## やったこと

- PDFファイルはバイナリのままダウンロードする必要があるため、gotに `responseType: 'buffer` を追加
- コンテンツがある領域が切り取られるようになっていたため、 fileImagesの取得時に `use_absolute_bounds: true` を追加

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
