### PR TITLE
Mimo/setup icons cli test

### DIFF
--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -14,6 +14,7 @@
     "build:uri-v1": "SOURCE_ROOT_DIR=../../../icon-files/svg/ OUTPUT_ROOT_DIR=../icon-files/v1/datauri pnpm tsx src/v2/transformDataUri.ts",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
+    "test": "vitest run",
     "cli:icons": "./dist/index.js",
     "icons": "tsx src/index.ts"
   },

--- a/packages/icons-cli/src/figma/FigmaFileClient.test.ts
+++ b/packages/icons-cli/src/figma/FigmaFileClient.test.ts
@@ -1,0 +1,187 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FigmaFileClient } from './FigmaFileClient'
+
+const { mockFile, mockFileImages, mockGotGet } = vi.hoisted(() => {
+  return {
+    mockFile: vi.fn(),
+    mockFileImages: vi.fn(),
+    mockGotGet: vi.fn(),
+  }
+})
+
+vi.mock('figma-js', () => {
+  return {
+    Client: vi.fn(() => ({
+      file: mockFile,
+      fileImages: mockFileImages,
+    })),
+  }
+})
+
+vi.mock('got', () => {
+  return {
+    default: {
+      get: mockGotGet,
+    },
+  }
+})
+
+function createV2FileResponse({
+  setName,
+  componentName,
+}: {
+  setName: string
+  componentName: string
+}) {
+  return {
+    data: {
+      document: {
+        children: [
+          {
+            type: 'CANVAS',
+            name: 'Icons 一覧',
+            children: [
+              {
+                type: 'FRAME',
+                name: 'Frame',
+                children: [
+                  {
+                    type: 'COMPONENT_SET',
+                    id: 'set-1',
+                    name: setName,
+                    children: [
+                      {
+                        type: 'COMPONENT',
+                        id: 'component-1',
+                        name: componentName,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }
+}
+
+describe('FigmaFileClient path traversal regression', () => {
+  let workDir: string
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    workDir = await fs.mkdtemp(path.join(tmpdir(), 'icons-cli-'))
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+
+    mockGotGet.mockResolvedValue({
+      body: '<svg><path /></svg>',
+    })
+  })
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore()
+    vi.clearAllMocks()
+    await fs.remove(path.join(tmpdir(), 'escaped'))
+    await fs.remove(workDir)
+  })
+
+  it('v2 variant に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=../../escaped,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(tmpdir(), 'escaped', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('component set name に ../ を含んでも OUTPUT_ROOT_DIR の外へ書き込まない', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: '../../pwned',
+        componentName: 'size=16',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outsidePath = path.join(workDir, 'pwned.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir).catch((error) => error)
+
+    await expect(fs.pathExists(outsidePath)).resolves.toBe(false)
+  })
+
+  it('正常な v2 名称なら想定ディレクトリに export される', async () => {
+    mockFile.mockResolvedValue(
+      createV2FileResponse({
+        setName: 'alert',
+        componentName: 'size=16,color=default',
+      }),
+    )
+    mockFileImages.mockResolvedValue({
+      data: {
+        images: {
+          'component-1': 'https://example.com/icon.svg',
+        },
+      },
+    })
+
+    const outputRootDir = path.join(workDir, 'out')
+    const outputFile = path.join(outputRootDir, '16', 'default', 'alert.svg')
+
+    const client = new FigmaFileClient(
+      'https://www.figma.com/file/FILE_ID/Test',
+      'token',
+      'svg',
+      'v2',
+    )
+
+    await client.loadSvg(outputRootDir)
+
+    await expect(fs.pathExists(outputFile)).resolves.toBe(true)
+    await expect(readFile(outputFile, 'utf8')).resolves.toBe(
+      '<svg><path /></svg>',
+    )
+  })
+})

--- a/packages/icons-cli/src/generateSource.test.ts
+++ b/packages/icons-cli/src/generateSource.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { generateIconSource } from './generateSource'
+
+async function importEsmFromSource(source: string) {
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`)
+}
+
+describe('generateSource regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-generate-source-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('クォートやバックスラッシュを含むSVGでも埋め込みモジュールが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const svgContent = `<svg><text>'"\\"</text></svg>\n`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, 'Add.svg'), svgContent)
+
+    await generateIconSource(outputDir)
+
+    const generatedModule = await readFile(
+      path.join(outputDir, 'src', '16', 'Add.js'),
+      'utf8',
+    )
+    const imported = await importEsmFromSource(generatedModule)
+
+    expect(imported.default).toBe(`<svg><text>'"\\"</text></svg>`)
+  })
+
+  it('危険なキー名を含んでもCJSエントリポイントが壊れない', async () => {
+    const outputDir = path.join(workDir, 'icons')
+    const svgRoot = path.join(outputDir, 'svg', '16')
+    const iconName = String.raw`Bad'"Name\Icon`
+
+    await fs.ensureDir(svgRoot)
+    await writeFile(path.join(svgRoot, `${iconName}.svg`), '<svg />')
+
+    await generateIconSource(outputDir)
+
+    const entrypoint = await readFile(
+      path.join(outputDir, 'src', 'index.cjs'),
+      'utf8',
+    )
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(entrypoint)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([`16/${iconName}`])
+  })
+})

--- a/packages/icons-cli/src/v2/transformCSS.test.ts
+++ b/packages/icons-cli/src/v2/transformCSS.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformCss(
+  sourceDir: string,
+  outputDir: string,
+  version: 'v1' | 'v2',
+) {
+  const previousVersion = process.env.VERSION
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.VERSION = version
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformCSS.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.story.tsx'))
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.VERSION
+    } else {
+      process.env.VERSION = previousVersion
+    }
+
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformCSS regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-css-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('通常のv2アイコン名では既存のclass名を維持する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+
+    await fs.ensureDir(path.join(sourceDir, '24', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '24', 'regular', 'Add.Circle.svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+
+    expect(css).toContain('.charcoal-icon-v2-add-circle')
+  })
+
+  it('危険な文字を含むv2ファイル名でも安全なclass名だけを生成する', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const safeClassName = 'charcoal-icon-v2-bad-name-16'
+
+    await fs.ensureDir(path.join(sourceDir, '16', 'regular'))
+    await writeFile(
+      path.join(sourceDir, '16', 'regular', 'Bad "Name"..svg'),
+      '<svg />',
+    )
+
+    await runTransformCss(sourceDir, outputDir, 'v2')
+
+    const css = await readFile(path.join(outputDir, 'index.css'), 'utf8')
+    const html = await readFile(path.join(outputDir, 'index.html'), 'utf8')
+    const story = await readFile(path.join(outputDir, 'index.story.tsx'), 'utf8')
+
+    expect(css).toContain(`.${safeClassName}`)
+    expect(html).toContain(`class="${safeClassName}"`)
+    expect(story).toContain(`className="${safeClassName}"`)
+
+    expect(css).not.toContain('"')
+    expect(html).not.toContain('Bad "Name"')
+  })
+})

--- a/packages/icons-cli/src/v2/transformDataUri.test.ts
+++ b/packages/icons-cli/src/v2/transformDataUri.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import vm from 'node:vm'
+import fs from 'fs-extra'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForFile(filePath: string) {
+  for (let i = 0; i < 100; i += 1) {
+    if (await fs.pathExists(filePath)) {
+      return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+
+  throw new Error(`timed out waiting for ${filePath}`)
+}
+
+async function runTransformDataUri(sourceDir: string, outputDir: string) {
+  const previousSourceRootDir = process.env.SOURCE_ROOT_DIR
+  const previousOutputRootDir = process.env.OUTPUT_ROOT_DIR
+
+  process.env.SOURCE_ROOT_DIR = path.relative(import.meta.dirname, sourceDir)
+  process.env.OUTPUT_ROOT_DIR = outputDir
+
+  try {
+    vi.resetModules()
+    await import(new URL('./transformDataUri.ts', import.meta.url).href)
+    await waitForFile(path.join(outputDir, 'index.d.ts'))
+  } finally {
+    if (previousSourceRootDir === undefined) {
+      delete process.env.SOURCE_ROOT_DIR
+    } else {
+      process.env.SOURCE_ROOT_DIR = previousSourceRootDir
+    }
+
+    if (previousOutputRootDir === undefined) {
+      delete process.env.OUTPUT_ROOT_DIR
+    } else {
+      process.env.OUTPUT_ROOT_DIR = previousOutputRootDir
+    }
+  }
+}
+
+describe('transformDataUri regression', () => {
+  let workDir: string
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(path.join(tmpdir(), 'icons-cli-transform-data-uri-'))
+  })
+
+  afterEach(async () => {
+    await fs.remove(workDir)
+  })
+
+  it('危険なキー名を含んでもCJS出力が壊れない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const iconName = String.raw`16/Bad'"Name\Icon`
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, `${iconName}.svg`), '<svg />')
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const cjs = await readFile(path.join(outputDir, 'index.cjs'), 'utf8')
+    const context = {
+      module: { exports: {} as Record<string, unknown> },
+    }
+
+    const script = new vm.Script(cjs)
+    script.runInNewContext(context)
+
+    expect(Object.keys(context.module.exports)).toEqual([iconName])
+  })
+
+  it('危険なSVG文字列でもdata URIを生で埋め込まない', async () => {
+    const sourceDir = path.join(workDir, 'input')
+    const outputDir = path.join(workDir, 'output')
+    const svgContent =
+      '<svg><text></style><script>alert("xss")</script></text></svg>'
+
+    await fs.ensureDir(path.join(sourceDir, '16'))
+    await writeFile(path.join(sourceDir, '16', 'Add.svg'), svgContent)
+
+    await runTransformDataUri(sourceDir, outputDir)
+
+    const mjs = await readFile(path.join(outputDir, 'index.mjs'), 'utf8')
+
+    expect(mjs).not.toContain('</style>')
+    expect(mjs).not.toContain('<script>')
+    expect(mjs).toContain('%3Csvg%3E')
+  })
+})

--- a/packages/icons-cli/vitest.config.ts
+++ b/packages/icons-cli/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    alias: [
+      {
+        find: /@charcoal-ui\/(.*)/,
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '..'),
+          '$1',
+          'src',
+        ),
+      },
+    ],
+  },
+})


### PR DESCRIPTION
## やったこと

- icons-cliのパス解決などがcharcoalのモノレポ専用すぎる可能性があるので、挙動を確認する
- 変更差分を確認しやすくするために、テストをセットアップする

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
