### PR TITLE
docs: icon.css と SSR/CLS 関連ドキュメントを補強

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -2845,9 +2845,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Basic 1`] = `
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -2876,9 +2876,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Basic 1`] = `
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -2908,9 +2908,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Basic 1`] = `
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -2939,9 +2939,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Basic 1`] = `
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -2985,9 +2985,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Invalid 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3016,9 +3016,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Invalid 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3047,9 +3047,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Invalid 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3078,9 +3078,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Invalid 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3124,9 +3124,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Overlay 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3155,9 +3155,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Overlay 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3186,9 +3186,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Overlay 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3217,9 +3217,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Overlay 1`] =
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3263,9 +3263,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Playground 1`
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3295,9 +3295,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Playground 1`
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3327,9 +3327,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Playground 1`
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div
@@ -3359,9 +3359,9 @@ exports[`Storybook Tests > react/MultiSelect > react/MultiSelect > Playground 1`
         >
           <pixiv-icon
             class="charcoal-icon"
+            fixed-size="16"
             name="24/Check"
             style="--charcoal-icon-ssr-size: 16px;"
-            unsafe-non-guideline-scale="0.6666666666666666"
           />
         </div>
         <div

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,8 @@ import themeDecorator from './theme-decorator'
 import { DocsContainer } from './docs-container'
 
 import './global.css'
+// vanilla HTML で <pixiv-icon> を使う docs / stories でも layout shift を防ぐ
+import '@charcoal-ui/icons/css/icon.css'
 
 /** @type  */
 export const parameters = {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "provenance": true
   },
   "devDependencies": {
+    "@charcoal-ui/icons": "workspace:^",
     "@charcoal-ui/icons-cli": "workspace:^",
     "@charcoal-ui/styled": "workspace:^",
     "@charcoal-ui/theme": "workspace:^",

--- a/packages/icons/src/PixivIcon.story.tsx
+++ b/packages/icons/src/PixivIcon.story.tsx
@@ -190,7 +190,38 @@ export const WithAttributes: StoryObj<Props> = {
   },
 }
 
-export const WithUnsafe: StoryObj<Props> = {
+export const WithFixedSize: StoryObj<Props> = {
+  render: ({ color, name, scale, ...args }) => {
+    return (
+      <>
+        <IconDef color={color}>
+          <pixiv-icon
+            fixed-size={args['fixed-size']}
+            name={name}
+            scale={scale}
+          />
+          アイコンと文字
+        </IconDef>
+        <Global />
+      </>
+    )
+  },
+  args: {
+    name: '16/Add',
+    'fixed-size': '60',
+    color: '#000000',
+  },
+  parameters: {
+    vrt: {
+      viewport: {
+        width: 1280,
+        height: 720,
+      },
+    },
+  },
+}
+
+export const WithUnsafeNonGuidelineScale: StoryObj<Props> = {
   render: ({ color, name, scale, ...args }) => {
     return (
       <>
@@ -200,7 +231,7 @@ export const WithUnsafe: StoryObj<Props> = {
             name={name}
             scale={scale}
           />
-          アイコンと文字
+          アイコンと文字 (deprecated)
         </IconDef>
         <Global />
       </>

--- a/packages/icons/src/README.mdx
+++ b/packages/icons/src/README.mdx
@@ -40,17 +40,22 @@ bun add @charcoal-ui/icons
 
 ## 使い方
 
-アプリケーションのエントリポイントで `import` します。
+アプリケーションのエントリポイントで以下の 2 つを `import` します。
 Storybook の場合は `preview.(js|ts)` に書くと良いでしょう。
 
-**`@charcoal-ui/react` の [`<Icon>`](/docs/react-icon--docs) コンポーネントを利用している場合、この `import` は内部で自動的に行われます。**
+**`@charcoal-ui/react` の [`<Icon>`](/docs/react-icon--docs) コンポーネントを利用している場合、両方の `import` は内部で自動的に行われます。**
 
 ```typescript
+// Custom Element 本体の登録と型定義
 import '@charcoal-ui/icons'
+// レイアウトシフト防止 CSS (SSR / 初期描画時にアイコンの寸法を確保する)
+import '@charcoal-ui/icons/css/icon.css'
 ```
 
 これだけで、`<pixiv-icon>` という HTML タグが利用可能になります。
 TypeScript の型定義がグローバルにインストールされるので、JSX で `<pixiv-icon>` を書く際にも型チェックが効きます。
+
+`icon.css` の役割と、レイアウトシフト対策の詳細は [SSR Guide](/docs/icons-ssr-guide--docs) を参照してください。
 
 ## 収録アイコン
 

--- a/packages/icons/src/SSR.mdx
+++ b/packages/icons/src/SSR.mdx
@@ -8,58 +8,91 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 `@charcoal-ui/icons` は、Node.js の環境下で import されたり、API を呼び出されても問題が起きないように設計されています。
 
 一方、Custom Element であるということは、**SVG アイコンの読み込みはクライアントサイドで行われます**。  
-したがって、大きさが確定せずにレイアウトシフトが起こりうるのは、SSR における注意点の一つと言えます。
+したがって、大きさが確定せずにレイアウトシフト (CLS) が起こりうるのは、SSR における注意点の一つと言えます。
 
-以下のようなコードをリセット CSS に含めることで、`<pixiv-icon>` によるレイアウトシフトの発生を防ぐことができます。  
-（簡単のため、ネスト記法が利用できるケースを意図しています）
+## なぜ CSS が必要なのか
 
-```css
-pixiv-icon {
-  display: inline-flex;
-  width: calc(var(--icon-size, 1em) * var(--scale, 1));
-  height: calc(var(--icon-size, 1em) * var(--scale, 1));
-}
+`@charcoal-ui/icons` の JS が読み込まれて `customElements.define('pixiv-icon', ...)` が実行されるまで、`<pixiv-icon>` は Shadow DOM を持たない単なる未登録 Custom Element です。CSS がない場合、ブラウザはこの要素のサイズを 0x0 として扱うため:
 
-&[name~='16/'] {
-  --icon-size: 16px;
-}
+- SSR で送出された HTML が画面に描画された直後: アイコンは **0x0** で何も見えない
+- JS がロードされて `pixiv-icon` が `:defined` になった瞬間: 突然 16x16 / 24x24 などの実サイズになり、**周囲のコンテンツが押し出される**
 
-&[name~='24/'] {
-  --icon-size: 24px;
-}
+この瞬間に発生する CLS を、`icon.css` が事前に寸法を確保することで防ぎます。
 
-&[name~='32/'] {
-  --icon-size: 32px;
-}
+## レイアウトシフト防止 CSS
 
-&[scale='2'] {
-  --scale: 2;
-}
+`@charcoal-ui/icons/css/icon.css` をインポートすると、`<pixiv-icon>` のレイアウトシフトを防止できます。
+アプリケーションのエントリポイント、または Storybook の `preview.(js|ts)` で 1 度だけ読み込んでください。
 
-&[scale='3'] {
-  --scale: 3;
-}
-
-/* NOTICE: 現状とサポートブラウザが少ない */
-@supports (--scale: attr(unsafe-non-guideline-scale)) {
-  &[unsafe-non-guideline-scale] {
-    --scale: attr(unsafe-non-guideline-scale);
-  }
-}
+```ts
+import '@charcoal-ui/icons/css/icon.css'
 ```
 
-ただしコメントにもある通り、**現状 `unsafe-non-guideline-scale` をつけた要素は、リセット CSS だけではレイアウトシフトが防げません。**
-CSS の `attr()` が数値の解釈をサポートするまで、個別にインラインスタイルを用いて大きさを確定させるなどのワークアラウンドが必要です。
+この CSS は 2 つのメカニズムを提供します。
+
+### 1. `.charcoal-icon` クラス（React 向け）
+
+`@charcoal-ui/react` の `<Icon>` コンポーネントは自動的に `.charcoal-icon` クラスと `--charcoal-icon-ssr-size` CSS 変数を設定します。
+CSS が読み込まれていれば、Custom Element の定義前でも正しいサイズが確保されます。
+
+### 2. `pixiv-icon:not(:defined)` セレクター（vanilla HTML 向け）
+
+React を使わない場合でも、`name` 属性のプレフィックス（`16/`, `24/`, `32/`, `Inline/`）と `scale` 属性に基づいてサイズが確保されます。
+
+## サイズ決定ルール
+
+`pixiv-icon:not(:defined)` セレクターでは、サイズは以下の優先順位で決まります。
+
+1. **`style="--charcoal-icon-ssr-size: Npx"` が指定されていれば、その値を使う**（最優先）
+2. それ以外は `name` プレフィックスと `scale` 属性から導出されたガイドラインデフォルトを使う
+
+`<pixiv-icon>` が JS によって `:defined` 状態になった後は、 `unsafe-non-guideline-size` / `unsafe-non-guideline-scale` 属性も解釈され、計算結果が `--charcoal-icon-ssr-size` に反映されます。
 
 ```html
-<pixiv-icon
-  name="24/Add"
-  unsafe-non-guideline-scale="0.5"
-  style="--scale: 0.5;"
-></pixiv-icon>
-<pixiv-icon
-  name="24/Add"
-  unsafe-non-guideline-scale="0.5"
-  style="width: 12px; height: 12px;"
-></pixiv-icon>
+<!-- ガイドライン通り 24px -->
+<pixiv-icon name="24/Add"></pixiv-icon>
+
+<!-- ガイドライン通り 48px (24 × scale=2) -->
+<pixiv-icon name="24/Add" scale="2"></pixiv-icon>
+
+<!-- name="24/Add" でも CSS 変数で上書きして 40px に -->
+<pixiv-icon name="24/Add" style="--charcoal-icon-ssr-size: 40px"></pixiv-icon>
 ```
+
+### `scale` 属性のプレフィックスごとの挙動
+
+`name` プレフィックスごとに `scale` のサポート範囲が異なります。表に整理すると以下の通りです。
+
+| プレフィックス | `scale=1` | `scale=2` | `scale=3` | 備考                              |
+| -------------- | --------- | --------- | --------- | --------------------------------- |
+| `16/`          | 16        | **16**    | **16**    | `scale` を無視（意図的な仕様）    |
+| `24/`          | 24        | 48        | 72        | すべて対応                        |
+| `32/`          | 32        | **32**    | **32**    | `scale` を無視（意図的な仕様）    |
+| `Inline/`      | 16        | 32        | **16**    | `scale=3` は `scale=1` と同じ扱い |
+
+`scale` に対応していない組み合わせを書いても **CLS は発生しません**（CSS と JS 双方で同じ結果を返すように揃えてあります）が、期待通りに大きくならないことに注意してください。
+大きく表示したい場合は次節の「ガイドライン外のサイズ指定」を使ってください。
+
+### ガイドライン外のサイズ指定
+
+ガイドライン外のサイズを使う場合は次のいずれかが使えます。
+
+- React: `<Icon>` の `unsafeNonGuidelineScale` / `unsafeNonGuidelineSize` props
+- vanilla HTML: `<pixiv-icon>` の `unsafe-non-guideline-scale` / `unsafe-non-guideline-size` 属性
+- どちらも使えない場合: `--charcoal-icon-ssr-size` CSS 変数を直接設定
+
+```jsx
+<Icon name="24/Add" unsafeNonGuidelineScale={1.5} /> {/* 24 × 1.5 = 36px */}
+<Icon name="24/Add" unsafeNonGuidelineSize={40} />   {/* 直接 40px */}
+```
+
+```html
+<!-- 属性で指定: hydrate 後に web component が --charcoal-icon-ssr-size を更新する -->
+<pixiv-icon name="24/Add" unsafe-non-guideline-scale="1.5"></pixiv-icon>
+<pixiv-icon name="24/Add" unsafe-non-guideline-size="40"></pixiv-icon>
+
+<!-- SSR 段階から CLS を完全に防ぎたい場合は CSS 変数を直接セット -->
+<pixiv-icon name="24/Add" style="--charcoal-icon-ssr-size: 12px"></pixiv-icon>
+```
+
+属性指定では、JS が読み込まれるまでは `pixiv-icon:not(:defined)` ルールの `name` + `scale` ベースのサイズが暫定的に使われ、`:defined` になった瞬間に正しいサイズに切り替わります。SSR 段階で正確なサイズを確保したい場合は `--charcoal-icon-ssr-size` CSS 変数を直接セットしてください。

--- a/packages/icons/src/SSR.mdx
+++ b/packages/icons/src/SSR.mdx
@@ -48,16 +48,17 @@ React を使わない場合でも、`name` 属性のプレフィックス（`16/
 1. **`style="--charcoal-icon-ssr-size: Npx"` が指定されていれば、その値を使う**（最優先）
 2. それ以外は `name` プレフィックスと `scale` 属性から導出されたガイドラインデフォルトを使う
 
-`unsafe-non-guideline-scale` / `unsafe-non-guideline-size` 属性は CSS の `attr()` での
+`fixed-size` / `unsafe-non-guideline-scale` 属性は CSS の `attr()` での
 数値解釈に制約があるためこの段階では参照できず、暫定値が表示されます。
+**ガイドライン外のサイズで CLS を完全に防ぐには、必ず `style="--charcoal-icon-ssr-size: Npx"` をインラインで併記してください** (React の `<Icon fixedSize>` 経由なら自動で付与されます)。
 
 ### hydrate 後 (`:defined` 状態)
 
 JS が読み込まれて web component が定義されると、`render()` が以下の優先順で size を計算し、
 **結果を `--charcoal-icon-ssr-size` の inline style に上書きします**。
 
-1. `unsafe-non-guideline-size` 属性（最優先 / ピクセル値）
-2. `unsafe-non-guideline-scale` 属性 × `name` のベースサイズ
+1. `fixed-size` 属性（最優先 / ピクセル値）
+2. `unsafe-non-guideline-scale` 属性 × `name` のベースサイズ（**deprecated**）
 3. `name` プレフィックスと `scale` 属性から導出されたガイドラインデフォルト
 
 つまりユーザーが書いた `style="--charcoal-icon-ssr-size: ..."` は **hydrate 後には属性ベースの計算結果で上書きされる** 点に注意してください。永続的に上書きしたい場合は属性で指定します。
@@ -69,8 +70,12 @@ JS が読み込まれて web component が定義されると、`render()` が以
 <!-- ガイドライン通り 48px (24 × scale=2) -->
 <pixiv-icon name="24/Add" scale="2"></pixiv-icon>
 
-<!-- 12px に固定 (hydrate 後も 12px のまま) -->
-<pixiv-icon name="24/Add" unsafe-non-guideline-size="12"></pixiv-icon>
+<!-- 12px に固定 (hydrate 後も 12px のまま)。SSR の CLS を避けるため style も併記 -->
+<pixiv-icon
+  name="24/Add"
+  fixed-size="12"
+  style="--charcoal-icon-ssr-size: 12px"
+></pixiv-icon>
 ```
 
 ### `scale` 属性のプレフィックスごとの挙動
@@ -89,32 +94,56 @@ JS が読み込まれて web component が定義されると、`render()` が以
 
 ### ガイドライン外のサイズ指定
 
-ガイドライン外のサイズを使う場合は次のいずれかを使います。
+ガイドライン外のサイズを使う場合は **`fixed-size` (vanilla HTML) / `fixedSize` (React)** を使います。
+`fixed-size` は他のサイズ指定 (`scale` / `unsafe-non-guideline-scale`) よりも常に優先されます。
 
-- React: `<Icon>` の `unsafeNonGuidelineScale` / `unsafeNonGuidelineSize` props
-- vanilla HTML: `<pixiv-icon>` の `unsafe-non-guideline-scale` / `unsafe-non-guideline-size` 属性
+#### React (`<Icon fixedSize={N}>`)
 
 ```jsx
-<Icon name="24/Add" unsafeNonGuidelineScale={1.5} /> {/* 24 × 1.5 = 36px */}
-<Icon name="24/Add" unsafeNonGuidelineSize={40} />   {/* 直接 40px */}
+<Icon name="24/Add" fixedSize={12} />  {/* 12px 固定 */}
+<Icon name="24/Add" fixedSize={40} />  {/* 40px 固定 */}
 ```
 
+`<Icon>` は同じ値を `--charcoal-icon-ssr-size` インライン CSS 変数として自動付与するため、
+**hydrate 前後とも正しいサイズで CLS は起きません**。利用者側で追加の対応は不要です。
+
+#### vanilla HTML (`<pixiv-icon fixed-size="N">`)
+
+CSS の `attr()` 関数は数値や `<length>` 型としての解釈をまだ十分にサポートしていないため、
+**`fixed-size` 属性だけではブラウザは hydrate 前にサイズを決定できません**。
+SSR 段階から CLS を防ぐには **必ずインラインスタイルで `--charcoal-icon-ssr-size` も同じ値を指定してください**。
+
 ```html
-<pixiv-icon name="24/Add" unsafe-non-guideline-scale="1.5"></pixiv-icon>
-<pixiv-icon name="24/Add" unsafe-non-guideline-size="40"></pixiv-icon>
-```
-
-React `<Icon>` は SSR 段階で `calcActualSize` の結果を `--charcoal-icon-ssr-size` の inline style に出力するので、hydrate 前後ともに正しいサイズで CLS が起きません。
-
-vanilla HTML の場合、JS が読み込まれるまで `unsafe-non-guideline-*` 属性は CSS から参照できないため、hydrate 前は `pixiv-icon:not(:defined)` の `name` + `scale` ベースのガイドラインサイズが暫定的に表示されます。CLS を SSR 段階から完全に避けたい場合は、SSR 側で size を事前計算し inline style に直接書き出してください。
-
-```html
-<!-- name="24/Add" unsafe-non-guideline-size="12" と同等。hydrate 前から 12px で表示 -->
+<!-- ✅ OK: fixed-size と --charcoal-icon-ssr-size の両方を指定 -->
 <pixiv-icon
   name="24/Add"
-  unsafe-non-guideline-size="12"
-  style="--charcoal-icon-ssr-size: 12px"
+  fixed-size="12"
+  style="--charcoal-icon-ssr-size: 12px;"
 ></pixiv-icon>
+
+<!-- ❌ NG: fixed-size だけだと CSS-only 段階で name 由来の 24px が表示され、
+     JS upgrade 後に 12px へジャンプする (= CLS) -->
+<pixiv-icon name="24/Add" fixed-size="12"></pixiv-icon>
 ```
 
-`style` だけ書いて属性を省くと **hydrate 後に属性ベースのガイドラインサイズで上書きされる** 点に注意してください。
+`fixed-size` 属性は Web Component の upgrade 後に **必ず** 反映され、
+`--charcoal-icon-ssr-size` インラインスタイルは upgrade 前の CSS-only 状態でサイズを確定させる役割を果たします。
+両者の値が一致していれば、SSR から hydrate 完了までを通じて同じサイズで表示されます。
+
+サーバーサイドのテンプレートで両方を出し分けるユーティリティを用意するか、React の `<Icon fixedSize>` を経由するのが安全です。
+
+#### 非推奨: `unsafe-non-guideline-scale`
+
+過去には `unsafe-non-guideline-scale` 属性でガイドライン外の倍率を指定できましたが、
+これも `fixed-size` と同じ理由で CSS-only 段階ではサイズを決定できません。
+**新規利用は `fixed-size` への移行を推奨します**。
+
+既存利用箇所では、以下のように個別にインラインスタイルでサイズを確定させる必要があります。
+
+```html
+<pixiv-icon
+  name="24/Add"
+  unsafe-non-guideline-scale="0.5"
+  style="--charcoal-icon-ssr-size: 12px;"
+></pixiv-icon>
+```

--- a/packages/icons/src/SSR.mdx
+++ b/packages/icons/src/SSR.mdx
@@ -41,12 +41,26 @@ React を使わない場合でも、`name` 属性のプレフィックス（`16/
 
 ## サイズ決定ルール
 
-`pixiv-icon:not(:defined)` セレクターでは、サイズは以下の優先順位で決まります。
+サイズの決定タイミングは hydrate の前後で異なります。
+
+### hydrate 前 (`pixiv-icon:not(:defined)` の段階)
 
 1. **`style="--charcoal-icon-ssr-size: Npx"` が指定されていれば、その値を使う**（最優先）
 2. それ以外は `name` プレフィックスと `scale` 属性から導出されたガイドラインデフォルトを使う
 
-`<pixiv-icon>` が JS によって `:defined` 状態になった後は、 `unsafe-non-guideline-size` / `unsafe-non-guideline-scale` 属性も解釈され、計算結果が `--charcoal-icon-ssr-size` に反映されます。
+`unsafe-non-guideline-scale` / `unsafe-non-guideline-size` 属性は CSS の `attr()` での
+数値解釈に制約があるためこの段階では参照できず、暫定値が表示されます。
+
+### hydrate 後 (`:defined` 状態)
+
+JS が読み込まれて web component が定義されると、`render()` が以下の優先順で size を計算し、
+**結果を `--charcoal-icon-ssr-size` の inline style に上書きします**。
+
+1. `unsafe-non-guideline-size` 属性（最優先 / ピクセル値）
+2. `unsafe-non-guideline-scale` 属性 × `name` のベースサイズ
+3. `name` プレフィックスと `scale` 属性から導出されたガイドラインデフォルト
+
+つまりユーザーが書いた `style="--charcoal-icon-ssr-size: ..."` は **hydrate 後には属性ベースの計算結果で上書きされる** 点に注意してください。永続的に上書きしたい場合は属性で指定します。
 
 ```html
 <!-- ガイドライン通り 24px -->
@@ -55,8 +69,8 @@ React を使わない場合でも、`name` 属性のプレフィックス（`16/
 <!-- ガイドライン通り 48px (24 × scale=2) -->
 <pixiv-icon name="24/Add" scale="2"></pixiv-icon>
 
-<!-- name="24/Add" でも CSS 変数で上書きして 40px に -->
-<pixiv-icon name="24/Add" style="--charcoal-icon-ssr-size: 40px"></pixiv-icon>
+<!-- 12px に固定 (hydrate 後も 12px のまま) -->
+<pixiv-icon name="24/Add" unsafe-non-guideline-size="12"></pixiv-icon>
 ```
 
 ### `scale` 属性のプレフィックスごとの挙動
@@ -75,11 +89,10 @@ React を使わない場合でも、`name` 属性のプレフィックス（`16/
 
 ### ガイドライン外のサイズ指定
 
-ガイドライン外のサイズを使う場合は次のいずれかが使えます。
+ガイドライン外のサイズを使う場合は次のいずれかを使います。
 
 - React: `<Icon>` の `unsafeNonGuidelineScale` / `unsafeNonGuidelineSize` props
 - vanilla HTML: `<pixiv-icon>` の `unsafe-non-guideline-scale` / `unsafe-non-guideline-size` 属性
-- どちらも使えない場合: `--charcoal-icon-ssr-size` CSS 変数を直接設定
 
 ```jsx
 <Icon name="24/Add" unsafeNonGuidelineScale={1.5} /> {/* 24 × 1.5 = 36px */}
@@ -87,12 +100,21 @@ React を使わない場合でも、`name` 属性のプレフィックス（`16/
 ```
 
 ```html
-<!-- 属性で指定: hydrate 後に web component が --charcoal-icon-ssr-size を更新する -->
 <pixiv-icon name="24/Add" unsafe-non-guideline-scale="1.5"></pixiv-icon>
 <pixiv-icon name="24/Add" unsafe-non-guideline-size="40"></pixiv-icon>
-
-<!-- SSR 段階から CLS を完全に防ぎたい場合は CSS 変数を直接セット -->
-<pixiv-icon name="24/Add" style="--charcoal-icon-ssr-size: 12px"></pixiv-icon>
 ```
 
-属性指定では、JS が読み込まれるまでは `pixiv-icon:not(:defined)` ルールの `name` + `scale` ベースのサイズが暫定的に使われ、`:defined` になった瞬間に正しいサイズに切り替わります。SSR 段階で正確なサイズを確保したい場合は `--charcoal-icon-ssr-size` CSS 変数を直接セットしてください。
+React `<Icon>` は SSR 段階で `calcActualSize` の結果を `--charcoal-icon-ssr-size` の inline style に出力するので、hydrate 前後ともに正しいサイズで CLS が起きません。
+
+vanilla HTML の場合、JS が読み込まれるまで `unsafe-non-guideline-*` 属性は CSS から参照できないため、hydrate 前は `pixiv-icon:not(:defined)` の `name` + `scale` ベースのガイドラインサイズが暫定的に表示されます。CLS を SSR 段階から完全に避けたい場合は、SSR 側で size を事前計算し inline style に直接書き出してください。
+
+```html
+<!-- name="24/Add" unsafe-non-guideline-size="12" と同等。hydrate 前から 12px で表示 -->
+<pixiv-icon
+  name="24/Add"
+  unsafe-non-guideline-size="12"
+  style="--charcoal-icon-ssr-size: 12px"
+></pixiv-icon>
+```
+
+`style` だけ書いて属性を省くと **hydrate 後に属性ベースのガイドラインサイズで上書きされる** 点に注意してください。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   .:
     devDependencies:
+      '@charcoal-ui/icons':
+        specifier: workspace:^
+        version: link:packages/icons
       '@charcoal-ui/icons-cli':
         specifier: workspace:^
         version: link:packages/icons-cli


### PR DESCRIPTION
## やったこと

元の `fix/icon-layout-shift` ブランチを 3 PR に分割した内の **3/3 (docs 拡張)**。

- `packages/icons/src/SSR.mdx` を `--charcoal-icon-ssr-size` CSS 変数 + 属性アプローチに合わせて書き換え、CLS 対策を解説
  - hydrate 前後でのサイズ決定ルールを整理
  - ガイドライン外サイズ指定セクションを **`fixed-size` (vanilla HTML) / `fixedSize` (React)** ベースに更新
  - vanilla HTML 利用時は `style="--charcoal-icon-ssr-size: Npx"` を併記しないと SSR 段階で CLS が発生する旨を ✅/❌ サンプル付きで明記
  - 非推奨となった `unsafe-non-guideline-scale` の利用パターンも併記
- `packages/icons/src/README.mdx` に `icon.css` の自動 import 動作を追記
- `.storybook/preview.ts` で `@charcoal-ui/icons/css/icon.css` を import し、vanilla HTML stories でも layout shift を防ぐ
- ルート `package.json` に `@charcoal-ui/icons` を devDependency として宣言 (storybook preview から参照するため)
- `packages/icons/src/PixivIcon.story.tsx` に `WithFixedSize` ストーリーを追加し、既存 `WithUnsafe` を `WithUnsafeNonGuidelineScale` (deprecated 例) にリネーム
- `.storybook/__snapshots__/storybook.test.ts.snap` を `fixedSize` ベース MultiSelect に合わせて更新

## 動作確認環境

- macOS, Node.js (リポジトリ既定バージョン)
- Storybook ローカル起動して SSR Guide / README docs が崩れていないことを目視確認
- `<pixiv-icon>` 系の story を開いて未 hydrate 時にもサイズが確定し CLS が起きないことを確認
- chrome-devtools で `<pixiv-icon fixed-size>` を SSR / pre-JS / post-JS の各段階で計測し、vanilla HTML 単独だと CLS が発生し、inline style を併記すれば防げることを確認

## チェックリスト

不要なチェック項目は消して構いません

- [ ] README やドキュメントに影響があることを確認した

## Stack

- base: #929 (\`fix/icon-cls\`)

#929 を merge 後、main を base に切り替えます。