### PR TITLE
fix(theme): enable TypeScript declaration generation

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -40,7 +40,6 @@
   "scripts": {
     "build": "npm-run-all --print-label -s 'build:*' --sequential serialize",
     "build:bundle": "FORCE_COLOR=1 tsup",
-    "build:dts": "tsc --project tsconfig.build.json --pretty --emitDeclarationOnly",
     "build:copy-css": "cpx --clean 'src/unstable-css/**/*.{css,d.ts}' dist/unstable-css",
     "build:token-object": "tsx cli/token-object.ts",
     "serialize": "node cli/index.js",

--- a/packages/theme/tsup.config.ts
+++ b/packages/theme/tsup.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
   },
   target: 'esnext',
   sourcemap: true,
+  dts: true,
   clean: true,
 })


### PR DESCRIPTION
## やったこと

- theme packakge の dts 生成を tsup に委任
  - workspace build を行うと theme package で build がコケるようになっていたため
 
## 動作確認環境
- CI/Local
## チェックリスト

不要なチェック項目は消して構いません

- [X] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [X] 追加したコンポーネントが index.ts から再 export されている
- [X] README やドキュメントに影響があることを確認した
