### PR TITLE
ci: Set cooldown in dependabot :dependabot: and pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     labels:
       - 'dependencies'
       - 'github-actions'
+    cooldown:
+      default-days: 7
 
   # npm (pnpm workspaces)
   - package-ecosystem: 'npm'
@@ -22,6 +24,8 @@ updates:
     open-pull-requests-limit: 15
     ignore:
       - dependency-name: '@charcoal-ui/*'
+    cooldown:
+      default-days: 7
     groups:
       types:
         patterns:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ packages:
 catalog:
   'react-compiler-runtime': '1.0.0'
   '@react-spring/web': '^10'
+
+minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
## やったこと

昨今サプライチェーンアタックにより依存パッケージの最新版が汚染されることも珍しくないため、dependabotにcooldownを設定して最新版が出てもアップデートを7日間待つようにしました。

c.f. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

あと別件ですがGitHub Actionsで使ってるactionもSHA Pinを行った方がよさそうです。

c.f. https://zenn.dev/azu/articles/ad168118524135#github-actions%E3%81%A7%E3%81%AFsha-pin%E3%82%92%E8%A1%8C%E3%81%86

## 動作確認環境
なし

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
