### PR TITLE
feat(react): add max rows prop in textarea

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -5338,6 +5338,50 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeight 1`] = `
 </div>
 `;
 
+exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightAndRows 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 3;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="false"
+          id="test-id"
+          rows="3"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/TextArea > react/TextArea > Default 1`] = `
 <div>
   <div
@@ -5526,6 +5570,104 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > Label 1`] = `
           id="test-id"
           rows="4"
         />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRows 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 5;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="4"
+        />
+        <span
+          class="charcoal-text-area-counter"
+        >
+          0
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowsAndRows 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 4;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="3"
+        />
+        <span
+          class="charcoal-text-area-counter"
+        >
+          0
+        </span>
       </div>
     </div>
   </div>

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -94,3 +94,21 @@ export const AutoHeight: StoryObj<typeof TextArea> = {
     return <TextArea autoHeight label="Label" />
   },
 }
+
+export const AutoHeightAndRows: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return <TextArea rows={3} autoHeight label="label" />
+  },
+}
+
+export const MaxRows: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return <TextArea maxRows={6} label="label" showCount />
+  },
+}
+
+export const MaxRowsAndRows: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return <TextArea rows={3} maxRows={6} label="label" showCount />
+  },
+}

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -1,7 +1,14 @@
 import './index.css'
 
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import FieldLabel from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { useFocusWithClick } from '../TextField/useFocusWithClick'
@@ -24,6 +31,8 @@ export type TextAreaProps = {
   subLabel?: React.ReactNode
   autoHeight?: boolean
 
+  maxRows?: number
+
   getCount?: (value: string) => number
 } & Omit<React.ComponentPropsWithoutRef<'textarea'>, 'onChange'>
 
@@ -44,6 +53,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       maxLength,
       autoHeight = false,
       rows: initialRows = 4,
+      maxRows,
       invalid,
       getCount = countCodePointsInString,
       ...props
@@ -54,13 +64,26 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const [count, setCount] = useState(getCount(value ?? ''))
     const [rows, setRows] = useState(initialRows)
+    const isEnableAutoHeight = useMemo(
+      () => autoHeight || (maxRows && maxRows >= 0),
+      [autoHeight, maxRows],
+    )
 
     const syncHeight = useCallback(
       (textarea: HTMLTextAreaElement) => {
-        const rows = (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
-        setRows(initialRows <= rows ? rows : initialRows)
+        const currentRows =
+          (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
+        const hasValidMaxRows = maxRows !== undefined && maxRows >= 1
+        const nextRows = initialRows <= currentRows ? currentRows : initialRows
+
+        if (!hasValidMaxRows || maxRows <= initialRows) {
+          setRows(nextRows)
+          return
+        }
+
+        setRows(nextRows <= maxRows ? nextRows : maxRows)
       },
-      [initialRows],
+      [initialRows, maxRows],
     )
 
     const nonControlled = value === undefined
@@ -74,12 +97,19 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         if (nonControlled) {
           setCount(count)
         }
-        if (autoHeight && textareaRef.current !== null) {
+        if (isEnableAutoHeight && textareaRef.current !== null) {
           syncHeight(textareaRef.current)
         }
         onChange?.(value)
       },
-      [autoHeight, getCount, maxLength, nonControlled, onChange, syncHeight],
+      [
+        isEnableAutoHeight,
+        getCount,
+        maxLength,
+        nonControlled,
+        onChange,
+        syncHeight,
+      ],
     )
 
     useEffect(() => {
@@ -87,10 +117,10 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     }, [getCount, value])
 
     useEffect(() => {
-      if (autoHeight && textareaRef.current !== null) {
+      if (isEnableAutoHeight && textareaRef.current !== null) {
         syncHeight(textareaRef.current)
       }
-    }, [autoHeight, syncHeight])
+    }, [isEnableAutoHeight, syncHeight])
 
     const containerRef = useRef(null)
 


### PR DESCRIPTION
## やったこと

- TextAreaコンポーネントに `maxRows` を追加しました
  - テキストエリア内の入力が `maxRows` 以下の場合は、入力の改行数に応じてテキストエリアの縦幅が変わりますが、 `maxRows` を超える行数になった場合、 `maxRows` で指定した行数に固定されます。
  - `maxRows` が指定されている時、 `autoHeight` が有効になっている状態と同じ扱いにしました。 `autoHeight` 単体で利用する場合と比較して、最大の行数が抑制される点に違いがあります。
  - `maxRows` と `rows` を併用する場合、テキストエリアの初期・最小行数を `rows` 、 最大行数を `maxRows` とする挙動になります。
    - これは `autoHeight`と `rows` に値が指定されているときもテキストエリアは `rows` を超えて伸びる挙動をしているためです。

## 動作確認環境
Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
