### PR TITLE
icon.ymlがIcons 2.0も生成するようにする

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  OUTPUT_ROOT_DIR: ../icon-files/
   TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'main' }}
 
 jobs:
@@ -33,17 +32,57 @@ jobs:
       - name: Build icons
         run: pnpm --filter @charcoal-ui/icons-cli run build
 
-      - name: Export icons
+      - name: Export icons 1.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export
 
-      - name: Optimize icons
+      - name: Optimize icons 1.0
+        env:
+          OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons svg:optimize --ignoreFile ../../misc/icons-cli-denylist
 
-      - name: Generate icon files
+      - name: Generate icon 1.0 files
+        env:
+          OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons files:generate
+
+      - name: build icons 1.0 data uri
+        run: pnpm --filter @charcoal-ui/icons-cli build:uri-v1
+
+      - name: build icons 1.0 svgo
+        run: pnpm --filter @charcoal-ui/icons-cli build:react-v1
+
+      - name: build icons 1.0 css
+        run: pnpm --filter @charcoal-ui/icons-cli build:css-v1
+
+      - name: Export icons 2.0
+        env:
+          FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          OUTPUT_ROOT_DIR: ../icon-files/v2
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2
+
+      - name: Optimize icons 2.0
+        env:
+          OUTPUT_ROOT_DIR: ../icon-files/v2
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons svg:optimize --ignoreFile ../../misc/icons-cli-denylist
+
+      - name: Generate icon 2.0 files
+        env:
+          OUTPUT_ROOT_DIR: ../icon-files/v2
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons files:generate
+
+      - name: build icons 2.0 data uri
+        run: pnpm --filter @charcoal-ui/icons-cli build:uri
+
+      - name: build icons 2.0 svgo
+        run: pnpm --filter @charcoal-ui/icons-cli build:react
+
+      - name: build icons 2.0 css
+        run: pnpm --filter @charcoal-ui/icons-cli build:css
 
       - name: Generate github token
         id: generate_token
@@ -52,10 +91,11 @@ jobs:
           app_id: ${{ secrets.CHARCOAL_BOT_APP_ID }}
           private_key: ${{ secrets.CHARCOAL_BOT_PRIVATE_KEY }}
 
-      - name: Create Pull Request for updated icons
+      - name: Create Pull Request
         env:
           GITHUB_ACCESS_TOKEN: ${{ steps.generate_token.outputs.token }}
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
-          GITHUB_DEFAULT_BRANCH: ${{ env.TARGET_BRANCH }}
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons github:pr
+          GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
+          TARGET_DIR: packages
+        run: pnpm pullrequest-cli github:pr -c icons -t 'Update icons'

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -38,7 +38,7 @@ jobs:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --sleepMs 1000
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export
 
       - name: Optimize icons 1.0
         env:
@@ -64,7 +64,7 @@ jobs:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2 --sleepMs 1000
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2
 
       - name: Optimize icons 2.0
         env:

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Export icons 1.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export
 
@@ -61,7 +61,7 @@ jobs:
       - name: Export icons 2.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2
 

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -97,5 +97,5 @@ jobs:
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
-          TARGET_DIR: packages
+          TARGET_DIRS: packages/icons,packages/icon-files
         run: pnpm pullrequest-cli github:pr -c icons -t 'Update icons'

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -37,7 +37,7 @@ jobs:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --sleepMs 1000
 
       - name: Optimize icons 1.0
         env:
@@ -63,7 +63,7 @@ jobs:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2 --sleepMs 1000
 
       - name: Optimize icons 2.0
         env:

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -104,5 +104,5 @@ jobs:
           GITHUB_REPO_OWNER: pixiv
           GITHUB_REPO_NAME: charcoal
           GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
-          TARGET_DIRS: packages/icons,packages/icon-files
+          TARGET_DIRS: packages/icons,packages/icon-files,packages/tailwind-config
         run: pnpm pullrequest-cli github:pr -c icons -t 'Update icons'

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -29,13 +29,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # あとでsnapshot updateを行うため全部ビルド
       - name: Build icons
-        run: pnpm --filter @charcoal-ui/icons-cli run build
+        run: pnpm run build
 
       - name: Export icons 1.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
           OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --sleepMs 1000
 
@@ -61,7 +62,7 @@ jobs:
       - name: Export icons 2.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2 --sleepMs 1000
 
@@ -83,6 +84,12 @@ jobs:
 
       - name: build icons 2.0 css
         run: pnpm --filter @charcoal-ui/icons-cli build:css
+
+      - name: format icons
+        run: pnpm fmt
+
+      - name: Update icon snapshots
+        run: pnpm exec vitest packages/tailwind-config/src/icons.test.ts -u --run
 
       - name: Generate github token
         id: generate_token

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Optimize icons 2.0
         env:
           OUTPUT_ROOT_DIR: ../icon-files/v2
-        run: pnpm --filter @charcoal-ui/icons-cli cli:icons svg:optimize --ignoreFile ../../misc/icons-cli-denylist
+        run: pnpm --filter @charcoal-ui/icons-cli cli:icons svg:optimize --ignoreFile ../../misc/icons-cli-denylist --color "#1F1F1F"
 
       - name: Generate icon 2.0 files
         env:

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Export icons 1.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --sleepMs 1000
 
@@ -62,7 +62,7 @@ jobs:
       - name: Export icons 2.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2 --sleepMs 1000
 

