### PR TITLE
fix: export LoadingSpinnerIconHandler type

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -54,6 +54,7 @@ export {
 export {
   default as LoadingSpinner,
   LoadingSpinnerIcon,
+  type LoadingSpinnerIconHandler,
 } from './components/LoadingSpinner'
 export {
   default as DropdownSelector,


### PR DESCRIPTION
## やったこと

- export LoadingSpinnerIconHandler type since some users are importing this from dist

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
