### PR TITLE
fix(react): handle unmatched DropdownSelector value

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -741,6 +741,9 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Def
             tabindex="-1"
           >
             <option
+              value=""
+            />
+            <option
               value="1"
             >
               1

--- a/lerna.json
+++ b/lerna.json
@@ -85,6 +85,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "commonjs",
   "bin": "./dist/index.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/components/DropdownSelector/index.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import DropdownSelector from '.'
+import DropdownMenuItem from './DropdownMenuItem'
+
+describe('DropdownSelector', () => {
+  describe('when `value` does not match any child `DropdownMenuItem`', () => {
+    it('keeps the DOM `<select>.value` aligned with props `value` without breaking placeholder display', () => {
+      const handleChange = vi.fn()
+      const { container } = render(
+        <DropdownSelector
+          label="Label"
+          value="missing-value"
+          placeholder="Select an option"
+          onChange={handleChange}
+        >
+          <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+          <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+        </DropdownSelector>,
+      )
+
+      const select = container.querySelector('select')
+      const button = screen.getByRole('button')
+
+      expect(select).not.toBeNull()
+      expect(select?.value).toBe('missing-value')
+      expect(button.textContent).toContain('Select an option')
+    })
+  })
+})

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -50,6 +50,10 @@ export default function DropdownSelector({
   )
 
   const propsArray = getValuesRecursive(props.children)
+  const hasMatchedValue = useMemo(
+    () => propsArray.some((itemProps) => itemProps.value === props.value),
+    [propsArray, props.value],
+  )
 
   const { visuallyHiddenProps } = useVisuallyHidden()
 
@@ -86,6 +90,9 @@ export default function DropdownSelector({
           tabIndex={-1}
           ref={selectRef}
         >
+          {!hasMatchedValue && (
+            <option value={props.value}>{props.value}</option>
+          )}
           {propsArray.map((itemProps) => {
             return (
               <option

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "type": "commonjs",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@charcoal-ui/token-cli",
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsdown",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## やったこと

- DropdownSelectorで `value` と `children` が一致しないときに、内部的な `<select>` の最も上の選択肢が `selectRef.current.value` から取得されてしまう問題に対応しました
  - propから渡されている `value` が選択肢と一致しないときに、 `value` をバインドした `<option>` タグを生成し、 `<select>` の挙動を利用して `selectRef.current.value` が `value` と同等になるようにしました。

## 動作確認環境
test

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
