### PR TITLE
fix: stop using pull_request_target for dependabot helper

### DIFF
--- a/.github/workflows/dependabot-helper.yml
+++ b/.github/workflows/dependabot-helper.yml
@@ -1,7 +1,7 @@
 name: Dependabot Helper
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/dependabot-helper.yml
+++ b/.github/workflows/dependabot-helper.yml
@@ -6,11 +6,12 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
   metadata:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'pixiv/charcoal'
     runs-on: ubuntu-latest
     outputs:
       dependency-names: ${{ steps.metadata.outputs.dependency-names }}
@@ -20,7 +21,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## やったこと

- `pull_request_target` の使用をやめ、 `pull_reqeust` に修正しました

## 動作確認環境
GitHub Actions

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
