### PR TITLE
chore: remove adding release tag to git

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,4 @@ jobs:
 
       # push tag only when publish success
       - name: git push version up commits
-        run: |
-          git tag ${{ github.event.inputs.release_tag }}
-          git push origin ${{ github.ref_name }} --tags
+        run: git push origin ${{ github.ref_name }} --tags

--- a/lerna.json
+++ b/lerna.json
@@ -86,5 +86,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "4.6.0"
+  "version": "4.6.1-beta.0"
 }

--- a/packages/esbuild-plugin-styled-components/package.json
+++ b/packages/esbuild-plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/esbuild-plugin-styled-components",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "private": true,
   "license": "Apache-2.0",
   "main": "src/index.ts",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "bin": "./dist/index.js",
   "scripts": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/pullrequest-cli/package.json
+++ b/packages/pullrequest-cli/package.json
@@ -31,5 +31,5 @@
     "url": "https://github.com/pixiv/charcoal.git",
     "directory": "packages/icons-cli"
   },
-  "version": "4.6.0"
+  "version": "4.6.1-beta.0"
 }

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs.js",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "bin": "bin/tailwind-diff.js",
   "scripts": {
     "build": "tsc",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "FORCE_COLOR=1 tsup-node",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "4.6.0",
+  "version": "4.6.1-beta.0",
   "license": "Apache-2.0",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",


### PR DESCRIPTION
## やったこと

- npmjsに設定しているリリースタグをgitにも設定するのをやめました
    - latestやbetaは頻繁に更新され、gitのtagとしての運用が難しいと判断したため

## 動作確認環境
https://github.com/pixiv/charcoal/actions/runs/15106431448/job/42456034578
https://github.com/pixiv/charcoal/releases/tag/v4.6.1-beta.0

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
