### PR TITLE
refactor icons-cli

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Export icons 1.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --sleepMs 1000
 
@@ -62,7 +62,7 @@ jobs:
       - name: Export icons 2.0
         env:
           FIGMA_FILE_URL: ${{ secrets.FIGMA_FILE_URL_V2 }}
-          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
+          FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN_LIMITED }}
           OUTPUT_ROOT_DIR: ../icon-files/v2
         run: pnpm --filter @charcoal-ui/icons-cli cli:icons figma:export --layout v2 --sleepMs 1000
 

--- a/misc/pullrequest-cli/src/getChangedFiles.ts
+++ b/misc/pullrequest-cli/src/getChangedFiles.ts
@@ -31,7 +31,7 @@ async function collectGitStatus() {
     /**
      * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
      */
-    (await execp(`git status --porcelain -u`)).split('\n').map((s) => {
+    (await execp(`git status --porcelain -uall`)).split('\n').map((s) => {
       return [
         s.slice(3),
         s.startsWith(' M')

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -14,6 +14,7 @@
     "build:uri-v1": "SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icon-files/v1/datauri pnpm tsx src/v2/transformDataUri.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
+    "test": "vitest run",
     "cli:icons": "./dist/index.js",
     "icons": "tsx src/index.ts"
   },

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -12,6 +12,7 @@
     "build:css-v1": "VERSION=v1 SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icons/css/v1 pnpm tsx src/v2/transformCSS.ts",
     "build:uri": "SOURCE_ROOT_DIR=../../../icon-files/v2/svg/ OUTPUT_ROOT_DIR=../icon-files/v2/datauri pnpm tsx src/v2/transformDataUri.ts",
     "build:uri-v1": "SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icon-files/v1/datauri pnpm tsx src/v2/transformDataUri.ts",
+    "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
     "test": "vitest run",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -15,7 +15,6 @@
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
-    "test": "vitest run",
     "cli:icons": "./dist/index.js",
     "icons": "tsx src/index.ts"
   },

--- a/packages/icons-cli/src/GitHubClient.ts
+++ b/packages/icons-cli/src/GitHubClient.ts
@@ -69,7 +69,7 @@ export class GithubClient {
   async createTreeFromDiff(outputDir: string): Promise<TreeItem[]> {
     const tree: TreeItem[] = []
 
-    for await (const file of getChangedFiles(outputDir)) {
+    for await (const file of getChangedFiles([outputDir])) {
       const item = {
         path: file.relativePath,
         // 100 はファイル 644 は実行不可なファイルであるという意味

--- a/packages/icons-cli/src/GitlabClient.ts
+++ b/packages/icons-cli/src/GitlabClient.ts
@@ -59,7 +59,7 @@ export class GitlabClient {
   async createActionsFromDiff(outputDir: string): Promise<CommitAction[]> {
     const actions: CommitAction[] = []
 
-    for await (const file of getChangedFiles(outputDir)) {
+    for await (const file of getChangedFiles([outputDir])) {
       actions.push({
         action:
           file.status === 'untracked'

--- a/packages/icons-cli/src/codegen.test.ts
+++ b/packages/icons-cli/src/codegen.test.ts
@@ -1,0 +1,84 @@
+import vm from 'node:vm'
+import { JSDOM } from 'jsdom'
+import { describe, expect, it } from 'vitest'
+import {
+  createCssClassNameSegment,
+  createSvgDataUri,
+  serializeJavaScriptValue,
+} from './codegen'
+import {
+  generateCjsEntrypoint,
+  generateIconSvgEmbeddedSource,
+} from './generateSource'
+
+describe('serializeJavaScriptValue', () => {
+  it.each([
+    '',
+    `O'Reilly said "hello" twice`,
+    String.raw`C:\icons\multi\\slash`,
+    `''''`,
+    `</script><script>alert("xss")</script>`,
+  ])('JS文字列として安全にシリアライズできる: %j', (value) => {
+    const script = new vm.Script(`value = ${serializeJavaScriptValue(value)}`)
+    const context = vm.createContext({ value: undefined as string | undefined })
+    script.runInContext(context)
+
+    expect(context.value).toBe(value)
+  })
+})
+
+describe('createSvgDataUri', () => {
+  it('通常のSVGでもdata URIを生成できる', () => {
+    expect(
+      createSvgDataUri('<svg xmlns="http://www.w3.org/2000/svg"></svg>'),
+    ).toBe(
+      'data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3C%2Fsvg%3E',
+    )
+  })
+
+  it('複数クォートやバックスラッシュを含むSVGでもCSSに安全に埋め込める', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><text>"\\" '' ''' </style><script>alert(1)</script></text></svg>`
+    const dataUri = createSvgDataUri(svg)
+
+    expect(dataUri.startsWith('data:image/svg+xml;utf8,')).toBe(true)
+    expect(dataUri).not.toContain('<svg')
+    expect(dataUri).not.toContain('</style>')
+    expect(dataUri).not.toContain('<script>')
+    expect(dataUri).toContain('%22')
+    expect(dataUri).toContain('%5C')
+
+    const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>')
+    const style = dom.window.document.createElement('style')
+    style.textContent = `.icon { background-image: url("${dataUri}"); }`
+    dom.window.document.head.append(style)
+
+    expect(style.sheet?.cssRules).toHaveLength(1)
+  })
+})
+
+describe('createCssClassNameSegment', () => {
+  it('既存の通常ケースを維持する', () => {
+    expect(createCssClassNameSegment('Add.Circle.svg')).toBe('add-circle')
+  })
+
+  it('危険な文字をCSS class名から除去する', () => {
+    expect(createCssClassNameSegment(`Bad "Name"..svg`)).toBe('bad-name')
+  })
+})
+
+describe('generateSource', () => {
+  it('空文字や連続クォートを含むSVGでも安全なモジュールソースを生成する', () => {
+    const source = generateIconSvgEmbeddedSource(`''""\\\n`)
+
+    expect(source).toContain(serializeJavaScriptValue(`''""\\`))
+  })
+
+  it('危険なキー名を含んでもCJSエントリポイントが壊れない', () => {
+    const iconName = String.raw`16/Bad'"Name\Icon`
+    const moduleContext = { module: { exports: {} as Record<string, unknown> } }
+    const script = new vm.Script(generateCjsEntrypoint([iconName]))
+    script.runInNewContext(moduleContext)
+
+    expect(Object.keys(moduleContext.module.exports)).toEqual([iconName])
+  })
+})

--- a/packages/icons-cli/src/codegen.test.ts
+++ b/packages/icons-cli/src/codegen.test.ts
@@ -47,7 +47,9 @@ describe('createSvgDataUri', () => {
     expect(dataUri).toContain('%22')
     expect(dataUri).toContain('%5C')
 
-    const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>')
+    const dom = new JSDOM(
+      '<!doctype html><html><head></head><body></body></html>',
+    )
     const style = dom.window.document.createElement('style')
     style.textContent = `.icon { background-image: url("${dataUri}"); }`
     dom.window.document.head.append(style)

--- a/packages/icons-cli/src/codegen.ts
+++ b/packages/icons-cli/src/codegen.ts
@@ -1,0 +1,28 @@
+const SVG_EXTENSION = /\.svg$/iu
+const NON_CSS_CLASS_NAME_CHARACTERS = /[^a-z0-9-]+/gu
+const DUPLICATE_DASHES = /-+/gu
+const EDGE_DASHES = /^-+|-+$/gu
+const LINE_SEPARATOR = /\u2028/gu
+const PARAGRAPH_SEPARATOR = /\u2029/gu
+
+export function serializeJavaScriptValue(value: unknown): string {
+  return JSON.stringify(value, null, 2)
+    .replace(LINE_SEPARATOR, '\\u2028')
+    .replace(PARAGRAPH_SEPARATOR, '\\u2029')
+}
+
+export function createSvgDataUri(svg: string): string {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
+
+export function createCssClassNameSegment(fileName: string): string {
+  const segment = fileName
+    .toLowerCase()
+    .replace(SVG_EXTENSION, '')
+    .replaceAll('.', '-')
+    .replace(NON_CSS_CLASS_NAME_CHARACTERS, '-')
+    .replace(DUPLICATE_DASHES, '-')
+    .replace(EDGE_DASHES, '')
+
+  return segment === '' ? 'icon' : segment
+}

--- a/packages/icons-cli/src/figma/FigmaFileClient.test.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.test.ts
@@ -184,4 +184,35 @@ describe('FigmaFileClient path traversal regression', () => {
       '<svg><path /></svg>',
     )
   })
+
+  it('/design から始まる URL でも fileId を取得できる', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=16,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outputFile = path.join(outputRootDir, '16', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/design/FILE_ID/Test?node-id=1-2',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir)
+
+    expect(mockFile).toHaveBeenCalledWith('FILE_ID')
+    await expect(fs.pathExists(outputFile)).resolves.toBe(true)
+  })
 })

--- a/packages/icons-cli/src/figma/FigmaFileClient.test.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.test.ts
@@ -1,0 +1,187 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FigmaFileClient } from './FigmaFileClient'
+
+const { mockFile, mockFileImages, mockGotGet } = vi.hoisted(() => {
+  return {
+    mockFile: vi.fn(),
+    mockFileImages: vi.fn(),
+    mockGotGet: vi.fn(),
+  }
+})
+
+vi.mock('figma-js', () => {
+  return {
+    Client: vi.fn(() => ({
+      file: mockFile,
+      fileImages: mockFileImages,
+    })),
+  }
+})
+
+vi.mock('got', () => {
+  return {
+    default: {
+      get: mockGotGet,
+    },
+  }
+})
+
+function createV2FileResponse({
+  setName,
+  componentName,
+}: {
+  setName: string
+  componentName: string
+}) {
+  return {
+    data: {
+      document: {
+        children: [
+          {
+            type: 'CANVAS',
+            name: 'Icons 一覧',
+            children: [
+              {
+                type: 'FRAME',
+                name: 'Frame',
+                children: [
+                  {
+                    type: 'COMPONENT_SET',
+                    id: 'set-1',
+                    name: setName,
+                    children: [
+                      {
+                        type: 'COMPONENT',
+                        id: 'component-1',
+                        name: componentName,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+}
+
+describe('FigmaFileClient path traversal regression', () => {
+  let workDir: string
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    workDir = await fs.mkdtemp(path.join(tmpdir(), 'icons-cli-'))
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+
+    mockGotGet.mockResolvedValue({
+      body: '<svg><path /></svg>',
+    })
+  })
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore()
+    vi.clearAllMocks()
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+    await fs.remove(workDir)
+  })
+
+  it('v2 variant に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=../../escaped,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(tmpdir(), 'escaped', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('component set name に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: '../../pwned',
+        componentName: 'size=16',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(workDir, 'pwned.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('正常な v2 名称なら想定ディレクトリに export される', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=16,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outputFile = path.join(outputRootDir, '16', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir)
+
+    await expect(fs.pathExists(outputFile)).resolves.toBe(true)
+    await expect(readFile(outputFile, 'utf8')).resolves.toBe(
+      '<svg><path /></svg>',
+    )
+  })
+})

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -43,6 +43,21 @@ function parseV2IconName(name: string) {
     .toLowerCase()
 }
 
+function resolveOutputPath(outputDir: string, filename: string) {
+  const normalizedOutputDir = path.resolve(outputDir)
+  const fullname = path.resolve(normalizedOutputDir, filename)
+  const relativePath = path.relative(normalizedOutputDir, fullname)
+
+  if (
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    return null
+  }
+
+  return fullname
+}
+
 type ExportFormat = 'svg' | 'pdf'
 
 function sleep(ms: number) {
@@ -182,7 +197,13 @@ export class FigmaFileClient {
       const filename = component.variant
         ? `${parseV2IconName(component.variant)}/${component.name}.${this.exportFormat}`
         : `${filenamify(component.name)}.${this.exportFormat}`
-      const fullname = path.join(outputDir, filename)
+      const fullname = resolveOutputPath(outputDir, filename)
+
+      if (fullname === null) {
+        console.log(`skip invalid output path: ${filename}`)
+        return
+      }
+
       const dirname = path.dirname(fullname)
 
       if (DRY_RUN) {

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -48,10 +48,7 @@ function resolveOutputPath(outputDir: string, filename: string) {
   const fullname = path.resolve(normalizedOutputDir, filename)
   const relativePath = path.relative(normalizedOutputDir, fullname)
 
-  if (
-    relativePath.startsWith('..') ||
-    path.isAbsolute(relativePath)
-  ) {
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
     return null
   }
 

--- a/packages/icons-cli/src/figma/FigmaFileClient.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.ts
@@ -9,7 +9,10 @@ import { concurrently } from '../concurrently'
 
 const DRY_RUN = Boolean(process.env.DRY_RUN)
 
-const matchPath = match<{ fileId: string; name: string }>('/file/:fileId/:name')
+const matchPath = match<{ fileId: string; name: string }>([
+  '/file/:fileId/:name',
+  '/design/:fileId/:name',
+])
 
 function extractParams(url: string): { fileId: string; nodeId?: string } {
   const { pathname, searchParams } = new URL(url)

--- a/packages/icons-cli/src/generateSource.test.ts
+++ b/packages/icons-cli/src/generateSource.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { generateIconSource } from './generateSource'
 
 async function importEsmFromSource(source: string) {
-  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`)
+  return import(
+    `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`
+  )
 }
 
 describe('generateSource regression', () => {

--- a/packages/icons-cli/src/generateSource.test.ts
+++ b/packages/icons-cli/src/generateSource.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { generateIconSource } from './generateSource'
+
+async function importEsmFromSource(source: string) {
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`)
+}
+
+describe('generateSource regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-generate-source-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('クォートやバックスラッシュを含むSVGでも埋め込みモジュールが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const svgContent = `<svg><text>'"\\"</text></svg>\n`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, 'Add.svg'), svgContent)
+
+    await generateIconSource(outputDir)
+
+    const generatedModule = await readFile(
+      path.join(outputDir, 'src', '16', 'Add.js'),
+      'utf8',
+    )
+    const imported = await importEsmFromSource(generatedModule)
+
+    expect(imported.default).toBe(`<svg><text>'"\\"</text></svg>`)
+  })
+
+  it('危険なキー名を含んでもCJSエントリポイントが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const iconName = String.raw`Bad'"Name\Icon`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, `${iconName}.svg`), '<svg />')
+
+    await generateIconSource(outputDir)
+
+    const entrypoint = await readFile(
+      path.join(outputDir, 'src', 'index.cjs'),
+      'utf8',
+    )
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(entrypoint)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([`16/${iconName}`])
+  })
+})

--- a/packages/icons-cli/src/generateSource.ts
+++ b/packages/icons-cli/src/generateSource.ts
@@ -1,43 +1,52 @@
 import path from 'path'
 import { glob } from 'node:fs/promises'
 import fs from 'fs-extra'
+import { serializeJavaScriptValue } from './codegen'
 
-const generateIconSvgEmbeddedSource = (svgString: string) => {
+export const generateIconSvgEmbeddedSource = (svgString: string) => {
   const str = svgString.replace(/\r?\n/g, '')
 
   return `/** This file is auto generated. DO NOT EDIT BY HAND. */
-export default '${str}'
+export default ${serializeJavaScriptValue(str)}
 `
 }
 
-const generateMjsEntrypoint = (
+export const generateMjsEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOT EDIT BY HAND. */
 
 export default {
 ${icons
-  .map((it) => `  '${it}': () => import('./${it}.js').then(m => m.default)`)
+  .map(
+    (it) =>
+      `  ${serializeJavaScriptValue(it)}: () => import(${serializeJavaScriptValue(`./${it}.js`)}).then(m => m.default)`,
+  )
   .join(',\n')}
 }
 `
 
-const generateCjsEntrypoint = (
+export const generateCjsEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOT EDIT BY HAND. */
 
 module.exports = {
 ${icons
-  .map((it) => `  '${it}': () => import('./${it}.js').then(m => m.default)`)
+  .map(
+    (it) =>
+      `  ${serializeJavaScriptValue(it)}: () => import(${serializeJavaScriptValue(`./${it}.js`)}).then(m => m.default)`,
+  )
   .join(',\n')}
 }
 `
 
-const generateTypeDefinitionEntrypoint = (
+export const generateTypeDefinitionEntrypoint = (
   icons: string[],
 ) => `/** This file is auto generated. DO NOt EDIT BY HAND. */
 
 declare var _default: {
-${icons.map((it) => `  '${it}': () => Promise<string>`).join(';\n')}
+${icons
+  .map((it) => `  ${serializeJavaScriptValue(it)}: () => Promise<string>`)
+  .join(';\n')}
 };
 export default _default;
 `

--- a/packages/icons-cli/src/getChangedFiles.ts
+++ b/packages/icons-cli/src/getChangedFiles.ts
@@ -3,20 +3,25 @@ import path from 'path'
 import { execp } from './utils'
 
 /**
- * dir 内で変更があったファイル情報を for await で回せるようにするやつ
+ * dirs 内で変更があったファイル情報を for await で回せるようにするやつ
  */
-export async function* getChangedFiles(dir: string) {
-  if (!existsSync(dir))
-    throw new Error(`icons-cli: target directory not found (${dir})`)
+export async function* getChangedFiles(dirs: string[]) {
+  for (const dir of dirs) {
+    if (!existsSync(dir))
+      throw new Error(`icons-cli: target directory not found (${dir})`)
+  }
   const gitStatus = await collectGitStatus()
   for (const [relativePath, status] of gitStatus) {
-    const fullpath = path.resolve(process.cwd(), '../../', relativePath)
-    if (!fullpath.startsWith(`${dir}/`)) {
+    const fullpath = path.resolve(process.cwd(), relativePath)
+    if (!dirs.some((dir) => fullpath.startsWith(`${dir}/`))) {
       continue
     }
-    if (!existsSync(fullpath))
-      throw new Error(`icons-cli: could not load svg (${fullpath})`)
-    const content = await fs.readFile(fullpath, { encoding: 'utf-8' })
+    if (status !== 'deleted' && !existsSync(fullpath))
+      throw new Error(`icons-cli: could not find file (${fullpath})`)
+    const content =
+      status === 'deleted'
+        ? ''
+        : await fs.readFile(fullpath, { encoding: 'utf-8' })
     yield { relativePath, content, status }
   }
 }
@@ -26,7 +31,7 @@ async function collectGitStatus() {
     /**
      * @see https://git-scm.com/docs/git-status#_porcelain_format_version_1
      */
-    (await execp(`git status --porcelain`)).split('\n').map((s) => {
+    (await execp(`git status --porcelain -uall`)).split('\n').map((s) => {
       return [
         s.slice(3),
         s.startsWith(' M')

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -31,7 +31,7 @@ async function runTransformCss(
 
   try {
     vi.resetModules()
-    await import(new URL('./transformCSS.ts', import.meta.url).href)
+    await import('./transformCSS')
     await waitForFile(path.join(outputDir, 'index.story.tsx'))
   } finally {
     if (previousVersion === undefined) {
@@ -106,7 +106,8 @@ describe('transformCSS regression', () => {
     expect(html).toContain(`class="${safeClassName}"`)
     expect(story).toContain(`className="${safeClassName}"`)
 
-    expect(css).not.toContain('"')
+    expect(css).not.toContain('Bad "Name"')
     expect(html).not.toContain('Bad "Name"')
+    expect(story).not.toContain('Bad "Name"')
   })
 })

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformCss(
+  sourceDir: string,
+  outputDir: string,
+  version: 'v1' | 'v2',
+) {
+  const previousVersion = process.env.VERSION
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.VERSION = version
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformCSS.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.story.tsx'))
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.VERSION
+    } else {
+      process.env.VERSION = previousVersion
+    }
+
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformCSS regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-css-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('通常のv2アイコン名では既存のclass名を維持する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+
+    await fs.ensureDir(path.join(sourceDir, '24', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '24', 'regular', 'Add.Circle.svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+
+    expect(css).toContain('.charcoal-icon-v2-add-circle')
+  })
+
+  it('危険な文字を含むv2ファイル名でも安全なclass名だけを生成する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const safeClassName = 'charcoal-icon-v2-bad-name-16'
+
+    await fs.ensureDir(path.join(sourceDir, '16', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '16', 'regular', 'Bad "Name"..svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+    const html = await readFile(path.join(outputDir, 'index.html'), 'utf8')
+    const story = await readFile(path.join(outputDir, 'index.story.tsx'), 'utf8')
+
+    expect(css).toContain(`.${safeClassName}`)
+    expect(html).toContain(`class="${safeClassName}"`)
+    expect(story).toContain(`className="${safeClassName}"`)
+
+    expect(css).not.toContain('"')
+    expect(html).not.toContain('Bad "Name"')
+  })
+})

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -97,7 +97,10 @@ describe('transformCSS regression', () => {
 
     const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
     const html = await readFile(path.join(outputDir, 'index.html'), 'utf8')
-    const story = await readFile(path.join(outputDir, 'index.story.tsx'), 'utf8')
+    const story = await readFile(
+      path.join(outputDir, 'index.story.tsx'),
+      'utf8',
+    )
 
     expect(css).toContain(`.${safeClassName}`)
     expect(html).toContain(`class="${safeClassName}"`)

--- a/packages/icons-cli/src/v2/transformCSS.ts
+++ b/packages/icons-cli/src/v2/transformCSS.ts
@@ -2,14 +2,51 @@ import { mustBeDefined } from '../utils'
 import { glob, readFile, writeFile } from 'fs/promises'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
-import { escape } from 'querystring'
+import {
+  createCssClassNameSegment,
+  createSvgDataUri,
+  serializeJavaScriptValue,
+} from '../codegen'
+
+const previewStyles = `:root {
+  font-size: 24px;
+}
+.icons {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fill, 300px);
+}
+.icons div {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+code {
+  font-size: 14px;
+}`
+
+function createPreviewItems(
+  classNames: string[],
+  classAttributeName: 'class' | 'className',
+) {
+  return classNames
+    .map(
+      (icon) => `
+  <div>
+    <div ${classAttributeName}="${icon}" aria-label=".${icon}" role="img"></div>
+    <code>.${icon}</code>
+  </div>`,
+    )
+    .join('\n')
+}
 
 async function transformV2(filePath: string, fileName: string) {
   const content = await readFile(filePath, 'utf-8')
   const [size, variant, name] = fileName.split('/')
+  const dataUri = createSvgDataUri(content)
   const cssName = [
     'charcoal-icon-v2',
-    name.toLowerCase().replace('.svg', '').replaceAll('.', '-'),
+    createCssClassNameSegment(name),
     ...(variant === 'regular' ? [] : [variant]),
     ...(size === '24' ? [] : [size]),
   ].join('-')
@@ -19,10 +56,7 @@ async function transformV2(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  background: url('data:image/svg+xml;utf8,${escape(content).replace(
-    "'",
-    "\\'",
-  )}');
+  background: url("${dataUri}");
   aspect-ratio: 1/1;
 }`
     : `
@@ -30,10 +64,7 @@ async function transformV2(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  mask-image: url('data:image/svg+xml;utf8,${escape(content).replace(
-    "'",
-    "\\'",
-  )}');
+  mask-image: url("${dataUri}");
   mask-size: 100% 100%;
   background: currentColor;
   aspect-ratio: 1/1;
@@ -49,9 +80,10 @@ async function transformV2(filePath: string, fileName: string) {
 async function transformV1(filePath: string, fileName: string) {
   const content = await readFile(filePath, 'utf-8')
   const [size, name] = fileName.split('/')
+  const dataUri = createSvgDataUri(content)
   const cssName = [
     'charcoal-icon-v1',
-    name.toLowerCase().replace('.svg', '').replaceAll('.', '-'),
+    createCssClassNameSegment(name),
     ...(size === '24' ? [] : [size]),
   ].join('-')
   const css = content.includes('<def')
@@ -60,10 +92,7 @@ async function transformV1(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  background: url('data:image/svg+xml;utf8,${escape(content).replace(
-    "'",
-    "\\'",
-  )}');
+  background: url("${dataUri}");
   aspect-ratio: 1/1;
 }`
     : `
@@ -71,10 +100,7 @@ async function transformV1(filePath: string, fileName: string) {
   display: inline-block;
   width: 1em;
   height: 1em;
-  mask-image: url('data:image/svg+xml;utf8,${escape(content).replace(
-    "'",
-    "\\'",
-  )}');
+  mask-image: url("${dataUri}");
   mask-size: 100% 100%;
   background: currentColor;
   aspect-ratio: 1/1;
@@ -129,38 +155,12 @@ async function main() {
   classNames = classNames.sort()
   const html = `
 <div class="icons">
-${classNames
-  .map(
-    (icon) => `
-  <div>
-    <div class="${icon}" aria-label=".${icon}" role="img" />
-    <code>.${icon}</code>
-  </div>
-`,
-  )
-  .join('\n')}
+${createPreviewItems(classNames, 'class')}
 </div>`
 
   await writeFile(
     path.join(outDir, 'index.html'),
-    `<link rel="stylesheet" href="./index.css"><style>
-  :root {
-    font-size: 24px;
-  }
-  .icons {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(auto-fill, 300px);
-  }
-  .icons div {
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-  }
-  code {
-    font-size: 14px;
-  }
-</style>${html}`,
+    `<link rel="stylesheet" href="./index.css"><style>${previewStyles}</style>${html}`,
   )
   await writeFile(
     path.join(outDir, 'index.story.tsx'),
@@ -179,26 +179,11 @@ export default {
   render(): JSX.Element {
     return (
       <>
-       <style>{\`${cssContent}\`}</style>
-       <style>
-  {\`:root {
-    font-size: 24px;
-  }
-  .icons {
-    display: grid;
-    gap: 8px;
-    grid-template-columns: repeat(auto-fill, 300px);
-  }
-  .icons div {
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-  }
-  code {
-    font-size: 14px;
-  }\`}
-</style>
-       ${html.replaceAll('class', 'className')}
+       <style>{${serializeJavaScriptValue(cssContent)}}</style>
+       <style>{${serializeJavaScriptValue(previewStyles)}}</style>
+       <div className="icons">
+${createPreviewItems(classNames, 'className')}
+       </div>
       </>
     )
   },

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -26,7 +26,7 @@ async function runTransformDataUri(sourceDir: string, outputDir: string) {
 
   try {
     vi.resetModules()
-    await import(new URL('./transformDataUri.ts', import.meta.url).href)
+    await import('./transformDataUri')
     await waitForFile(path.join(outputDir, 'index.d.ts'))
   } finally {
     if (previousSourceRootDir === undefined) {

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformDataUri(sourceDir: string, outputDir: string) {
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformDataUri.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.d.ts'))
+  } finally {
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformDataUri regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-data-uri-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('危険なキー名を含んでもCJS出力が壊れない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const iconName = String.raw`16/Bad'"Name\Icon`
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, `${iconName}.svg`), '<svg />')
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const cjs = await readFile(path.join(outputDir, 'index.cjs'), 'utf8')
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(cjs)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([iconName])
+  })
+
+  it('危険なSVG文字列でもdata URIを生で埋め込まない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const svgContent =
+      '<svg><text></style><script>alert("xss")</script></text></svg>'
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, '16', 'Add.svg'), svgContent)
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const mjs = await readFile(path.join(outputDir, 'index.mjs'), 'utf8')
+
+    expect(mjs).not.toContain('</style>')
+    expect(mjs).not.toContain('<script>')
+    expect(mjs).toContain('%3Csvg%3E')
+  })
+})

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -47,7 +47,9 @@ describe('transformDataUri regression', () => {
   let workDir: string
 
   beforeEach(async () => {
-    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-data-uri-'))
+    workDir = await mkdtemp(
+      path.join(tmpdir(), 'icons-cli-transform-data-uri-'),
+    )
   })
 
   afterEach(async () => {

--- a/packages/icons-cli/src/v2/transformDataUri.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.ts
@@ -1,8 +1,8 @@
 import { glob, readFile, writeFile } from 'fs/promises'
 import { ensureDir } from 'fs-extra'
 import path from 'path'
+import { createSvgDataUri, serializeJavaScriptValue } from '../codegen'
 import { mustBeDefined } from '../utils'
-import { escape } from 'querystring'
 
 async function main() {
   mustBeDefined(process.env.SOURCE_ROOT_DIR, 'SOURCE_ROOT_DIR')
@@ -21,45 +21,39 @@ async function main() {
 
       return {
         iconName: fileName.replace('.svg', ''),
-        uri: `data:image/svg+xml;utf8,${escape(content).replace("'", "\\'")}`,
+        uri: createSvgDataUri(content),
         isSetCurrentcolor: !content.includes('<def'),
       }
     }),
   )
 
-  const js = `/** This file is auto generated. DO NOT EDIT BY HAND. */
-  
-export default {
-${dataUris
-  .map(
-    (it) =>
-      `'${it.iconName}': {uri: '${it.uri}', isSetCurrentcolor: ${
-        it.isSetCurrentcolor ? 'true' : 'false'
-      }}`,
+  const dataUriMap = Object.fromEntries(
+    dataUris.map(({ iconName, uri, isSetCurrentcolor }) => [
+      iconName,
+      { uri, isSetCurrentcolor },
+    ]),
   )
-  .join(',\n')}
-}`
+
+  const js = `/** This file is auto generated. DO NOT EDIT BY HAND. */
+
+export default ${serializeJavaScriptValue(dataUriMap)}
+`
   await writeFile(path.join(outDir, 'index.mjs'), js)
 
   const cjs = `/** This file is auto generated. DO NOT EDIT BY HAND. */
-  
-module.exports = {
-${dataUris
-  .map(
-    (it) =>
-      `'${it.iconName}': {uri: '${it.uri}', isSetCurrentcolor: ${
-        it.isSetCurrentcolor ? 'true' : 'false'
-      }}`,
-  )
-  .join(',\n')}
-}`
+
+module.exports = ${serializeJavaScriptValue(dataUriMap)}
+`
   await writeFile(path.join(outDir, 'index.cjs'), cjs)
 
   const dts = `/** This file is auto generated. DO NOT EDIT BY HAND. */
   
 declare var _default: {
 ${dataUris
-  .map((it) => `'${it.iconName}': { uri: string, isSetCurrentcolor: boolean }`)
+  .map(
+    (it) =>
+      `${serializeJavaScriptValue(it.iconName)}: { uri: string, isSetCurrentcolor: boolean }`,
+  )
   .join(';\n')}}
 export default _default;
 `

--- a/packages/icons-cli/vitest.config.ts
+++ b/packages/icons-cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    alias: [
+      {
+        find: /@charcoal-ui\/(.*)/,
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '..'),
+          '$1',
+          'src',
+        ),
+      },
+    ],
+  },
+})


### PR DESCRIPTION
## やったこと

アイコン更新フローと関連 CLI の改善を行いました。主に、`@charcoal-ui/icons-cli` の安全性強化、Figma 2.0 向け生成フローの整備、PR 自動作成まわりの改善、回帰テスト追加を含みます。

### icons-cli の変更

- `figma:export` に `--sleepMs` オプションを追加し、Figma export リクエスト間に待機時間を入れられるようにしました
- `sleepMs` 指定時は export ダウンロードを直列実行にし、負の値はエラーにしました
- Figma URL として `/file/...` に加えて `/design/...` 形式も受け付けるようにしました
- Figma の component set 名や variant 名に `../` などが含まれても、`OUTPUT_ROOT_DIR` の外へ書き込まないようにしました
- SVG やアイコン名にクォート、バックスラッシュ、`</style>`、`<script>` などが含まれる場合でも、生成される JS / CSS / data URI が壊れにくいように安全なシリアライズへ変更しました
- 異常な文字を含むアイコン名では、生成される CSS class 名を安全な形式に正規化するようにしました
- 通常の v2 アイコン名については既存の class 名を維持するようにしています
- 文字列シリアライズ、SVG の data URI 化、CSS class 名生成を `codegen.ts` に共通化しました

### PR 作成 CLI の変更

- `pullrequest-cli` が単一ディレクトリ指定の `TARGET_DIR` に加えて、複数ディレクトリ指定の `TARGET_DIRS` を受け付けるようにしました
- changed files 収集処理を見直し、untracked files / untracked directories を含めて扱えるようにしました
- deleted file を含む差分でも PR 作成処理が壊れないようにしました
- `icons-cli` 側の GitHub / GitLab PR 作成処理も、更新後の changed files API に追従させました

### workflow の変更

- GitHub Actions の icons workflow を更新し、icons 1.0 / 2.0 の export・optimize・source generate・data URI build・React build・CSS build をまとめて実行するようにしました
- icons 2.0 の export では v2 layout と専用の Figma URL を使うようにしました
- workflow 内で `fmt` と icon snapshot update も実行するようにしました
- PR 作成処理は `icons-cli github:pr` から `pullrequest-cli github:pr` に切り替え、`packages/icons` と `packages/icon-files` をまとめて対象にするようにしました

### テスト

- `vitest` 実行設定を追加しました
- 以下の回帰テストを追加しました
  - Figma export のパストラバーサル対策
  - `/design/...` Figma URL 対応
  - `generateSource` の文字列エスケープ
  - `transformCSS` の class 名生成と埋め込み安全性
  - `transformDataUri` の data URI / CJS 出力の安全性
  - 共通 codegen ユーティリティの動作確認

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
