### PR TITLE
fix(icons-cli): escape CSS data URIs safely

### DIFF
--- a/packages/icons-cli/src/codegen.test.ts
+++ b/packages/icons-cli/src/codegen.test.ts
@@ -36,8 +36,8 @@ describe('createSvgDataUri', () => {
     )
   })
 
-  it('複数クォートやバックスラッシュを含むSVGでもCSSに安全に埋め込める', () => {
-    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><text>"\\" '' ''' </style><script>alert(1)</script></text></svg>`
+  it('複数クォートや括弧やバックスラッシュを含むSVGでもCSSに安全に埋め込める', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><text>"\\" '' ''' () </style><script>alert(1)</script></text></svg>`
     const dataUri = createSvgDataUri(svg)
 
     expect(dataUri.startsWith('data:image/svg+xml;utf8,')).toBe(true)
@@ -45,6 +45,9 @@ describe('createSvgDataUri', () => {
     expect(dataUri).not.toContain('</style>')
     expect(dataUri).not.toContain('<script>')
     expect(dataUri).toContain('%22')
+    expect(dataUri).toContain('%27')
+    expect(dataUri).toContain('%28')
+    expect(dataUri).toContain('%29')
     expect(dataUri).toContain('%5C')
 
     const dom = new JSDOM(
@@ -55,6 +58,12 @@ describe('createSvgDataUri', () => {
     dom.window.document.head.append(style)
 
     expect(style.sheet?.cssRules).toHaveLength(1)
+
+    const singleQuotedStyle = dom.window.document.createElement('style')
+    singleQuotedStyle.textContent = `.icon { background-image: url('${dataUri}'); }`
+    dom.window.document.head.append(singleQuotedStyle)
+
+    expect(singleQuotedStyle.sheet?.cssRules).toHaveLength(1)
   })
 })
 

--- a/packages/icons-cli/src/codegen.ts
+++ b/packages/icons-cli/src/codegen.ts
@@ -1,3 +1,5 @@
+import { encodeSvgAsDataUri } from './utils'
+
 const SVG_EXTENSION = /\.svg$/iu
 const NON_CSS_CLASS_NAME_CHARACTERS = /[^a-z0-9-]+/gu
 const DUPLICATE_DASHES = /-+/gu
@@ -12,7 +14,9 @@ export function serializeJavaScriptValue(value: unknown): string {
 }
 
 export function createSvgDataUri(svg: string): string {
-  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+  return `data:image/svg+xml;utf8,${encodeSvgAsDataUri(svg)
+    .replaceAll("'", '%27')
+    .replaceAll('"', '%22')}`
 }
 
 export function createCssClassNameSegment(fileName: string): string {


### PR DESCRIPTION
## やったこと

- iconsのdata uriで、エスケープのたりていなかった箇所を補いました。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
