### PR TITLE
fix: themeHelper update loop

### DIFF
--- a/packages/react/src/core/themeHelper.test.tsx
+++ b/packages/react/src/core/themeHelper.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useLocalStorage } from './themeHelper'
+
+describe('themeHelper', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('does not enter an update loop when localStorage contains JSON', () => {
+    localStorage.setItem('theme', JSON.stringify({ mode: 'dark' }))
+
+    const { result } = renderHook(() =>
+      useLocalStorage<{ mode: string }>('theme'),
+    )
+
+    expect(result.current[0]).toEqual({ mode: 'dark' })
+    expect(result.current[2]).toBe(true)
+  })
+})

--- a/packages/react/src/core/themeHelper.ts
+++ b/packages/react/src/core/themeHelper.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 export const LOCAL_STORAGE_KEY = 'charcoal-theme'
 export const DEFAULT_ROOT_ATTRIBUTE = 'theme'
@@ -29,6 +29,9 @@ export const themeSetter =
     }
   }
 
+// デフォルト引数で生成すると毎レンダー新しい関数になり、effect が再実行される
+const defaultThemeSetter = themeSetter()
+
 /**
  * `<html data-theme="dark">` にマッチするセレクタを生成する
  */
@@ -51,7 +54,7 @@ export function prefersColorScheme<T extends 'light' | 'dark'>(theme: T) {
  */
 export function useThemeSetter({
   key = LOCAL_STORAGE_KEY,
-  setter = themeSetter(),
+  setter = defaultThemeSetter,
 }: { key?: string; setter?: (theme: string | undefined) => void } = {}) {
   const [theme, , system] = useTheme(key)
 
@@ -93,29 +96,33 @@ export function useLocalStorage<T>(key: string, defaultValue?: () => T) {
   const [state, setState] = useState<T>()
   const defaultValueMemo = useMemo(() => defaultValue?.(), [defaultValue])
 
+  const fetch = useCallback(() => {
+    const raw = localStorage.getItem(key)
+    setState((raw !== null ? deserialize(raw) : null) ?? defaultValueMemo)
+    setReady(true)
+  }, [defaultValueMemo, key])
+
+  const handleStorage = useCallback(
+    (e: StorageEvent) => {
+      if (e.storageArea !== localStorage) {
+        return
+      }
+      if (e.key !== key) {
+        return
+      }
+      fetch()
+    },
+    [fetch, key],
+  )
+
+  // JSON は deserialize のたびに新しい object になるため、入力変更時だけ再取得する
   useEffect(() => {
     fetch()
     window.addEventListener('storage', handleStorage)
     return () => {
       window.removeEventListener('storage', handleStorage)
     }
-  })
-
-  const handleStorage = (e: StorageEvent) => {
-    if (e.storageArea !== localStorage) {
-      return
-    }
-    if (e.key !== key) {
-      return
-    }
-    fetch()
-  }
-
-  const fetch = () => {
-    const raw = localStorage.getItem(key)
-    setState((raw !== null ? deserialize(raw) : null) ?? defaultValueMemo)
-    setReady(true)
-  }
+  }, [fetch, handleStorage])
 
   const set = (value: T | undefined) => {
     if (value === undefined) {


### PR DESCRIPTION
## やったこと

- **fix: add themeHelper update loop test**
- **fix: themeHelper update loop**

Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.

#### Stacktrace

```
 onChange in ../src/core/themeHelper.ts [Line 167] (In app)

  useEffect(() => {
    const matcher = window.matchMedia(query)

    const onChange = () => {
      setState(matcher.matches)  <-- SUSPECT LINE
    }

    matcher.addEventListener('change', onChange)

    setState(matcher.matches)
```

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
