### PR TITLE
fix: HintText make context prop optional

### DIFF
--- a/packages/react/src/components/HintText/index.tsx
+++ b/packages/react/src/components/HintText/index.tsx
@@ -7,13 +7,13 @@ import { useClassNames } from '../../_lib/useClassNames'
 export type HintTextContext = 'page' | 'section'
 export interface HintTextProps {
   children: ReactNode
-  context: HintTextContext
+  context?: HintTextContext
   className?: string
 }
 
 export default function HintText({
   children,
-  context,
+  context = 'section',
   className,
 }: HintTextProps) {
   const classNames = useClassNames('charcoal-hint-text', className)


### PR DESCRIPTION
## やったこと

- make context prop default to 'section'

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
