### PR TITLE
fix: make tw classnames lowercase

### DIFF
--- a/packages/tailwind-config/src/icons.ts
+++ b/packages/tailwind-config/src/icons.ts
@@ -10,7 +10,9 @@ const transformClassNameV2 = (fileName: string) => {
     name.replaceAll('.', '-'),
     ...(variant === 'regular' ? [] : [variant]),
     ...(size === '24' ? [] : [size]),
-  ].join('-')
+  ]
+    .join('-')
+    .toLowerCase()
 }
 
 const transformClassNameV1 = (fileName: string) => {
@@ -19,7 +21,9 @@ const transformClassNameV1 = (fileName: string) => {
     '.icon-v1',
     name.replaceAll('.', '-'),
     ...(size === '24' ? [] : [size]),
-  ].join('-')
+  ]
+    .join('-')
+    .toLowerCase()
 }
 
 export const createIconUtilities = ({ v2 = false }: { v2?: boolean }) => {


### PR DESCRIPTION
## やったこと

- This is technically breaking change but the tailwind icons are unstable in v4.

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