--- a/misc/pullrequest-cli/README.md
+++ b/misc/pullrequest-cli/README.md
@@ -8,6 +8,12 @@ CLI for creating pull request in CI.
 GITHUB_ACCESS_TOKEN=xxxx GITHUB_REPO_OWNER=pixiv GITHUB_REPO_NAME=charcoal GITHUB_DEFAULT_BRANCH=main TARGET_DIR=path/to/target/dir pnpm pullrequest-cli -c category_name -t "Pull request created by pullrequest-cli"
 ```
 
+or
+
+```
+GITHUB_ACCESS_TOKEN=xxxx GITHUB_REPO_OWNER=pixiv GITHUB_REPO_NAME=charcoal GITHUB_DEFAULT_BRANCH=main TARGET_DIRS=path/to/target/dir1,path/to/target/dir2 pnpm pullrequest-cli -c category_name -t "Pull request created by pullrequest-cli"
+```
+
 ### Environment values
 
 | param name   | required | description                                       |

--- a/misc/pullrequest-cli/src/GitHubClient.ts
+++ b/misc/pullrequest-cli/src/GitHubClient.ts
@@ -22,7 +22,7 @@ export class GithubClient {
     repoName: string,
     token: string,
     defaultBranch: string,
-    outputDir: string,
+    outputDirs: string[],
     category: string,
     pullrequestTitle: string,
   ) {
@@ -34,8 +34,10 @@ export class GithubClient {
       category,
       pullrequestTitle,
     )
-    const outputDirFullPath = path.resolve(process.cwd(), outputDir)
-    const diff = await client.createTreeFromDiff(outputDirFullPath)
+    const outputDirFullPaths = outputDirs.map((outputDir) =>
+      path.resolve(process.cwd(), outputDir),
+    )
+    const diff = await client.createTreeFromDiff(outputDirFullPaths)
     // eslint-disable-next-line no-console
     console.log(`${diff.length} files are changed`)
     if (diff.length === 0) {
@@ -86,10 +88,10 @@ export class GithubClient {
     return `[${this.category}]${this.message} ${this.now.toDateString()}`
   }
 
-  async createTreeFromDiff(outputDir: string): Promise<TreeItem[]> {
+  async createTreeFromDiff(outputDirs: string[]): Promise<TreeItem[]> {
     const tree: TreeItem[] = []
 
-    for await (const file of getChangedFiles(outputDir)) {
+    for await (const file of getChangedFiles(outputDirs)) {
       const item = {
         path: file.relativePath,
         // 100 はファイル 644 は実行不可なファイルであるという意味

--- a/misc/pullrequest-cli/src/GitHubClient.ts
+++ b/misc/pullrequest-cli/src/GitHubClient.ts
@@ -92,22 +92,23 @@ export class GithubClient {
     const tree: TreeItem[] = []
 
     for await (const file of getChangedFiles(outputDirs)) {
-      const item = {
-        path: file.relativePath,
-        // 100 はファイル 644 は実行不可なファイルであるという意味
-        // @see https://octokit.github.io/rest.js/v18#git-create-tree
-        mode: '100644' as const,
-        content: file.content,
-      }
-
       if (file.status === 'deleted') {
         // https://stackoverflow.com/questions/23637961/how-do-i-mark-a-file-as-deleted-in-a-tree-using-the-github-api
         tree.push({
-          ...item,
+          path: file.relativePath,
+          // 100 はファイル 644 は実行不可なファイルであるという意味
+          // @see https://octokit.github.io/rest.js/v18#git-create-tree
+          mode: '100644',
           sha: null,
         })
       } else {
-        tree.push(item)
+        tree.push({
+          path: file.relativePath,
+          // 100 はファイル 644 は実行不可なファイルであるという意味
+          // @see https://octokit.github.io/rest.js/v18#git-create-tree
+          mode: '100644',
+          content: file.content,
+        })
       }
     }
 

--- a/misc/pullrequest-cli/src/getChangedFiles.ts
+++ b/misc/pullrequest-cli/src/getChangedFiles.ts
@@ -31,7 +31,7 @@ async function collectGitStatus() {
     /**
      * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
      */
-    (await execp(`git status --porcelain -u`)).split('\n').map((s) => {
+    (await execp(`git status --porcelain -uall`)).split('\n').map((s) => {
       return [
         s.slice(3),
         s.startsWith(' M')

--- a/misc/pullrequest-cli/src/getChangedFiles.ts
+++ b/misc/pullrequest-cli/src/getChangedFiles.ts
@@ -3,20 +3,25 @@ import path from 'path'
 import { execp } from './utils.ts'
 
 /**
- * dir 内で変更があったファイル情報を for await で回せるようにするやつ
+ * dirs 内で変更があったファイル情報を for await で回せるようにするやつ
  */
-export async function* getChangedFiles(dir: string) {
-  if (!existsSync(dir))
-    throw new Error(`pullrequest-cli: target directory not found (${dir})`)
+export async function* getChangedFiles(dirs: string[]) {
+  for (const dir of dirs) {
+    if (!existsSync(dir))
+      throw new Error(`pullrequest-cli: target directory not found (${dir})`)
+  }
   const gitStatus = await collectGitStatus()
   for (const [relativePath, status] of gitStatus) {
     const fullpath = path.resolve(process.cwd(), relativePath)
-    if (!fullpath.startsWith(`${dir}/`)) {
+    if (!dirs.some((dir) => fullpath.startsWith(`${dir}/`))) {
       continue
     }
-    if (!existsSync(fullpath))
+    if (status !== 'deleted' && !existsSync(fullpath))
       throw new Error(`pullrequest-cli: could not find file (${fullpath})`)
-    const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
+    const content =
+      status === 'deleted'
+        ? ''
+        : await fs.readFile(fullpath, { encoding: 'utf-8' })
     yield { relativePath, content, status }
   }
 }

--- a/misc/pullrequest-cli/src/index.mts
+++ b/misc/pullrequest-cli/src/index.mts
@@ -5,6 +5,7 @@ import { GithubClient } from './GitHubClient.ts'
 import { mustBeDefined } from './utils.ts'
 
 const TARGET_DIR = process.env.TARGET_DIR
+const TARGET_DIRS = process.env.TARGET_DIRS
 
 /**
  * GitHub
@@ -33,14 +34,17 @@ void yargs(process.argv.slice(2))
     },
     async ({ title, category }) => {
       mustBeDefined(GITHUB_ACCESS_TOKEN, 'GITHUB_ACCESS_TOKEN')
-      mustBeDefined(TARGET_DIR, 'TARGET_DIR')
+      const targetDirs = TARGET_DIRS?.split(',')
+        .map((dir) => dir.trim())
+        .filter(Boolean) ?? (TARGET_DIR ? [TARGET_DIR] : undefined)
+      mustBeDefined(targetDirs, 'TARGET_DIR or TARGET_DIRS')
 
       await GithubClient.runFromCli(
         GITHUB_REPO_OWNER ?? 'pixiv',
         GITHUB_REPO_NAME ?? 'charcoal',
         GITHUB_ACCESS_TOKEN,
         GITHUB_DEFAULT_BRANCH ?? 'main',
-        TARGET_DIR,
+        targetDirs,
         category,
         title,
       )

--- a/misc/pullrequest-cli/src/index.mts
+++ b/misc/pullrequest-cli/src/index.mts
@@ -34,9 +34,10 @@ void yargs(process.argv.slice(2))
     },
     async ({ title, category }) => {
       mustBeDefined(GITHUB_ACCESS_TOKEN, 'GITHUB_ACCESS_TOKEN')
-      const targetDirs = TARGET_DIRS?.split(',')
-        .map((dir) => dir.trim())
-        .filter(Boolean) ?? (TARGET_DIR ? [TARGET_DIR] : undefined)
+      const targetDirs =
+        TARGET_DIRS?.split(',')
+          .map((dir) => dir.trim())
+          .filter(Boolean) ?? (TARGET_DIR ? [TARGET_DIR] : undefined)
       mustBeDefined(targetDirs, 'TARGET_DIR or TARGET_DIRS')
 
       await GithubClient.runFromCli(

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "tailwindcss": "^3.4.17",
     "tsdown": "0.20.3",
     "typescript": "5.9.3",
-    "vite": "8.0.0",
+    "vite": "8.0.5",
     "vitest": "^2.0.1",
     "wait-on": "^7.2.0",
     "yargs": "^17.3.1",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -14,6 +14,7 @@
     "build:uri-v1": "SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icon-files/v1/datauri pnpm tsx src/v2/transformDataUri.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
+    "test": "vitest run",
     "cli:icons": "./dist/index.js",
     "icons": "tsx src/index.ts"
   },

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -12,6 +12,7 @@
     "build:css-v1": "VERSION=v1 SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icons/css/v1 pnpm tsx src/v2/transformCSS.ts",
     "build:uri": "SOURCE_ROOT_DIR=../../../icon-files/v2/svg/ OUTPUT_ROOT_DIR=../icon-files/v2/datauri pnpm tsx src/v2/transformDataUri.ts",
     "build:uri-v1": "SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icon-files/v1/datauri pnpm tsx src/v2/transformDataUri.ts",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
     "test": "vitest run",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -15,7 +15,6 @@
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
-    "test": "vitest run",
     "cli:icons": "./dist/index.js",
     "icons": "tsx src/index.ts"
   },

--- a/packages/icons-cli/src/GitHubClient.ts
+++ b/packages/icons-cli/src/GitHubClient.ts
@@ -69,7 +69,7 @@ export class GithubClient {
   async createTreeFromDiff(outputDir: string): Promise<TreeItem[]> {
     const tree: TreeItem[] = []
 
-    for await (const file of getChangedFiles(outputDir)) {
+    for await (const file of getChangedFiles([outputDir])) {
       const item = {
         path: file.relativePath,
         // 100 はファイル 644 は実行不可なファイルであるという意味

--- a/packages/icons-cli/src/GitlabClient.ts
+++ b/packages/icons-cli/src/GitlabClient.ts
@@ -59,7 +59,7 @@ export class GitlabClient {
   async createActionsFromDiff(outputDir: string): Promise<CommitAction[]> {
     const actions: CommitAction[] = []
 
-    for await (const file of getChangedFiles(outputDir)) {
+    for await (const file of getChangedFiles([outputDir])) {
       actions.push({
         action:
           file.status === 'untracked'

--- a/packages/icons-cli/src/codegen.test.ts
+++ b/packages/icons-cli/src/codegen.test.ts
@@ -1,0 +1,84 @@
+import vm from 'node:vm'
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import {
+  createCssClassNameSegment,
+  createSvgDataUri,
+  serializeJavaScriptValue,
+} from './codegen'
+import {
+  generateCjsEntrypoint,
+  generateIconSvgEmbeddedSource,
+} from './generateSource'
+
+describe('serializeJavaScriptValue', () => {
+  it.each([
+    '',
+    `O'Reilly said "hello" twice`,
+    String.raw`C:\icons\multi\\slash`,
+    `''''`,
+    `</script><script>alert("xss")</script>`,
+  ])('JS文字列として安全にシリアライズできる: %j', (value) => {
+    const script = new vm.Script(`value = ${serializeJavaScriptValue(value)}`)
+    const context = vm.createContext({ value: undefined as string | undefined })
+    script.runInContext(context)
+
+    expect(context.value).toBe(value)
+  })
+})
+
+describe('createSvgDataUri', () => {
+  it('通常のSVGでもdata URIを生成できる', () => {
+    expect(
+      createSvgDataUri('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+    ).toBe(
+      'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E',
+    )
+  })
+
+  it('複数クォートやバックスラッシュを含むSVGでもCSSに安全に埋め込める', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><text>"\\" '' ''' </style><script>alert(1)</script></text></svg>`
+    const dataUri = createSvgDataUri(svg)
+
+    expect(dataUri.startsWith('data:image/svg+xml;utf8,')).toBe(true)
+    expect(dataUri).not.toContain('<svg')
+    expect(dataUri).not.toContain('</style>')
+    expect(dataUri).not.toContain('<script>')
+    expect(dataUri).toContain('%22')
+    expect(dataUri).toContain('%5C')
+
+    const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>')
+    const style = dom.window.document.createElement('style')
+    style.textContent = `.icon { background-image: url("${dataUri}"); }`
+    dom.window.document.head.append(style)
+
+    expect(style.sheet?.cssRules).toHaveLength(1)
+  })
+})
+
+describe('createCssClassNameSegment', () => {
+  it('既存の通常ケースを維持する', () => {
+    expect(createCssClassNameSegment('Add.Circle.svg')).toBe('add-circle')
+  })
+
+  it('危険な文字をCSS class名から除去する', () => {
+    expect(createCssClassNameSegment(`Bad "Name"..svg`)).toBe('bad-name')
+  })
+})
+
+describe('generateSource', () => {
+  it('空文字や連続クォートを含むSVGでも安全なモジュールソースを生成する', () => {
+    const source = generateIconSvgEmbeddedSource(`''""\\\n`)
+
+    expect(source).toContain(serializeJavaScriptValue(`''""\\`))
+  })
+
+  it('危険なキー名を含んでもCJSエントリポイントが壊れない', () => {
+    const iconName = String.raw`16/Bad'"Name\Icon`
+    const moduleContext = { module: { exports: {} as Record<string, unknown> } }
+    const script = new vm.Script(generateCjsEntrypoint([iconName]))
+    script.runInNewContext(moduleContext)
+
+    expect(Object.keys(moduleContext.module.exports)).toEqual([iconName])
+  })
+})

--- a/packages/icons-cli/src/codegen.test.ts
+++ b/packages/icons-cli/src/codegen.test.ts
@@ -47,7 +47,9 @@ describe('createSvgDataUri', () => {
     expect(dataUri).toContain('%22')
     expect(dataUri).toContain('%5C')
 
-    const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>')
+    const dom = new JSDOM(
+      '<!doctype html><html><head></head><body></body></html>',
+    )
     const style = dom.window.document.createElement('style')
     style.textContent = `.icon { background-image: url("${dataUri}"); }`
     dom.window.document.head.append(style)

--- a/packages/icons-cli/src/codegen.ts
+++ b/packages/icons-cli/src/codegen.ts
@@ -1,0 +1,28 @@
+const SVG_EXTENSION = /\.svg$/iu
+const NON_CSS_CLASS_NAME_CHARACTERS = /[^a-z0-9-]+/gu
+const DUPLICATE_DASHES = /-+/gu
+const EDGE_DASHES = /^-+|-+$/gu
+const LINE_SEPARATOR = /\u2028/gu
+const PARAGRAPH_SEPARATOR = /\u2029/gu
+
+export function serializeJavaScriptValue(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+    .replace(LINE_SEPARATOR, '\\u2028')
+    .replace(PARAGRAPH_SEPARATOR, '\\u2029')
+}
+
+export function createSvgDataUri(svg: string): string {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
+
+export function createCssClassNameSegment(fileName: string): string {
+  const segment = fileName
+    .toLowerCase()
+    .replace(SVG_EXTENSION, '')
+    .replaceAll('.', '-')
+    .replace(NON_CSS_CLASS_NAME_CHARACTERS, '-')
+    .replace(DUPLICATE_DASHES, '-')
+    .replace(EDGE_DASHES, '')
+
+  return segment === '' ? 'icon' : segment
+}

--- a/packages/icons-cli/src/figma/FigmaFileClient.test.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.test.ts
@@ -184,4 +184,35 @@ describe('FigmaFileClient path traversal regression', () => {
       '<svg><path /></svg>',
     )
   })
+
+  it('/design から始まる URL でも fileId を取得できる', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=16,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outputFile = path.join(outputRootDir, '16', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/design/FILE_ID/Test?node-id=1-2',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir)
+
+    expect(mockFile).toHaveBeenCalledWith('FILE_ID')
+    await expect(fs.pathExists(outputFile)).resolves.toBe(true)
+  })
 })

--- a/packages/icons-cli/src/figma/FigmaFileClient.test.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.test.ts
@@ -1,0 +1,187 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FigmaFileClient } from './FigmaFileClient'
+
+const { mockFile, mockFileImages, mockGotGet } = vi.hoisted(() => {
+  return {
+    mockFile: vi.fn(),
+    mockFileImages: vi.fn(),
+    mockGotGet: vi.fn(),
+  }
+})
+
+vi.mock('figma-js', () => {
+  return {
+    Client: vi.fn(() => ({
+      file: mockFile,
+      fileImages: mockFileImages,
+    })),
+  }
+})
+
+vi.mock('got', () => {
+  return {
+    default: {
+      get: mockGotGet,
+    },
+  }
+})
+
+function createV2FileResponse({
+  setName,
+  componentName,
+}: {
+  setName: string
+  componentName: string
+}) {
+  return {
+    data: {
+      document: {
+        children: [
+          {
+            type: 'CANVAS',
+            name: 'Icons 一覧',
+            children: [
+              {
+                type: 'FRAME',
+                name: 'Frame',
+                children: [
+                  {
+                    type: 'COMPONENT_SET',
+                    id: 'set-1',
+                    name: setName,
+                    children: [
+                      {
+                        type: 'COMPONENT',
+                        id: 'component-1',
+                        name: componentName,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+}
+
+describe('FigmaFileClient path traversal regression', () => {
+  let workDir: string
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    workDir = await fs.mkdtemp(path.join(tmpdir(), 'icons-cli-'))
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+
+    mockGotGet.mockResolvedValue({
+      body: '<svg><path /></svg>',
+    })
+  })
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore()
+    vi.clearAllMocks()
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+    await fs.remove(workDir)
+  })
+
+  it('v2 variant に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=../../escaped,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(tmpdir(), 'escaped', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('component set name に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: '../../pwned',
+        componentName: 'size=16',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(workDir, 'pwned.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('正常な v2 名称なら想定ディレクトリに export される', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=16,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outputFile = path.join(outputRootDir, '16', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir)
+
+    await expect(fs.pathExists(outputFile)).resolves.toBe(true)
+    await expect(readFile(outputFile, 'utf8')).resolves.toBe(
+      '<svg><path /></svg>',
+    )
+  })
+})

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -45,6 +45,12 @@ function parseV2IconName(name: string) {
 
 type ExportFormat = 'svg' | 'pdf'
 
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
 interface Component {
   id: string
   name: string
@@ -60,8 +66,10 @@ export class FigmaFileClient {
   private readonly exportFormat: ExportFormat
   private readonly client: Figma.ClientInterface
   private readonly layoutVersion: FigmaIconFileLayoutVersion
+  private readonly requestSleepMs?: number
 
   private components: Record<string, Component> = {}
+  private hasRequested = false
 
   static async runFromCli(
     url: string,
@@ -69,8 +77,15 @@ export class FigmaFileClient {
     outputRootDir: string,
     exportFormat: ExportFormat,
     layoutVersion: FigmaIconFileLayoutVersion = 'v1',
+    requestSleepMs?: number,
   ) {
-    const client = new this(url, token, exportFormat, layoutVersion)
+    const client = new this(
+      url,
+      token,
+      exportFormat,
+      layoutVersion,
+      requestSleepMs,
+    )
 
     const outputDir = path.join(process.cwd(), outputRootDir, exportFormat)
 
@@ -87,6 +102,7 @@ export class FigmaFileClient {
     personalAccessToken: string,
     exportFormat: ExportFormat,
     layoutVersion: FigmaIconFileLayoutVersion,
+    requestSleepMs?: number,
   ) {
     this.client = Figma.Client({
       personalAccessToken,
@@ -98,6 +114,7 @@ export class FigmaFileClient {
 
     this.exportFormat = exportFormat
     this.layoutVersion = layoutVersion
+    this.requestSleepMs = requestSleepMs
   }
 
   async loadSvg(outputDir: string) {
@@ -140,6 +157,7 @@ export class FigmaFileClient {
   private async loadImageUrls() {
     console.log('Getting export urls')
 
+    await this.sleepBeforeRequest()
     const { data } = await this.client.fileImages(this.fileId, {
       format: this.exportFormat,
       ids: Object.keys(this.components),
@@ -153,44 +171,74 @@ export class FigmaFileClient {
   }
 
   private async downloadImages(outputDir: string) {
+    const components = Object.values(this.components)
+    const shouldSleepBetweenRequests = (this.requestSleepMs ?? 0) > 0
+
+    const downloadImage = async (component: Component) => {
+      if (component.image === undefined) {
+        return
+      }
+
+      const filename = component.variant
+        ? `${parseV2IconName(component.variant)}/${component.name}.${this.exportFormat}`
+        : `${filenamify(component.name)}.${this.exportFormat}`
+      const fullname = path.join(outputDir, filename)
+      const dirname = path.dirname(fullname)
+
+      if (DRY_RUN) {
+        console.log(`[DRY_RUN] skip: ${filename} => ✅ writing...`)
+        return
+      }
+
+      await this.sleepBeforeRequest()
+      const response = await got.get(
+        component.image,
+        this.exportFormat == 'pdf' ? { responseType: 'buffer' } : {},
+      )
+
+      await ensureDir(dirname)
+
+      console.log(`found: ${filename} => ✅ writing...`)
+      await writeFile(fullname, response.body, 'utf8')
+    }
+
+    // sleep指定時は直列実行
+    if (shouldSleepBetweenRequests) {
+      for (const component of components) {
+        await downloadImage(component)
+      }
+
+      return
+    }
+
+    // sleep未指定時は並列実行
     return concurrently(
-      Object.values(this.components).map((component) => async () => {
-        if (component.image === undefined) {
-          return
-        }
-
-        const filename = component.variant
-          ? `${parseV2IconName(component.variant)}/${component.name}.${
-              this.exportFormat
-            }`
-          : `${filenamify(component.name)}.${this.exportFormat}`
-        const fullname = path.join(outputDir, filename)
-        const dirname = path.dirname(fullname)
-
-        if (DRY_RUN) {
-          console.log(`[DRY_RUN] skip: ${filename} => ✅ writing...`)
-          return
-        }
-
-        const response = await got.get(
-          component.image,
-          this.exportFormat == 'pdf' ? { responseType: 'buffer' } : {},
-        )
-
-        await ensureDir(dirname)
-
-        console.log(`found: ${filename} => ✅ writing...`)
-        await writeFile(fullname, response.body, 'utf8')
-      }),
+      components.map((component) => async () => downloadImage(component)),
     )
   }
 
   private async getFile() {
     console.log('Processing response')
 
+    await this.sleepBeforeRequest()
     const { data } = await this.client.file(this.fileId.toString())
 
     return data
+  }
+
+  private async sleepBeforeRequest() {
+    const requestSleepMs = this.requestSleepMs ?? 0
+
+    if (requestSleepMs <= 0) {
+      return
+    }
+
+    if (this.hasRequested) {
+      console.log(`Sleeping ${requestSleepMs}ms before next export request`)
+      await sleep(requestSleepMs)
+    }
+
+    this.hasRequested = true
   }
 
   private findComponentsRecursively(child: Figma.Node) {

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -43,6 +43,21 @@ function parseV2IconName(name: string) {
     .toLowerCase()
 }
 
+function resolveOutputPath(outputDir: string, filename: string) {
+  const normalizedOutputDir = path.resolve(outputDir)
+  const fullname = path.resolve(normalizedOutputDir, filename)
+  const relativePath = path.relative(normalizedOutputDir, fullname)
+
+  if (
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    return null
+  }
+
+  return fullname
+}
+
 type ExportFormat = 'svg' | 'pdf'
 
 function sleep(ms: number) {
@@ -182,7 +197,13 @@ export class FigmaFileClient {
       const filename = component.variant
         ? `${parseV2IconName(component.variant)}/${component.name}.${this.exportFormat}`
         : `${filenamify(component.name)}.${this.exportFormat}`
-      const fullname = path.join(outputDir, filename)
+      const fullname = resolveOutputPath(outputDir, filename)
+
+      if (fullname === null) {
+        console.log(`skip invalid output path: ${filename}`)
+        return
+      }
+
       const dirname = path.dirname(fullname)
 
       if (DRY_RUN) {

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -48,10 +48,7 @@ function resolveOutputPath(outputDir: string, filename: string) {
   const fullname = path.resolve(normalizedOutputDir, filename)
   const relativePath = path.relative(normalizedOutputDir, fullname)
 
-  if (
-    relativePath.startsWith('..') ||
-    path.isAbsolute(relativePath)
-  ) {
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
     return null
   }
 

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -9,7 +9,10 @@ import { concurrently } from '../concurrently'
 
 const DRY_RUN = Boolean(process.env.DRY_RUN)
 
-const matchPath = match<{ fileId: string; name: string }>('/file/:fileId/:name')
+const matchPath = match<{ fileId: string; name: string }>([
+  '/file/:fileId/:name',
+  '/design/:fileId/:name',
+])
 
 function extractParams(url: string): { fileId: string; nodeId?: string } {
   const { pathname, searchParams } = new URL(url)

--- a/packages/icons-cli/src/generateSource.test.ts
+++ b/packages/icons-cli/src/generateSource.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { generateIconSource } from './generateSource'
 
 async function importEsmFromSource(source: string) {
-  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`)
+  return import(
+    `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`
+  )
 }
 
 describe('generateSource regression', () => {

--- a/packages/icons-cli/src/generateSource.test.ts
+++ b/packages/icons-cli/src/generateSource.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { generateIconSource } from './generateSource'
+
+async function importEsmFromSource(source: string) {
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`)
+}
+
+describe('generateSource regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-generate-source-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('クォートやバックスラッシュを含むSVGでも埋め込みモジュールが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const svgContent = `<svg><text>'"\\"</text></svg>\n`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, 'Add.svg'), svgContent)
+
+    await generateIconSource(outputDir)
+
+    const generatedModule = await readFile(
+      path.join(outputDir, 'src', '16', 'Add.js'),
+      'utf8',
+    )
+    const imported = await importEsmFromSource(generatedModule)
+
+    expect(imported.default).toBe(`<svg><text>'"\\"</text></svg>`)
+  })
+
+  it('危険なキー名を含んでもCJSエントリポイントが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const iconName = String.raw`Bad'"Name\Icon`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, `${iconName}.svg`), '<svg />')
+
+    await generateIconSource(outputDir)
+
+    const entrypoint = await readFile(
+      path.join(outputDir, 'src', 'index.cjs'),
+      'utf8',
+    )
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(entrypoint)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([`16/${iconName}`])
+  })
+})

--- a/packages/icons-cli/src/generateSource.ts
+++ b/packages/icons-cli/src/generateSource.ts
@@ -1,43 +1,52 @@
 import path from 'path'
 import { glob } from 'node:fs/promises'
 import fs from 'fs-extra'
+import { serializeJavaScriptValue } from './codegen'
 
-const generateIconSvgEmbeddedSource = (svgString: string) => {
+export const generateIconSvgEmbeddedSource = (svgString: string) => {
   const str = svgString.replace(/\r?\n/g, '')
 
   return `/** This file is auto generated. DO NOT EDIT BY HAND. */
-export default '${str}'
+export default ${serializeJavaScriptValue(str)}
 `
 }
 
-const generateMjsEntrypoint = (
+export const generateMjsEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOT EDIT BY HAND. */
 
 export default {
 ${icons
-  .map((it) => `  '${it}': () => import('./${it}.js').then(m => m.default)`)
+  .map(
+    (it) =>
+      `  ${serializeJavaScriptValue(it)}: () => import(${serializeJavaScriptValue(`./${it}.js`)}).then(m => m.default)`,
+  )
   .join(',\n')}
 }
 `
 
-const generateCjsEntrypoint = (
+export const generateCjsEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOT EDIT BY HAND. */
 
 module.exports = {
 ${icons
-  .map((it) => `  '${it}': () => import('./${it}.js').then(m => m.default)`)
+  .map(
+    (it) =>
+      `  ${serializeJavaScriptValue(it)}: () => import(${serializeJavaScriptValue(`./${it}.js`)}).then(m => m.default)`,
+  )
   .join(',\n')}
 }
 `
 
-const generateTypeDefinitionEntrypoint = (
+export const generateTypeDefinitionEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOt EDIT BY HAND. */
 
 declare var _default: {
-${icons.map((it) => `  '${it}': () => Promise<string>`).join(';\n')}
+${icons
+  .map((it) => `  ${serializeJavaScriptValue(it)}: () => Promise<string>`)
+  .join(';\n')}
 };
 export default _default;
 `

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -3,20 +3,25 @@ import path from 'path'
 import { execp } from './utils'
 
 /**
- * dir 内で変更があったファイル情報を for await で回せるようにするやつ
+ * dirs 内で変更があったファイル情報を for await で回せるようにするやつ
  */
-export async function* getChangedFiles(dir: string) {
-  if (!existsSync(dir))
-    throw new Error(`icons-cli: target directory not found (${dir})`)
+export async function* getChangedFiles(dirs: string[]) {
+  for (const dir of dirs) {
+    if (!existsSync(dir))
+      throw new Error(`icons-cli: target directory not found (${dir})`)
+  }
   const gitStatus = await collectGitStatus()
   for (const [relativePath, status] of gitStatus) {
-    const fullpath = path.resolve(process.cwd(), '../../', relativePath)
-    if (!fullpath.startsWith(`${dir}/`)) {
+    const fullpath = path.resolve(process.cwd(), relativePath)
+    if (!dirs.some((dir) => fullpath.startsWith(`${dir}/`))) {
       continue
     }
-    if (!existsSync(fullpath))
-      throw new Error(`icons-cli: could not load svg (${fullpath})`)
-    const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
+    if (status !== 'deleted' && !existsSync(fullpath))
+      throw new Error(`icons-cli: could not find file (${fullpath})`)
+    const content =
+      status === 'deleted'
+        ? ''
+        : await fs.readFile(fullpath, { encoding: 'utf-8' })
     yield { relativePath, content, status }
   }
 }
@@ -26,7 +31,7 @@ async function collectGitStatus() {
     /**
      * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
      */
-    (await execp(`git status --porcelain`)).split('\n').map((s) => {
+    (await execp(`git status --porcelain -uall`)).split('\n').map((s) => {
       return [
         s.slice(3),
         s.startsWith(' M')

--- a/packages/icons-cli/src/index.ts
+++ b/packages/icons-cli/src/index.ts
@@ -47,11 +47,19 @@ void yargs
         default: 'v1',
         describe: 'Figma icon file layout version',
       },
+      sleepMs: {
+        type: 'number',
+        describe: 'Sleep duration between export requests in milliseconds',
+      },
     },
-    async ({ format, layout }) => {
+    async ({ format, layout, sleepMs }) => {
       mustBeDefined(FIGMA_FILE_URL, 'FIGMA_FILE_URL')
       mustBeDefined(FIGMA_TOKEN, 'FIGMA_TOKEN')
       mustBeDefined(OUTPUT_ROOT_DIR, 'OUTPUT_ROOT_DIR')
+
+      if (sleepMs !== undefined && sleepMs < 0) {
+        throw new TypeError('sleepMs must be 0 or greater.')
+      }
 
       await FigmaFileClient.runFromCli(
         FIGMA_FILE_URL,
@@ -59,6 +67,7 @@ void yargs
         OUTPUT_ROOT_DIR,
         format as 'svg' | 'pdf',
         layout as 'v1' | 'v2',
+        sleepMs,
       )
     },
   )

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -31,7 +31,7 @@ async function runTransformCss(
 
   try {
     vi.resetModules()
-    await import(new URL('./transformCSS.ts', import.meta.url).href)
+    await import('./transformCSS')
     await waitForFile(path.join(outputDir, 'index.story.tsx'))
   } finally {
     if (previousVersion === undefined) {
@@ -106,7 +106,8 @@ describe('transformCSS regression', () => {
     expect(html).toContain(`class="${safeClassName}"`)
     expect(story).toContain(`className="${safeClassName}"`)
 
-    expect(css).not.toContain('"')
+    expect(css).not.toContain('Bad "Name"')
     expect(html).not.toContain('Bad "Name"')
+    expect(story).not.toContain('Bad "Name"')
   })
 })

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformCss(
+  sourceDir: string,
+  outputDir: string,
+  version: 'v1' | 'v2',
+) {
+  const previousVersion = process.env.VERSION
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.VERSION = version
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformCSS.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.story.tsx'))
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.VERSION
+    } else {
+      process.env.VERSION = previousVersion
+    }
+
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformCSS regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-css-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('通常のv2アイコン名では既存のclass名を維持する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+
+    await fs.ensureDir(path.join(sourceDir, '24', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '24', 'regular', 'Add.Circle.svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+
+    expect(css).toContain('.charcoal-icon-v2-add-circle')
+  })
+
+  it('危険な文字を含むv2ファイル名でも安全なclass名だけを生成する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const safeClassName = 'charcoal-icon-v2-bad-name-16'
+
+    await fs.ensureDir(path.join(sourceDir, '16', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '16', 'regular', 'Bad "Name"..svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+    const html = await readFile(path.join(outputDir, 'index.html'), 'utf8')
+    const story = await readFile(path.join(outputDir, 'index.story.tsx'), 'utf8')
+
+    expect(css).toContain(`.${safeClassName}`)
+    expect(html).toContain(`class="${safeClassName}"`)
+    expect(story).toContain(`className="${safeClassName}"`)
+
+    expect(css).not.toContain('"')
+    expect(html).not.toContain('Bad "Name"')
+  })
+})

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -97,7 +97,10 @@ describe('transformCSS regression', () => {
 
     const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
     const html = await readFile(path.join(outputDir, 'index.html'), 'utf8')
-    const story = await readFile(path.join(outputDir, 'index.story.tsx'), 'utf8')
+    const story = await readFile(
+      path.join(outputDir, 'index.story.tsx'),
+      'utf8',
+    )
 
     expect(css).toContain(`.${safeClassName}`)
     expect(html).toContain(`class="${safeClassName}"`)

--- a/packages/icons-cli/src/v2/transformCSS.ts
+++ b/packages/icons-cli/src/v2/transformCSS.ts
@@ -2,14 +2,51 @@ import { mustBeDefined } from '../utils'
 import { glob, readFile, writeFile } from 'fs/promises'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
-import { encodeSvgAsDataUri } from '../utils'
+import {
+  createCssClassNameSegment,
+  createSvgDataUri,
+  serializeJavaScriptValue,
+} from '../codegen'
+
+const previewStyles = `:root {
+  font-size: 24px;
+}
+.icons {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fill, 300px);
+}
+.icons div {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+code {
+  font-size: 14px;
+}`
+
+function createPreviewItems(
+  classNames: string[],
+  classAttributeName: 'class' | 'className',
+) {
+  return classNames
+    .map(
+      (icon) => `
+  <div>
+    <div ${classAttributeName}="${icon}" aria-label=".${icon}" role="img"></div>
+    <code>.${icon}</code>
+  </div>`,
+    )
+    .join('\n')
+}
 
 async function transformV2(filePath: string, fileName: string) {
   const content = await readFile(filePath, 'utf-8')
   const [size, variant, name] = fileName.split('/')
+  const dataUri = createSvgDataUri(content)
   const cssName = [
     'charcoal-icon-v2',
-    name.toLowerCase().replace('.svg', '').replaceAll('.', '-'),
+    createCssClassNameSegment(name),
     ...(variant === 'regular' ? [] : [variant]),
     ...(size === '24' ? [] : [size]),
   ].join('-')
@@ -19,9 +56,7 @@ async function transformV2(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  background: url('data:image/svg+xml;utf8,${encodeSvgAsDataUri(
-    content,
-  ).replace("'", "\\'")}');
+  background: url("${dataUri}");
   aspect-ratio: 1/1;
 }`
     : `
@@ -29,9 +64,7 @@ async function transformV2(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  mask-image: url('data:image/svg+xml;utf8,${encodeSvgAsDataUri(
-    content,
-  ).replace("'", "\\'")}');
+  mask-image: url("${dataUri}");
   mask-size: 100% 100%;
   background: currentColor;
   aspect-ratio: 1/1;
@@ -47,9 +80,10 @@ async function transformV2(filePath: string, fileName: string) {
 async function transformV1(filePath: string, fileName: string) {
   const content = await readFile(filePath, 'utf-8')
   const [size, name] = fileName.split('/')
+  const dataUri = createSvgDataUri(content)
   const cssName = [
     'charcoal-icon-v1',
-    name.toLowerCase().replace('.svg', '').replaceAll('.', '-'),
+    createCssClassNameSegment(name),
     ...(size === '24' ? [] : [size]),
   ].join('-')
   const css = content.includes('<def')
@@ -58,9 +92,7 @@ async function transformV1(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  background: url('data:image/svg+xml;utf8,${encodeSvgAsDataUri(
-    content,
-  ).replace("'", "\\'")}');
+  background: url("${dataUri}");
   aspect-ratio: 1/1;
 }`
     : `
@@ -68,9 +100,7 @@ async function transformV1(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  mask-image: url('data:image/svg+xml;utf8,${encodeSvgAsDataUri(
-    content,
-  ).replace("'", "\\'")}');
+  mask-image: url("${dataUri}");
   mask-size: 100% 100%;
   background: currentColor;
   aspect-ratio: 1/1;
@@ -125,38 +155,12 @@ async function main() {
   classNames = classNames.sort()
   const html = `
 <div class="icons">
-${classNames
-  .map(
-    (icon) => `
-  <div>
-    <div class="${icon}" aria-label=".${icon}" role="img" />
-    <code>.${icon}</code>
-  </div>
-`,
-  )
-  .join('\n')}
+${createPreviewItems(classNames, 'class')}
 </div>`
 
   await writeFile(
     path.join(outDir, 'index.html'),
-    `<link rel="stylesheet" href="./index.css"><style>
-  :root {
-    font-size: 24px;
-  }
-  .icons {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(auto-fill, 300px);
-  }
-  .icons div {
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-  }
-  code {
-    font-size: 14px;
-  }
-</style>${html}`,
+    `<link rel="stylesheet" href="./index.css"><style>${previewStyles}</style>${html}`,
   )
   await writeFile(
     path.join(outDir, 'index.story.tsx'),
@@ -175,26 +179,11 @@ export default {
   render(): JSX.Element {
     return (
       <>
-       <style>{\`${cssContent}\`}</style>
-       <style>
-  {\`:root {
-    font-size: 24px;
-  }
-  .icons {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(auto-fill, 300px);
-  }
-  .icons div {
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-  }
-  code {
-    font-size: 14px;
-  }\`}
-</style>
-       ${html.replaceAll('class', 'className')}
+       <style>{${serializeJavaScriptValue(cssContent)}}</style>
+       <style>{${serializeJavaScriptValue(previewStyles)}}</style>
+       <div className="icons">
+${createPreviewItems(classNames, 'className')}
+       </div>
       </>
     )
   },

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -26,7 +26,7 @@ async function runTransformDataUri(sourceDir: string, outputDir: string) {
 
   try {
     vi.resetModules()
-    await import(new URL('./transformDataUri.ts', import.meta.url).href)
+    await import('./transformDataUri')
     await waitForFile(path.join(outputDir, 'index.d.ts'))
   } finally {
     if (previousSourceRootDir === undefined) {

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformDataUri(sourceDir: string, outputDir: string) {
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformDataUri.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.d.ts'))
+  } finally {
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformDataUri regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-data-uri-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('危険なキー名を含んでもCJS出力が壊れない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const iconName = String.raw`16/Bad'"Name\Icon`
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, `${iconName}.svg`), '<svg />')
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const cjs = await readFile(path.join(outputDir, 'index.cjs'), 'utf8')
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(cjs)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([iconName])
+  })
+
+  it('危険なSVG文字列でもdata URIを生で埋め込まない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const svgContent =
+      '<svg><text></style><script>alert("xss")</script></text></svg>'
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, '16', 'Add.svg'), svgContent)
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const mjs = await readFile(path.join(outputDir, 'index.mjs'), 'utf8')
+
+    expect(mjs).not.toContain('</style>')
+    expect(mjs).not.toContain('<script>')
+    expect(mjs).toContain('%3Csvg%3E')
+  })
+})

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -47,7 +47,9 @@ describe('transformDataUri regression', () => {
   let workDir: string
 
   beforeEach(async () => {
-    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-data-uri-'))
+    workDir = await mkdtemp(
+      path.join(tmpdir(), 'icons-cli-transform-data-uri-'),
+    )
   })
 
   afterEach(async () => {

--- a/packages/icons-cli/src/v2/transformDataUri.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.ts
@@ -1,7 +1,8 @@
 import { glob, readFile, writeFile } from 'fs/promises'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
-import { encodeSvgAsDataUri, mustBeDefined } from '../utils'
+import { createSvgDataUri, serializeJavaScriptValue } from '../codegen'
+import { mustBeDefined } from '../utils'
 
 async function main() {
   mustBeDefined(process.env.SOURCE_ROOT_DIR, 'SOURCE_ROOT_DIR')
@@ -20,48 +21,39 @@ async function main() {
 
       return {
         iconName: fileName.replace('.svg', ''),
-        uri: `data:image/svg+xml;utf8,${encodeSvgAsDataUri(content).replace(
-          "'",
-          "\\'",
-        )}`,
+        uri: createSvgDataUri(content),
         isSetCurrentcolor: !content.includes('<def'),
       }
     }),
   )
 
-  const js = `/** This file is auto generated. DO NOT EDIT BY HAND. */
-  
-export default {
-${dataUris
-  .map(
-    (it) =>
-      `'${it.iconName}': {uri: '${it.uri}', isSetCurrentcolor: ${
-        it.isSetCurrentcolor ? 'true' : 'false'
-      }}`,
+  const dataUriMap = Object.fromEntries(
+    dataUris.map(({ iconName, uri, isSetCurrentcolor }) => [
+      iconName,
+      { uri, isSetCurrentcolor },
+    ]),
   )
-  .join(',\n')}
-}`
+
+  const js = `/** This file is auto generated. DO NOT EDIT BY HAND. */
+
+export default ${serializeJavaScriptValue(dataUriMap)}
+`
   await writeFile(path.join(outDir, 'index.mjs'), js)
 
   const cjs = `/** This file is auto generated. DO NOT EDIT BY HAND. */
-  
-module.exports = {
-${dataUris
-  .map(
-    (it) =>
-      `'${it.iconName}': {uri: '${it.uri}', isSetCurrentcolor: ${
-        it.isSetCurrentcolor ? 'true' : 'false'
-      }}`,
-  )
-  .join(',\n')}
-}`
+
+module.exports = ${serializeJavaScriptValue(dataUriMap)}
+`
   await writeFile(path.join(outDir, 'index.cjs'), cjs)
 
   const dts = `/** This file is auto generated. DO NOT EDIT BY HAND. */
   
 declare var _default: {
 ${dataUris
-  .map((it) => `'${it.iconName}': { uri: string, isSetCurrentcolor: boolean }`)
+  .map(
+    (it) =>
+      `${serializeJavaScriptValue(it.iconName)}: { uri: string, isSetCurrentcolor: boolean }`,
+  )
   .join(';\n')}}
 export default _default;
 `

--- a/packages/icons-cli/vitest.config.ts
+++ b/packages/icons-cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    alias: [
+      {
+        find: /@charcoal-ui\/(.*)/,
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '..'),
+          '$1',
+          'src',
+        ),
+      },
+    ],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,10 +518,10 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.28.5
+        version: 7.29.0
       '@babel/parser':
         specifier: ^7.23.9
-        version: 7.28.5
+        version: 7.29.2
       '@storybook/addon-knobs':
         specifier: ^7.0.2
         version: 7.1.1(@storybook/addons@7.6.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/api@7.6.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@8.6.9(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/core-events@8.6.9(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@storybook/theming@8.6.9(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -563,7 +563,7 @@ importers:
         version: 4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       babel-plugin-styled-components:
         specifier: ^2.1.4
-        version: 2.1.4(@babel/core@7.28.5)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
+        version: 2.1.4(@babel/core@7.29.0)(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
@@ -578,7 +578,7 @@ importers:
         version: 6.30.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-components:
         specifier: ^5.3.3
-        version: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+        version: 5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
       use-resize-observer:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -615,7 +615,7 @@ importers:
         version: 4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       jest-styled-components:
         specifier: ^7.1.1
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+        version: 7.2.0(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
@@ -624,7 +624,7 @@ importers:
         version: 18.3.1
       styled-components:
         specifier: ^5.3.3
-        version: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+        version: 5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
 
   packages/tailwind-config:
     dependencies:
@@ -753,32 +753,16 @@ packages:
   '@asamuzakjp/css-color@3.1.1':
     resolution: {integrity: sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==}
 
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@7.28.5':
-    resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.28.5':
-    resolution: {integrity: sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/generator@7.28.5':
-    resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
@@ -791,10 +775,6 @@ packages:
 
   '@babel/helper-annotate-as-pure@7.25.9':
     resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-compilation-targets@7.27.2':
-    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
@@ -815,19 +795,9 @@ packages:
     resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.27.1':
-    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.28.6':
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-transforms@7.28.3':
-    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
 
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
@@ -873,18 +843,9 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.4':
-    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helpers@7.29.2':
     resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.5':
-    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
@@ -1010,24 +971,12 @@ packages:
     resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.2':
-    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.5':
-    resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -5970,20 +5919,19 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.12.0:
-    resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
-
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -5993,6 +5941,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -7540,10 +7489,6 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -8065,10 +8010,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -10171,41 +10112,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
       lru-cache: 10.4.3
 
-  '@babel/code-frame@7.27.1':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.28.5': {}
-
   '@babel/compat-data@7.29.0': {}
-
-  '@babel/core@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@babel/types': 7.28.5
-      '@jridgewell/remapping': 2.3.5
-      convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/core@7.29.0':
     dependencies:
@@ -10216,7 +10129,7 @@ snapshots:
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -10226,14 +10139,6 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/generator@7.28.5':
-    dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.1.0
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -10254,15 +10159,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.28.5
-
-  '@babel/helper-compilation-targets@7.27.2':
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.24.4
-      lru-cache: 5.1.1
-      semver: 6.3.1
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -10272,15 +10169,15 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.27.0(@babel/core@7.28.5)':
+  '@babel/helper-create-class-features-plugin@7.27.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.28.5)
+      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -10289,62 +10186,46 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
-    dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.28.6':
-    dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-imports@7.28.6(supports-color@5.5.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
-  '@babel/helper-replace-supers@7.26.5(@babel/core@7.28.5)':
+  '@babel/helper-replace-supers@7.26.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.25.9
       '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10358,19 +10239,10 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.4':
-    dependencies:
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-
-  '@babel/parser@7.28.5':
-    dependencies:
-      '@babel/types': 7.28.5
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -10380,52 +10252,47 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.2
 
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.27.0(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.27.0(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.5)':
-    dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
@@ -10433,70 +10300,64 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
-
-  '@babel/template@7.27.2':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
 
   '@babel/template@7.28.6':
     dependencies:
@@ -10504,19 +10365,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.5(supports-color@5.5.0)':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -10527,11 +10376,6 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -10707,7 +10551,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
       '@babel/runtime': 7.27.0
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
@@ -11257,7 +11101,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 6.1.1
@@ -11277,7 +11121,7 @@ snapshots:
 
   '@jest/transform@30.2.0':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 7.0.1
@@ -12491,7 +12335,7 @@ snapshots:
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.37.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
       '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
     optionalDependencies:
       '@types/babel__core': 7.20.5
@@ -12503,7 +12347,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.7
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.37.0
 
@@ -12937,10 +12781,10 @@ snapshots:
 
   '@storybook/test-runner@0.24.2(@types/node@22.14.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.1))(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.14.1)(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       '@jest/types': 30.2.0
       '@swc/core': 1.15.3
       '@swc/jest': 0.2.39(@swc/core@1.15.3)
@@ -12999,55 +12843,55 @@ snapshots:
 
   '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2(postcss@8.5.6))(postcss@8.5.6)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       postcss: 8.5.6
       postcss-syntax: 0.36.2(postcss@8.5.6)
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.28.5)':
+  '@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
 
-  '@svgr/babel-preset@8.1.0(@babel/core@7.28.5)':
+  '@svgr/babel-preset@8.1.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.5)
-      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-replace-jsx-attribute-value': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-dynamic-title': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
+      '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
   '@svgr/cli@8.1.0(typescript@5.9.3)':
     dependencies:
@@ -13067,8 +12911,8 @@ snapshots:
 
   '@svgr/core@8.1.0(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@5.9.3)
       snake-case: 3.0.4
@@ -13078,13 +12922,13 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
@@ -13186,7 +13030,7 @@ snapshots:
 
   '@testing-library/dom@8.20.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.27.0
       '@types/aria-query': 5.0.4
       aria-query: 5.1.3
@@ -13274,24 +13118,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -13814,9 +13658,9 @@ snapshots:
 
   '@vitejs/plugin-react@4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.29.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
       vite: 8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -14291,13 +14135,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-jest@30.2.0(@babel/core@7.28.5):
+  babel-jest@30.2.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@jest/transform': 30.2.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 7.0.1
-      babel-preset-jest: 30.2.0(@babel/core@7.28.5)
+      babel-preset-jest: 30.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -14336,24 +14180,12 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.28.5
-
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.5)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      lodash: 4.17.21
-      picomatch: 2.3.1
-      styled-components: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      '@babel/types': 7.29.0
 
   babel-plugin-styled-components@2.1.4(@babel/core@7.29.0)(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
       lodash: 4.17.21
       picomatch: 2.3.1
@@ -14362,30 +14194,30 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.5):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-jest@30.2.0(@babel/core@7.28.5):
+  babel-preset-jest@30.2.0(@babel/core@7.29.0):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       babel-plugin-jest-hoist: 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
   bail@2.0.2: {}
 
@@ -14495,7 +14327,7 @@ snapshots:
       fs-minipass: 3.0.3
       glob: 10.4.5
       lru-cache: 7.18.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 1.0.2
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -15764,9 +15596,9 @@ snapshots:
 
   eslint-plugin-react-compiler@19.0.0-beta-ebf51a3-20250411(eslint@9.38.0(jiti@2.6.0)):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.5)
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
       eslint: 9.38.0(jiti@2.6.0)
       hermes-parser: 0.25.1
       zod: 3.25.76
@@ -15776,8 +15608,8 @@ snapshots:
 
   eslint-plugin-react-hooks@6.1.1(eslint@9.38.0(jiti@2.6.0)):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
       eslint: 9.38.0(jiti@2.6.0)
       zod: 4.1.12
       zod-validation-error: 4.0.2(zod@4.1.12)
@@ -16205,7 +16037,7 @@ snapshots:
 
   fs-minipass@3.0.3:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   fs-monkey@1.0.6: {}
 
@@ -16296,10 +16128,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.12.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -16356,7 +16184,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -17002,7 +16830,7 @@ snapshots:
 
   istanbul-lib-instrument@4.0.3:
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -17011,8 +16839,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -17021,8 +16849,8 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -17140,12 +16968,12 @@ snapshots:
 
   jest-config@30.2.0(@types/node@22.14.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.1))(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.14.1)(typescript@5.9.3)):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
       '@jest/pattern': 30.0.1
       '@jest/test-sequencer': 30.2.0
       '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.5)
+      babel-jest: 30.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       ci-info: 4.3.1
       deepmerge: 4.3.1
@@ -17282,7 +17110,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -17294,7 +17122,7 @@ snapshots:
 
   jest-message-util@30.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@jest/types': 30.2.0
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -17412,15 +17240,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -17437,17 +17265,17 @@ snapshots:
 
   jest-snapshot@30.2.0:
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
       '@jest/expect-utils': 30.2.0
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
       chalk: 4.1.2
       expect: 30.2.0
       graceful-fs: 4.2.11
@@ -17467,11 +17295,6 @@ snapshots:
       jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
-
-  jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)):
-    dependencies:
-      '@adobe/css-tools': 4.4.2
-      styled-components: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
 
   jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)):
     dependencies:
@@ -17494,7 +17317,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.3.1
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   jest-validate@30.2.0:
     dependencies:
@@ -18508,7 +18331,7 @@ snapshots:
 
   minipass-fetch@3.0.5:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-sized: 1.0.3
       minizlib: 2.1.2
     optionalDependencies:
@@ -18538,8 +18361,6 @@ snapshots:
   minipass@4.2.8: {}
 
   minipass@5.0.0: {}
-
-  minipass@7.1.2: {}
 
   minipass@7.1.3: {}
 
@@ -19093,7 +18914,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -19141,7 +18962,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -19169,8 +18990,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -19442,7 +19261,7 @@ snapshots:
   react-docgen@7.1.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -19457,7 +19276,7 @@ snapshots:
   react-docgen@8.0.2:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -20193,7 +20012,7 @@ snapshots:
 
   ssri@10.0.6:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   ssri@9.0.1:
     dependencies:
@@ -20393,28 +20212,10 @@ snapshots:
 
   style-search@0.1.0: {}
 
-  styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1):
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
-      '@emotion/is-prop-valid': 1.3.1
-      '@emotion/stylis': 0.8.5
-      '@emotion/unitless': 0.7.5
-      babel-plugin-styled-components: 2.1.4(@babel/core@7.28.5)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
-      css-to-react-native: 3.2.0
-      hoist-non-react-statics: 3.3.2
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-is: 18.3.1
-      shallowequal: 1.1.0
-      supports-color: 5.5.0
-    transitivePeerDependencies:
-      - '@babel/core'
-
   styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1):
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -20807,7 +20608,7 @@ snapshots:
       hookable: 6.0.1
       import-without-cache: 0.2.5
       obug: 2.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       rolldown: 1.0.0-rc.3
       rolldown-plugin-dts: 0.22.3(@typescript/native-preview@7.0.0-dev.20250930.1)(rolldown@1.0.0-rc.3)(typescript@5.9.3)
       semver: 7.7.3
@@ -20830,7 +20631,7 @@ snapshots:
   tsx@4.19.3:
     dependencies:
       esbuild: 0.25.1
-      get-tsconfig: 4.12.0
+      get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -20995,7 +20796,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.15.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   unquote@1.1.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 10.2.19(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: 10.2.19
-        version: 10.2.19(@types/react@18.3.20)(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+        version: 10.2.19(@types/react@18.3.20)(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/addon-links':
         specifier: 10.2.19
         version: 10.2.19(react@18.3.1)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -90,10 +90,10 @@ importers:
         version: 4.0.2(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/builder-vite':
         specifier: 10.2.19
-        version: 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+        version: 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/react-vite':
         specifier: 10.2.19
-        version: 10.2.19(esbuild@0.25.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+        version: 10.2.19(esbuild@0.25.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/react-webpack5':
         specifier: 10.2.19
         version: 10.2.19(@swc/core@1.15.3)(esbuild@0.25.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
@@ -138,7 +138,7 @@ importers:
         version: 7.0.0-dev.20250930.1
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vueless/storybook-dark-mode':
         specifier: ^10.0.6
         version: 10.0.6(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -263,8 +263,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: 8.0.0
-        version: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+        specifier: 8.0.5
+        version: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vitest:
         specifier: ^2.0.1
         version: 2.1.9(@types/node@22.14.1)(jsdom@19.0.0)(lightningcss@1.32.0)(terser@5.39.0)
@@ -560,7 +560,7 @@ importers:
         version: 3.0.3
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@8.0.0(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       babel-plugin-styled-components:
         specifier: ^2.1.4
         version: 2.1.4(@babel/core@7.28.5)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))(supports-color@5.5.0)
@@ -612,10 +612,10 @@ importers:
         version: 3.0.3
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.4(vite@8.0.0(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+        version: 4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       jest-styled-components:
         specifier: ^7.1.1
-        version: 7.2.0(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
+        version: 7.2.0(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1))
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
@@ -624,7 +624,7 @@ importers:
         version: 18.3.1
       styled-components:
         specifier: ^5.3.3
-        version: 5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+        version: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
 
   packages/tailwind-config:
     dependencies:
@@ -661,7 +661,7 @@ importers:
         version: 18.3.1
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3))
+        version: 3.4.17(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.14.1)(typescript@5.9.3))
 
   packages/tailwind-diff:
     dependencies:
@@ -2038,18 +2038,14 @@ packages:
   '@originjs/vite-plugin-commonjs@1.0.3':
     resolution: {integrity: sha512-KuEXeGPptM2lyxdIEJ4R11+5ztipHoE7hy8ClZt3PYaOVQ/pyngd2alaSrPnwyFeOW1UagRBaQ752aA1dTMdOQ==}
 
-  '@oxc-project/runtime@0.115.0':
-    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@oxc-project/types@0.112.0':
     resolution: {integrity: sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ==}
 
   '@oxc-project/types@0.114.0':
     resolution: {integrity: sha512-//nBfbzHQHvJs8oFIjv6coZ6uxQ4alLfiPe6D5vit6c4pmxATHHlVwgB1k+Hv4yoAMyncdxgRBF5K4BYWUCzvA==}
 
-  '@oxc-project/types@0.115.0':
-    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@parcel/watcher@2.0.4':
     resolution: {integrity: sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==}
@@ -2446,6 +2442,12 @@ packages:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2458,11 +2460,11 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [android]
+    os: [darwin]
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A==}
@@ -2476,10 +2478,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
@@ -2494,11 +2496,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [darwin]
+    os: [freebsd]
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
     resolution: {integrity: sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww==}
@@ -2512,11 +2514,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
-    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
+    cpu: [arm]
+    os: [linux]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
     resolution: {integrity: sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag==}
@@ -2530,10 +2532,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
-    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
+    cpu: [arm64]
     os: [linux]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
@@ -2548,8 +2550,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2566,22 +2568,22 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [linux]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
@@ -2596,8 +2598,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
-    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2614,11 +2616,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
-    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
     resolution: {integrity: sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ==}
@@ -2632,11 +2634,10 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
-    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
     resolution: {integrity: sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g==}
@@ -2648,10 +2649,11 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
-    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
     resolution: {integrity: sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg==}
@@ -2665,10 +2667,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
+    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
@@ -2683,11 +2685,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
-    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -2697,9 +2696,6 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
-
-  '@rolldown/pluginutils@1.0.0-rc.9':
-    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rollup/plugin-babel@6.1.0':
     resolution: {integrity: sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==}
@@ -8074,6 +8070,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==}
     engines: {node: '>=0.10'}
@@ -8679,6 +8679,11 @@ packages:
       vue-tsc:
         optional: true
 
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.0-rc.3:
     resolution: {integrity: sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8686,11 +8691,6 @@ packages:
 
   rolldown@1.0.0-rc.5:
     resolution: {integrity: sha512-0AdalTs6hNTioaCYIkAa7+xsmHBfU5hCNclZnM/lp7lGGDuUOb6N4BVNtwiomybbencDjq/waKjTImqiGCs5sw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.0.0-rc.9:
-    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -9262,6 +9262,7 @@ packages:
   tar@6.1.11:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
@@ -9762,14 +9763,14 @@ packages:
       terser:
         optional: true
 
-  vite@8.0.0:
-    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+  vite@8.0.5:
+    resolution: {integrity: sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.0.0-alpha.31
-      esbuild: ^0.27.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -9912,10 +9913,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -11311,11 +11314,11 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.2.2(typescript@5.9.3)
-      vite: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -11743,13 +11746,11 @@ snapshots:
     dependencies:
       esbuild: 0.14.54
 
-  '@oxc-project/runtime@0.115.0': {}
-
   '@oxc-project/types@0.112.0': {}
 
   '@oxc-project/types@0.114.0': {}
 
-  '@oxc-project/types@0.115.0': {}
+  '@oxc-project/types@0.122.0': {}
 
   '@parcel/watcher@2.0.4':
     dependencies:
@@ -12350,13 +12351,16 @@ snapshots:
 
   '@remix-run/router@1.23.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.3':
     optional: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.3':
@@ -12365,7 +12369,7 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.3':
@@ -12374,7 +12378,7 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.3':
@@ -12383,7 +12387,7 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3':
@@ -12392,7 +12396,7 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
@@ -12401,7 +12405,7 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
@@ -12410,13 +12414,13 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
@@ -12425,7 +12429,7 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
@@ -12434,7 +12438,7 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.3':
@@ -12443,7 +12447,9 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.3':
@@ -12456,9 +12462,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3':
@@ -12467,7 +12471,7 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.3':
@@ -12476,16 +12480,13 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
-    optional: true
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.0-rc.5': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
-
-  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.37.0)':
     dependencies:
@@ -12617,10 +12618,10 @@ snapshots:
       axe-core: 4.10.3
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.2.19(@types/react@18.3.20)(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
+  '@storybook/addon-docs@10.2.19(@types/react@18.3.20)(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.20)(react@18.3.1)
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.2.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -12706,12 +12707,12 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
+  '@storybook/builder-vite@10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -12774,14 +12775,14 @@ snapshots:
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
+  '@storybook/csf-plugin@10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
     dependencies:
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.1
       rollup: 4.37.0
-      vite: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       webpack: 5.98.0(@swc/core@1.15.3)(esbuild@0.25.1)
 
   '@storybook/csf@0.1.13':
@@ -12875,11 +12876,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/react-vite@10.2.19(esbuild@0.25.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
+  '@storybook/react-vite@10.2.19(esbuild@0.25.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.37.0)
-      '@storybook/builder-vite': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
+      '@storybook/builder-vite': 10.2.19(esbuild@0.25.1)(rollup@4.37.0)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1))
       '@storybook/react': 10.2.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.19
@@ -12889,7 +12890,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 10.2.19(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -13811,21 +13812,21 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@4.3.4(vite@8.0.0(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.3.4(vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.28.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 8.0.0(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -16025,9 +16026,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -17466,6 +17467,11 @@ snapshots:
       jest-snapshot: 29.7.0
     transitivePeerDependencies:
       - supports-color
+
+  jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)):
+    dependencies:
+      '@adobe/css-tools': 4.4.2
+      styled-components: 5.3.11(@babel/core@7.28.5)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
 
   jest-styled-components@7.2.0(styled-components@5.3.11(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)):
     dependencies:
@@ -19166,6 +19172,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.3.1: {}
 
   pidtree@0.6.0: {}
@@ -19232,14 +19240,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.15.3)(@types/node@22.14.1)(typescript@5.9.3)
-
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3)):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.7.0
-    optionalDependencies:
-      postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3)
 
   postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.98.0(@swc/core@1.15.3)(esbuild@0.25.1)):
     dependencies:
@@ -19799,6 +19799,27 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown@1.0.0-rc.12:
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+
   rolldown@1.0.0-rc.3:
     dependencies:
       '@oxc-project/types': 0.112.0
@@ -19836,27 +19857,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.5
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.5
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.5
-
-  rolldown@1.0.0-rc.9:
-    dependencies:
-      '@oxc-project/types': 0.115.0
-      '@rolldown/pluginutils': 1.0.0-rc.9
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
 
   rollup@4.37.0:
     dependencies:
@@ -20599,33 +20599,6 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3))
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
   tapable@2.2.1: {}
 
   tar-stream@2.2.0:
@@ -20709,8 +20682,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.0.2: {}
 
@@ -20799,27 +20772,6 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.14.1
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.3
-    optional: true
-
-  ts-node@10.9.2(@swc/core@1.15.3)(@types/node@24.6.1)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 24.6.1
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -21202,13 +21154,12 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.39.0
 
-  vite@8.0.0(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
+  vite@8.0.5(@types/node@22.14.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
-      '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.6
-      rolldown: 1.0.0-rc.9
+      rolldown: 1.0.0-rc.12
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.14.1
@@ -21219,13 +21170,12 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@8.0.0(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
+  vite@8.0.5(@types/node@24.6.1)(esbuild@0.25.1)(jiti@2.6.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
-      '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       postcss: 8.5.6
-      rolldown: 1.0.0-rc.9
+      rolldown: 1.0.0-rc.12
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.6.1


### PR DESCRIPTION
## やったこと

- Icons 2.0の生成フローを追加しました
- Icons 1.0に対してもSVGOを利用したもの、CSSを利用したもの、Data URIの生成フローを追加しました
- pullrequest-cliを拡張して、複数のディレクトリを対象にとれるようにしました
  - `packages/icons` と `packages/icon-files` 両方の差分を検出するための変更です
  - `packages/` を対象に広げると意図していない差分を含んだPull Requestが作成されたら怖いと思って、pullrequest-cliを修正することにしました。
- CodeQLにめちゃくちゃ怒られるので別でリファクタを入れています
  - #891 

## 動作確認環境
- https://github.com/pixiv/charcoal/pull/894

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
