### PR TITLE
feat: upgrade react aria

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,11 +35,8 @@ updates:
           - 'patch'
       react-ecosystem:
         patterns:
-          - '@react-aria/*'
-          - '@react-stately/*'
-          - '@react-types/*'
+          - 'react-aria'
           - 'react-stately'
-          - '@react-spring/*'
         update-types:
           - 'minor'
           - 'patch'

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -4512,7 +4512,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ful
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4527,7 +4528,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ful
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4542,7 +4544,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ful
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4576,7 +4579,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Obj
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4591,7 +4595,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Obj
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4606,7 +4611,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Obj
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4621,8 +4627,9 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Obj
       >
         <input
           class="charcoal-segmented-control-radio__input"
+          data-react-aria-pressable="true"
           disabled=""
-          name="test-id"
+          name="test"
           type="radio"
           value="option4"
         />
@@ -4655,7 +4662,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ran
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4670,7 +4678,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ran
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4685,7 +4694,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Ran
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4719,7 +4729,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Str
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4734,7 +4745,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Str
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4749,7 +4761,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Str
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4783,7 +4796,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4798,7 +4812,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4813,7 +4828,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4847,7 +4863,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4862,7 +4879,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4877,7 +4895,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"
@@ -4911,7 +4930,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option1"
@@ -4926,7 +4946,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option2"
@@ -4941,7 +4962,8 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
       >
         <input
           class="charcoal-segmented-control-radio__input"
-          name="test-id"
+          data-react-aria-pressable="true"
+          name="test"
           tabindex="0"
           type="radio"
           value="option3"

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -124,7 +124,10 @@ const viteConfig: ViteStorybookConfig = {
       'styled-components',
     ]
     config.plugins ??= []
-
+    config.define = {
+      ...config.define,
+      'process.env.TEST': process.env.TEST,
+    }
     config.plugins.unshift({
       name: 'fix-storybook-mdx-react-shim-file-url',
       enforce: 'pre',

--- a/.storybook/src/v6.0.0.mdx
+++ b/.storybook/src/v6.0.0.mdx
@@ -99,7 +99,3 @@ npx @react-spectrum/codemods use-monopackages --path /path/to/src
 # サブパス import（より細かいバンドル制御）
 npx @react-spectrum/codemods use-subpaths --path /path/to/src
 ```
-
-## UnstableTextEllipsis / UnstablePagination の追加
-
-`@charcoal-ui/react@v5.5.0` で、react-sandbox の TextEllipsis / Pager・LinkPager を styled-components 非依存で取り込みました。props 詳細は各 Storybook を参照してください。

--- a/.storybook/src/v6.0.0.mdx
+++ b/.storybook/src/v6.0.0.mdx
@@ -79,3 +79,27 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 - Unstable のため、マイナーバージョン内でも props や export 名が変わる可能性があります。
 - 安定化後は `Unstable` プレフィックスを外し、通常のコンポーネント名で提供する予定です。
+
+---
+
+## React Aria モノパッケージへの移行
+
+React Aria v1.17.0 ([リリースノート](https://react-aria.adobe.com/releases/v1-17-0)) に合わせ、`@charcoal-ui/react` の React Aria 依存を個別パッケージ（`@react-aria/*`, `@react-stately/*`）からモノパッケージ（`react-aria`, `react-stately`）に移行しました。
+
+- `react-aria` / `react-stately` は **dependencies から peerDependencies に変更**されました（`react-aria >= 3.48.0`, `react-stately >= 3.46.0`）。npm 7+・pnpm・yarn では自動インストールされるため通常は追加対応不要です。
+- 目的：アプリ側でも React Aria を使う場合の重複インストールを防ぎ、バンドルサイズとランタイムの不整合を解消します。
+- 既存の `@react-aria/*` 個別パッケージとも共存可能ですが、バージョン不整合に注意してください。
+
+### 必要な対応（任意）
+
+`@react-aria/*` / `@react-stately/*` を直接 import している場合、React Aria 公式 codemod でモノパッケージ import に移行できます。
+
+```bash
+npx @react-spectrum/codemods use-monopackages --path /path/to/src
+# サブパス import（より細かいバンドル制御）
+npx @react-spectrum/codemods use-subpaths --path /path/to/src
+```
+
+## UnstableTextEllipsis / UnstablePagination の追加
+
+`@charcoal-ui/react@v5.5.0` で、react-sandbox の TextEllipsis / Pager・LinkPager を styled-components 非依存で取り込みました。props 詳細は各 Storybook を参照してください。

--- a/misc/dependency-compat/check-compat.mjs
+++ b/misc/dependency-compat/check-compat.mjs
@@ -23,8 +23,7 @@ const isCI = process.argv.includes('--ci')
 const KEY_DEPS = [
   'react',
   'react-dom',
-  '@react-aria/overlays',
-  '@react-aria/utils',
+  'react-aria',
   'react-stately',
   'storybook',
   'tailwindcss',

--- a/misc/test/vitest.snapshot-serializer.ts
+++ b/misc/test/vitest.snapshot-serializer.ts
@@ -1,0 +1,103 @@
+const processed = new WeakSet<object>()
+
+const REACT_ARIA_ID_PATTERN = /react-aria-:[^"'`\s<>]+/gu
+
+function isElement(value: unknown): value is HTMLElement {
+  return typeof HTMLElement !== 'undefined' && value instanceof HTMLElement
+}
+
+function isTestingLibraryContainer(value: unknown): value is HTMLElement {
+  return (
+    isElement(value) &&
+    !processed.has(value) &&
+    value.parentElement === document.body &&
+    value.tagName === 'DIV' &&
+    (value.innerHTML.includes('react-aria-:') || hasModalPortal(value))
+  )
+}
+
+function hasModalPortal(source: HTMLElement) {
+  return Array.from(document.body.children).some((child) => {
+    return (
+      child !== source &&
+      !source.contains(child) &&
+      child.classList.contains('charcoal-modal-background')
+    )
+  })
+}
+
+function normalizeReactAriaIds(root: HTMLElement) {
+  const elements = [root, ...Array.from(root.querySelectorAll('*'))]
+
+  for (const element of elements) {
+    for (const attr of Array.from(element.attributes)) {
+      if (REACT_ARIA_ID_PATTERN.test(attr.value)) {
+        element.setAttribute(
+          attr.name,
+          attr.value.replace(REACT_ARIA_ID_PATTERN, 'test-id'),
+        )
+      }
+      REACT_ARIA_ID_PATTERN.lastIndex = 0
+    }
+  }
+}
+
+function appendPortalContent(source: HTMLElement, target: HTMLElement) {
+  const portalNodes = Array.from(document.body.children).filter((child) => {
+    return (
+      child !== source &&
+      !source.contains(child) &&
+      child.classList.contains('charcoal-modal-background')
+    )
+  })
+
+  if (portalNodes.length === 0) {
+    return
+  }
+
+  const overlayContainer =
+    target.querySelector('[data-overlay-container="true"]') ?? target
+
+  target.removeAttribute('aria-hidden')
+
+  for (const child of Array.from(overlayContainer.children)) {
+    if (child.classList.contains('charcoal-modal-background')) {
+      break
+    }
+    child.setAttribute('aria-hidden', 'true')
+  }
+
+  for (const portalNode of portalNodes) {
+    overlayContainer.appendChild(portalNode.cloneNode(true))
+  }
+}
+
+export default {
+  test: isTestingLibraryContainer,
+  serialize(
+    value: HTMLElement,
+    config: unknown,
+    indentation: string,
+    depth: number,
+    refs: unknown[],
+    printer: (
+      value: unknown,
+      config: unknown,
+      indentation: string,
+      depth: number,
+      refs: unknown[],
+    ) => string,
+  ) {
+    const clone = value.cloneNode(true) as HTMLElement
+
+    processed.add(clone)
+    appendPortalContent(value, clone)
+    normalizeReactAriaIds(clone)
+
+    try {
+      return printer(clone, config, indentation, depth, refs)
+    } finally {
+      processed.delete(clone)
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "@originjs/vite-plugin-commonjs": "^1.0.3",
     "@pixiv/eslint-config": "^1.1.0",
     "@playwright/test": "^1.58.2",
-    "@react-aria/overlays": "^3.20.0",
-    "@react-aria/utils": "^3.23.0",
     "@rollup/plugin-babel": "6.1.0",
     "@storybook/addon-a11y": "10.3.5",
     "@storybook/addon-docs": "10.3.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,12 +29,9 @@
     "test:browser": "vitest run --config vitest.browser.config.ts"
   },
   "devDependencies": {
-    "@react-types/dialog": "^3.5.15",
-    "@react-types/switch": "^3.1.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^13.5.0",
-    "@types/glob": "^8.1.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/warning": "^3.0.4",
@@ -45,32 +42,24 @@
     "playwright": "^1.58.2",
     "postcss-nested": "^7.0.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-aria": "catalog:",
+    "react-stately": "catalog:"
   },
   "dependencies": {
     "@charcoal-ui/foundation": "workspace:*",
     "@charcoal-ui/icons": "workspace:*",
     "@charcoal-ui/theme": "workspace:*",
     "@charcoal-ui/utils": "workspace:*",
-    "@react-aria/button": "^3.9.1",
-    "@react-aria/checkbox": "^3.13.0",
-    "@react-aria/dialog": "^3.5.10",
-    "@react-aria/focus": "^3.16.0",
-    "@react-aria/overlays": "^3.20.0",
-    "@react-aria/radio": "^3.10.0",
-    "@react-aria/ssr": "^3.9.1",
-    "@react-aria/switch": "^3.6.0",
-    "@react-aria/utils": "^3.23.0",
-    "@react-aria/visually-hidden": "^3.8.8",
     "@react-spring/web": "catalog:",
-    "@react-stately/radio": "^3.10.2",
     "polished": "^4.1.4",
     "react-compiler-runtime": "catalog:",
-    "react-stately": "^3.26.0",
     "warning": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">=17.0.0"
+    "react": ">=17.0.0",
+    "react-aria": ">=3.48.0",
+    "react-stately": ">=3.46.0"
   },
   "files": [
     "src",

--- a/packages/react/src/components/Checkbox/index.tsx
+++ b/packages/react/src/components/Checkbox/index.tsx
@@ -1,9 +1,9 @@
 import './index.css'
 
 import { forwardRef, memo } from 'react'
-import { useId } from '@react-aria/utils'
 import CheckboxInput, { CheckboxInputProps } from './CheckboxInput'
 import { CheckboxWithLabel } from './CheckboxWithLabel'
+import { useId } from 'react-aria/useId'
 
 export type CheckboxProps = CheckboxInputProps
 

--- a/packages/react/src/components/DropdownSelector/Popover/index.tsx
+++ b/packages/react/src/components/DropdownSelector/Popover/index.tsx
@@ -1,9 +1,10 @@
 import './index.css'
 
 import { RefObject, useContext, useRef, ReactNode } from 'react'
-import { DismissButton, Overlay, usePopover } from '@react-aria/overlays'
 import { ModalBackgroundContext } from '../../Modal/ModalBackgroundContext'
 import { usePreventScroll } from './usePreventScroll'
+import { DismissButton, Overlay } from 'react-aria/Overlay'
+import { usePopover } from 'react-aria/usePopover'
 
 export type PopoverProps = {
   isOpen: boolean

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -7,11 +7,12 @@ import { DropdownPopover } from './DropdownPopover'
 import { findPreviewRecursive } from './utils/findPreviewRecursive'
 import MenuList, { MenuListChildren } from './MenuList'
 import { getValuesRecursive } from './MenuList/internals/getValuesRecursive'
-import { useVisuallyHidden } from '@react-aria/visually-hidden'
 import { AssistiveText } from '../TextField/AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
-import { useId } from '@react-aria/utils'
 import { PopoverProps } from './Popover'
+
+import { useVisuallyHidden } from 'react-aria/VisuallyHidden'
+import { useId } from 'react-aria/useId'
 
 export type DropdownSelectorProps = {
   label: string

--- a/packages/react/src/components/Modal/Dialog/index.tsx
+++ b/packages/react/src/components/Modal/Dialog/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react'
 import * as React from 'react'
-import { useDialog } from '@react-aria/dialog'
+import { useDialog } from 'react-aria/useDialog'
 import { useForwardedRef } from '../../../_lib/useForwardedRef'
 import { Size, BottomSheet } from '..'
 

--- a/packages/react/src/components/Modal/index.story.tsx
+++ b/packages/react/src/components/Modal/index.story.tsx
@@ -1,6 +1,5 @@
 import Modal, { ModalDismissButton, ModalProps } from '.'
-import { OverlayProvider } from '@react-aria/overlays'
-import { useOverlayTriggerState } from 'react-stately'
+import { useOverlayTriggerState } from 'react-stately/useOverlayTriggerState'
 import Button from '../Button'
 import {
   ModalAlign,
@@ -13,6 +12,9 @@ import DropdownSelector from '../DropdownSelector'
 import Checkbox from '../Checkbox'
 import DropdownMenuItem from '../DropdownSelector/DropdownMenuItem'
 import { Meta, StoryObj } from '@storybook/react-vite'
+import { OverlayProvider } from 'react-aria'
+
+const defaultOpen = !!process.env.TEST
 
 export default {
   title: 'react/Modal',
@@ -38,7 +40,7 @@ export default {
     },
   },
   render: function Render(args) {
-    const state = useOverlayTriggerState({})
+    const state = useOverlayTriggerState({ defaultOpen })
     return (
       // Application must be wrapped in an OverlayProvider so that it can be
       // hidden from screen readers when a modal opens.
@@ -138,13 +140,12 @@ export const FullBottomSheet: StoryObj<typeof Modal> = {
     bottomSheet: 'full',
   },
   render: function Render(args) {
-    const state = useOverlayTriggerState({})
+    const state = useOverlayTriggerState({ defaultOpen })
     return (
       // Application must be wrapped in an OverlayProvider so that it can be
       // hidden from screen readers when a modal opens.
       <OverlayProvider>
         <Button onClick={() => state.open()}>Open Modal</Button>
-
         <Modal
           {...args}
           isDismissable
@@ -184,13 +185,12 @@ export const FullBottomSheet: StoryObj<typeof Modal> = {
 
 export const BottomSheet: StoryObj<typeof Modal> = {
   render: function Render(args) {
-    const state = useOverlayTriggerState({})
+    const state = useOverlayTriggerState({ defaultOpen })
     return (
       // Application must be wrapped in an OverlayProvider so that it can be
       // hidden from screen readers when a modal opens.
       <OverlayProvider>
         <Button onClick={() => state.open()}>Open Modal</Button>
-
         <Modal
           {...args}
           isOpen={state.isOpen}
@@ -224,7 +224,7 @@ export const BottomSheet: StoryObj<typeof Modal> = {
 
 export const NotDismmissableStory: StoryObj<typeof Modal> = {
   render: function Render(args) {
-    const state = useOverlayTriggerState({})
+    const state = useOverlayTriggerState({ defaultOpen })
     return (
       <OverlayProvider>
         <Button onClick={() => state.open()}>Open Modal</Button>
@@ -254,7 +254,7 @@ export const NotDismmissableStory: StoryObj<typeof Modal> = {
 
 export const BackgroundScroll: StoryObj<typeof Modal> = {
   render: function Render(args) {
-    const state = useOverlayTriggerState({})
+    const state = useOverlayTriggerState({ defaultOpen })
     return (
       <OverlayProvider>
         <div

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -1,11 +1,9 @@
 import { useContext, forwardRef, memo } from 'react'
 import * as React from 'react'
-import { Overlay } from '@react-aria/overlays'
-import type { AriaDialogProps } from '@react-types/dialog'
+import type { AriaDialogProps } from 'react-aria/useDialog'
 import { animated, useTransition, easings } from '@react-spring/web'
 import Button, { ButtonProps } from '../Button'
 import IconButton, { IconButtonProps } from '../IconButton'
-import { useObjectRef } from '@react-aria/utils'
 import { Dialog } from './Dialog'
 import { ModalBackgroundContext } from './ModalBackgroundContext'
 import {
@@ -15,6 +13,9 @@ import {
 } from './useCustomModalOverlay'
 
 import './index.css'
+
+import { Overlay } from 'react-aria/Overlay'
+import { useObjectRef } from 'react-aria/useObjectRef'
 
 export type BottomSheet = boolean | 'full'
 export type Size = 'S' | 'M' | 'L'

--- a/packages/react/src/components/Modal/useCustomModalOverlay.tsx
+++ b/packages/react/src/components/Modal/useCustomModalOverlay.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
+import { ariaHideOutside } from 'react-aria/private/overlays/ariaHideOutside'
+import { useOverlayFocusContain } from 'react-aria/private/overlays/Overlay'
+import { usePreventScroll } from '../DropdownSelector/Popover/usePreventScroll'
+
 import {
   AriaModalOverlayProps,
   ModalOverlayAria,
-  ariaHideOutside,
-  useOverlay,
-  useOverlayFocusContain,
-} from '@react-aria/overlays'
-import { usePreventScroll } from '../DropdownSelector/Popover/usePreventScroll'
+} from 'react-aria/useModalOverlay'
+import { useOverlay } from 'react-aria/useOverlay'
 
 /**
  * We want to enable scrolling on the modal background,

--- a/packages/react/src/components/SegmentedControl/RadioGroupContext.tsx
+++ b/packages/react/src/components/SegmentedControl/RadioGroupContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 import * as React from 'react'
-import type { RadioGroupState } from '@react-stately/radio'
+import { RadioGroupState } from 'react-stately/useRadioGroupState'
 
 const RadioContext = createContext<RadioGroupState | null>(null)
 

--- a/packages/react/src/components/SegmentedControl/index.tsx
+++ b/packages/react/src/components/SegmentedControl/index.tsx
@@ -1,16 +1,16 @@
 import { ReactNode, forwardRef, memo, useMemo, useRef } from 'react'
 import * as React from 'react'
-import { useRadioGroupState } from '@react-stately/radio'
+import { RadioProvider, useRadioContext } from './RadioGroupContext'
+import { useClassNames } from '../../_lib/useClassNames'
+import './index.css'
 import {
   AriaRadioGroupProps,
   AriaRadioProps,
   useRadio,
   useRadioGroup,
-} from '@react-aria/radio'
-import { RadioProvider, useRadioContext } from './RadioGroupContext'
-import { useClassNames } from '../../_lib/useClassNames'
+} from 'react-aria/useRadioGroup'
 
-import './index.css'
+import { useRadioGroupState } from 'react-stately/useRadioGroupState'
 
 type SegmentedControlItem = {
   label: React.ReactNode

--- a/packages/react/src/components/Switch/index.tsx
+++ b/packages/react/src/components/Switch/index.tsx
@@ -1,9 +1,9 @@
 import './index.css'
 
 import { memo, forwardRef } from 'react'
-import { useId } from '@react-aria/utils'
 import SwitchInput, { type SwitchInputProps } from './SwitchInput'
 import { SwitchWithLabel } from './SwitchWithLabel'
+import { useId } from 'react-aria/useId'
 
 export type SwitchProps = SwitchInputProps
 

--- a/packages/react/src/components/TagItem/index.tsx
+++ b/packages/react/src/components/TagItem/index.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, memo, useMemo, ForwardedRef, type JSX } from 'react'
-import { useObjectRef } from '@react-aria/utils'
 import Icon from '../Icon'
 import { useClassNames } from '../../_lib/useClassNames'
-
 import './index.css'
+
+import { useObjectRef } from 'react-aria/useObjectRef'
 
 type SizeMap = {
   S: 32

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -1,21 +1,13 @@
 import './index.css'
 
-import { useVisuallyHidden } from '@react-aria/visually-hidden'
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
 import FieldLabel from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { useFocusWithClick } from '../TextField/useFocusWithClick'
-import { useId } from '@react-aria/utils'
 import { AssistiveText } from '../TextField/AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
+import { useVisuallyHidden } from 'react-aria/VisuallyHidden'
+import { useId } from 'react-aria/useId'
 
 /**
  * `TextArea` を `imperativeRef` から操作するためのハンドル

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import FieldLabel from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { useFocusWithClick } from '../TextField/useFocusWithClick'

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -1,6 +1,14 @@
 import './index.css'
 
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import FieldLabel from '../FieldLabel'
 import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { useFocusWithClick } from '../TextField/useFocusWithClick'

--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -1,14 +1,14 @@
 import './index.css'
 
-import { useVisuallyHidden } from '@react-aria/visually-hidden'
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import * as React from 'react'
 import FieldLabel from '../FieldLabel'
-import { countCodePointsInString } from '../../_lib'
+import { countCodePointsInString, mergeRefs } from '../../_lib'
 import { useFocusWithClick } from './useFocusWithClick'
-import { mergeRefs, useId } from '@react-aria/utils'
 import { AssistiveText } from './AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
+import { useVisuallyHidden } from 'react-aria/VisuallyHidden'
+import { useId } from 'react-aria/useId'
 
 export type TextFieldProps = {
   prefix?: ReactNode

--- a/packages/react/src/core/OverlayProvider.tsx
+++ b/packages/react/src/core/OverlayProvider.tsx
@@ -1,1 +1,1 @@
-export { OverlayProvider } from '@react-aria/overlays'
+export { OverlayProvider } from 'react-aria/private/overlays/useModal'

--- a/packages/react/src/core/SSRProvider.tsx
+++ b/packages/react/src/core/SSRProvider.tsx
@@ -1,5 +1,5 @@
-import { SSRProvider as OriginSSRProvider } from '@react-aria/ssr'
 import { version, Fragment } from 'react'
+import { SSRProvider as OriginSSRProvider } from 'react-aria/SSRProvider'
 
 export function isReactVersionOver(minVersion: number): boolean {
   // version history on the react side: https://github.com/facebook/react/commits/main/packages/shared/ReactVersion.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,15 @@ catalogs:
     '@react-spring/web':
       specifier: ^10
       version: 10.0.3
+    react-aria:
+      specifier: 3.48.0
+      version: 3.48.0
     react-compiler-runtime:
       specifier: 1.0.0
       version: 1.0.0
+    react-stately:
+      specifier: 3.46.0
+      version: 3.46.0
 
 overrides:
   playwright: ^1.58.2
@@ -56,12 +62,6 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.59.1
-      '@react-aria/overlays':
-        specifier: ^3.20.0
-        version: 3.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils':
-        specifier: ^3.23.0
-        version: 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rollup/plugin-babel':
         specifier: 6.1.0
         version: 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.37.0)
@@ -398,61 +398,19 @@ importers:
       '@charcoal-ui/utils':
         specifier: workspace:*
         version: link:../utils
-      '@react-aria/button':
-        specifier: ^3.9.1
-        version: 3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/checkbox':
-        specifier: ^3.13.0
-        version: 3.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/dialog':
-        specifier: ^3.5.10
-        version: 3.5.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/focus':
-        specifier: ^3.16.0
-        version: 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays':
-        specifier: ^3.20.0
-        version: 3.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/radio':
-        specifier: ^3.10.0
-        version: 3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/ssr':
-        specifier: ^3.9.1
-        version: 3.9.7(react@18.3.1)
-      '@react-aria/switch':
-        specifier: ^3.6.0
-        version: 3.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils':
-        specifier: ^3.23.0
-        version: 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden':
-        specifier: ^3.8.8
-        version: 3.8.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spring/web':
         specifier: 'catalog:'
         version: 10.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/radio':
-        specifier: ^3.10.2
-        version: 3.10.11(react@18.3.1)
       polished:
         specifier: ^4.1.4
         version: 4.3.1
       react-compiler-runtime:
         specifier: 'catalog:'
         version: 1.0.0(react@18.3.1)
-      react-stately:
-        specifier: ^3.26.0
-        version: 3.36.1(react@18.3.1)
       warning:
         specifier: ^4.0.3
         version: 4.0.3
     devDependencies:
-      '@react-types/dialog':
-        specifier: ^3.5.15
-        version: 3.5.16(react@18.3.1)
-      '@react-types/switch':
-        specifier: ^3.1.2
-        version: 3.5.9(react@18.3.1)
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -462,9 +420,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^13.5.0
         version: 13.5.0(@testing-library/dom@10.4.0)
-      '@types/glob':
-        specifier: ^8.1.0
-        version: 8.1.0
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.20
@@ -495,9 +450,15 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-aria:
+        specifier: 'catalog:'
+        version: 3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-stately:
+        specifier: 'catalog:'
+        version: 3.46.0(react@18.3.1)
 
   packages/react-sandbox:
     dependencies:
@@ -1546,21 +1507,6 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
-  '@formatjs/ecma402-abstract@2.3.4':
-    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
-
-  '@formatjs/fast-memoize@2.2.7':
-    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
-
-  '@formatjs/icu-messageformat-parser@2.11.2':
-    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
-
-  '@formatjs/icu-skeleton-parser@1.8.14':
-    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
-
-  '@formatjs/intl-localematcher@0.6.1':
-    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
-
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
@@ -1642,17 +1588,14 @@ packages:
       '@types/node':
         optional: true
 
-  '@internationalized/date@3.7.0':
-    resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
 
-  '@internationalized/message@3.1.6':
-    resolution: {integrity: sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==}
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
 
-  '@internationalized/number@3.6.0':
-    resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
-
-  '@internationalized/string@3.2.5':
-    resolution: {integrity: sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==}
+  '@internationalized/string@3.2.8':
+    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2119,102 +2062,6 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@react-aria/button@3.12.1':
-    resolution: {integrity: sha512-IgCENCVUzjfI4nVgJ8T1z2oD81v3IO2Ku96jVljqZ/PWnFACsRikfLeo8xAob3F0LkRW4CTK4Tjy6BRDsy2l6A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/checkbox@3.15.3':
-    resolution: {integrity: sha512-/m5JYoGsi5L0NZnacgqEcMqBo6CcTmsJ9nAY/07MDCUJBcL/Xokd8cL/1K21n6K69MiCPcxORbSBdxJDm9dR0A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/dialog@3.5.23':
-    resolution: {integrity: sha512-ud8b4G5vcFEZPEjzdXrjOadwRMBKBDLiok6lIl1rsPkd1qnLMFxsl3787kct1Ex0PVVKOPlcH7feFw+1T7NsLw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/focus@3.20.1':
-    resolution: {integrity: sha512-lgYs+sQ1TtBrAXnAdRBQrBo0/7o5H6IrfDxec1j+VRpcXL0xyk0xPq+m3lZp8typzIghqDgpnKkJ5Jf4OrzPIw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/form@3.0.14':
-    resolution: {integrity: sha512-UYoqdGetKV+4lwGnJ22sWKywobOWYBcOetiBYTlrrnCI6e5j1Jk5iLkLvesCOoI7yfWIW9Ban5Qpze5MUrXUhQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/i18n@3.12.7':
-    resolution: {integrity: sha512-eLbYO2xrpeOKIEmLv2KD5LFcB0wltFqS+pUjsOzkKZg6H3b6AFDmJPxr/a0x2KGHtpGJvuHwCSbpPi9PzSSQLg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/interactions@3.24.1':
-    resolution: {integrity: sha512-OWEcIC6UQfWq4Td5Ptuh4PZQ4LHLJr/JL2jGYvuNL6EgL3bWvzPrRYIF/R64YbfVxIC7FeZpPSkS07sZ93/NoA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/label@3.7.16':
-    resolution: {integrity: sha512-tPog3rc5pQ9s2/5bIBtmHtbj+Ebqs2yyJgJdFjZ1/HxrjF8HMrgtBPHCn/70YD5XvmuC3OSkua84kLjNX5rBbA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/overlays@3.26.1':
-    resolution: {integrity: sha512-AtQ0mp+H0alFFkojKBADEUIc1AKFsSobH4QNoxQa3V4bZKQoXxga7cRhD5RRYanu3XCQOkIxZJ3vdVK/LVVBXA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/radio@3.11.1':
-    resolution: {integrity: sha512-plAO5MW+QD9/kMe5NNKBzKf/+b6CywdoZ5a1T/VbvkBQYYcHaYQeBuKQ4l+hF+OY2tKAWP0rrjv7tEtacPc9TA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/ssr@3.9.7':
-    resolution: {integrity: sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==}
-    engines: {node: '>= 12'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/switch@3.7.1':
-    resolution: {integrity: sha512-CE7G9pPeltbE5wEVIPlrbjarYoMNS8gsb3+RD4Be/ghKSpwppmQyn12WIs6oQl3YQSBD/GZhfA6OTyOBo0Ro9A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/toggle@3.11.1':
-    resolution: {integrity: sha512-9SBvSFpGcLODN1u64tQ8aL6uLFnuuJRA2N0Kjmxp5PE1gk8IKG+BXsjZmq7auDAN5WPISBXw1RzEOmbghruBTQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/toolbar@3.0.0-beta.14':
-    resolution: {integrity: sha512-F9wFYhcbVUveo6+JfAjKyz19BnBaXBYG7YyZdGurhn5E1bD+Zrwz/ZCTrrx40xJsbofciCiiwnKiXmzB20Kl5Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/utils@3.28.1':
-    resolution: {integrity: sha512-mnHFF4YOVu9BRFQ1SZSKfPhg3z+lBRYoW5mLcYTQihbKhz48+I1sqRkP7ahMITr8ANH3nb34YaMME4XWmK2Mgg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/visually-hidden@3.8.21':
-    resolution: {integrity: sha512-iii5qO+cVHrHiOeiBYCnTRUQG2eOgEPFmiMG4dAuby8+pJJ8U4BvffX2sDTYWL6ztLLBYyrsUHPSw1Ld03JhmA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@react-spring/animated@10.0.3':
     resolution: {integrity: sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ==}
     peerDependencies:
@@ -2380,11 +2227,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/button@3.11.0':
-    resolution: {integrity: sha512-gJh5i0JiBiZGZGDo+tXMp6xbixPM7IKZ0sDuxTYBG49qNzzWJq0uNYltO3emwSVXFSsBgRV/Wu8kQGhfuN7wIw==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@react-types/calendar@3.6.1':
     resolution: {integrity: sha512-EMbFJX/3gD5j+R0qZEGqK+wlhBxMSHhGP8GqP9XGbpuJPE3w9/M/PVWdh8FUdzf9srYxPOq5NgiGI1JUJvdZqw==}
     peerDependencies:
@@ -2407,11 +2249,6 @@ packages:
 
   '@react-types/datepicker@3.11.0':
     resolution: {integrity: sha512-GAYgPzqKvd1lR2sLYYMlUkNg2+QoM2uVUmpeQLP1SbYpDr1y8lG5cR54em1G4X/qY4+nCWGiwhRC2veP0D0kfA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/dialog@3.5.16':
-    resolution: {integrity: sha512-2D16XjuW9fG3LkVIXu3RzUp3zcK2IZOWlAl+r5i0aLw2Q0QHyYMfGbmgvhxVeAhxhEj/57/ziSl/8rJ9pzmFnw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -2455,13 +2292,13 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/slider@3.7.9':
-    resolution: {integrity: sha512-MxCIVkrBSbN3AxIYW4hOpTcwPmIuY4841HF36sDLFWR3wx06z70IY3GFwV7Cbp814vhc84d4ABnPMwtE+AZRGQ==}
+  '@react-types/shared@3.34.0':
+    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/switch@3.5.9':
-    resolution: {integrity: sha512-7XIS5qycIKhdfcWfzl8n458/7tkZKCNfMfZmIREgozKOtTBirjmtRRsefom2hlFT8VIlG7COmY4btK3oEuEhnQ==}
+  '@react-types/slider@3.7.9':
+    resolution: {integrity: sha512-MxCIVkrBSbN3AxIYW4hOpTcwPmIuY4841HF36sDLFWR3wx06z70IY3GFwV7Cbp814vhc84d4ABnPMwtE+AZRGQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -3472,9 +3309,6 @@ packages:
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
-  '@types/glob@8.1.0':
-    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
-
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -3546,9 +3380,6 @@ packages:
 
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
-
-  '@types/minimatch@5.1.2':
-    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -4218,6 +4049,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -6482,9 +6317,6 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  intl-messageformat@10.7.16:
-    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
-
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
@@ -8567,6 +8399,12 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  react-aria@3.48.0:
+    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   react-colorful@5.6.1:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
@@ -8633,6 +8471,11 @@ packages:
 
   react-stately@3.36.1:
     resolution: {integrity: sha512-H9kiGAylNec/iE5qk7qQLV1cvtSAIVq3mgt87zx2EA+f+/sYy2oBtchFPaDiBf/m7xMEKf0Fr9zSLU6G99xQ8g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-stately@3.46.0:
+    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
@@ -11115,32 +10958,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@formatjs/ecma402-abstract@2.3.4':
-    dependencies:
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/intl-localematcher': 0.6.1
-      decimal.js: 10.5.0
-      tslib: 2.8.1
-
-  '@formatjs/fast-memoize@2.2.7':
-    dependencies:
-      tslib: 2.8.1
-
-  '@formatjs/icu-messageformat-parser@2.11.2':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.4
-      '@formatjs/icu-skeleton-parser': 1.8.14
-      tslib: 2.8.1
-
-  '@formatjs/icu-skeleton-parser@1.8.14':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.4
-      tslib: 2.8.1
-
-  '@formatjs/intl-localematcher@0.6.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@gar/promisify@1.1.3': {}
 
   '@gitbeaker/core@25.6.0':
@@ -11211,20 +11028,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.1
 
-  '@internationalized/date@3.7.0':
+  '@internationalized/date@3.12.1':
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@internationalized/message@3.1.6':
-    dependencies:
-      '@swc/helpers': 0.5.15
-      intl-messageformat: 10.7.16
-
-  '@internationalized/number@3.6.0':
+  '@internationalized/number@3.6.6':
     dependencies:
       '@swc/helpers': 0.5.15
 
-  '@internationalized/string@3.2.5':
+  '@internationalized/string@3.2.8':
     dependencies:
       '@swc/helpers': 0.5.15
 
@@ -11983,183 +11795,6 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@react-aria/button@3.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/toolbar': 3.0.0-beta.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.2(react@18.3.1)
-      '@react-types/button': 3.11.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/checkbox@3.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/form': 3.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/toggle': 3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/checkbox': 3.6.12(react@18.3.1)
-      '@react-stately/form': 3.1.2(react@18.3.1)
-      '@react-stately/toggle': 3.8.2(react@18.3.1)
-      '@react-types/checkbox': 3.9.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/dialog@3.5.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/dialog': 3.5.16(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/focus@3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/form@3.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/form': 3.1.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/i18n@3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/message': 3.1.6
-      '@internationalized/number': 3.6.0
-      '@internationalized/string': 3.2.5
-      '@react-aria/ssr': 3.9.7(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/interactions@3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/ssr': 3.9.7(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/flags': 3.1.0
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/label@3.7.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/overlays@3.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/ssr': 3.9.7(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/visually-hidden': 3.8.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/overlays': 3.6.14(react@18.3.1)
-      '@react-types/button': 3.11.0(react@18.3.1)
-      '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/radio@3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/form': 3.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/label': 3.7.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/radio': 3.10.11(react@18.3.1)
-      '@react-types/radio': 3.8.7(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/ssr@3.9.7(react@18.3.1)':
-    dependencies:
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-
-  '@react-aria/switch@3.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/toggle': 3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@react-types/switch': 3.5.9(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/toggle@3.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-stately/toggle': 3.8.2(react@18.3.1)
-      '@react-types/checkbox': 3.9.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/toolbar@3.0.0-beta.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/focus': 3.20.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/i18n': 3.12.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/utils@3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/ssr': 3.9.7(react@18.3.1)
-      '@react-stately/flags': 3.1.0
-      '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@react-aria/visually-hidden@3.8.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-aria/interactions': 3.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/utils': 3.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      '@swc/helpers': 0.5.15
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@react-spring/animated@10.0.3(react@18.3.1)':
     dependencies:
       '@react-spring/shared': 10.0.3(react@18.3.1)
@@ -12194,10 +11829,10 @@ snapshots:
 
   '@react-stately/calendar@3.7.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.12.1
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/calendar': 3.6.1(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12206,26 +11841,26 @@ snapshots:
       '@react-stately/form': 3.1.2(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/checkbox': 3.9.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/collections@3.12.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/color@3.8.3(react@18.3.1)':
     dependencies:
-      '@internationalized/number': 3.6.0
-      '@internationalized/string': 3.2.5
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
       '@react-stately/form': 3.1.2(react@18.3.1)
       '@react-stately/numberfield': 3.9.10(react@18.3.1)
       '@react-stately/slider': 3.6.2(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/color': 3.0.3(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12238,39 +11873,39 @@ snapshots:
       '@react-stately/select': 3.6.11(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/combobox': 3.13.3(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/data@3.12.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/datepicker@3.13.0(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.7.0
-      '@internationalized/string': 3.2.5
+      '@internationalized/date': 3.12.1
+      '@internationalized/string': 3.2.8
       '@react-stately/form': 3.1.2(react@18.3.1)
       '@react-stately/overlays': 3.6.14(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/datepicker': 3.11.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/disclosure@3.0.2(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/dnd@3.5.2(react@18.3.1)':
     dependencies:
       '@react-stately/selection': 3.20.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12280,7 +11915,7 @@ snapshots:
 
   '@react-stately/form@3.1.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12289,7 +11924,7 @@ snapshots:
       '@react-stately/collections': 3.12.2(react@18.3.1)
       '@react-stately/selection': 3.20.0(react@18.3.1)
       '@react-types/grid': 3.3.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12298,7 +11933,7 @@ snapshots:
       '@react-stately/collections': 3.12.2(react@18.3.1)
       '@react-stately/selection': 3.20.0(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12306,13 +11941,13 @@ snapshots:
     dependencies:
       '@react-stately/overlays': 3.6.14(react@18.3.1)
       '@react-types/menu': 3.9.15(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/numberfield@3.9.10(react@18.3.1)':
     dependencies:
-      '@internationalized/number': 3.6.0
+      '@internationalized/number': 3.6.6
       '@react-stately/form': 3.1.2(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/numberfield': 3.8.9(react@18.3.1)
@@ -12331,7 +11966,7 @@ snapshots:
       '@react-stately/form': 3.1.2(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/radio': 3.8.7(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12348,7 +11983,7 @@ snapshots:
       '@react-stately/list': 3.12.0(react@18.3.1)
       '@react-stately/overlays': 3.6.14(react@18.3.1)
       '@react-types/select': 3.9.10(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12356,14 +11991,14 @@ snapshots:
     dependencies:
       '@react-stately/collections': 3.12.2(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
   '@react-stately/slider@3.6.2(react@18.3.1)':
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@react-types/slider': 3.7.9(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
@@ -12376,7 +12011,7 @@ snapshots:
       '@react-stately/selection': 3.20.0(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/grid': 3.3.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@react-types/table': 3.11.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
@@ -12384,7 +12019,7 @@ snapshots:
   '@react-stately/tabs@3.8.0(react@18.3.1)':
     dependencies:
       '@react-stately/list': 3.12.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@react-types/tabs': 3.3.13(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
@@ -12399,7 +12034,7 @@ snapshots:
     dependencies:
       '@react-stately/utils': 3.10.5(react@18.3.1)
       '@react-types/checkbox': 3.9.2(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12415,7 +12050,7 @@ snapshots:
       '@react-stately/collections': 3.12.2(react@18.3.1)
       '@react-stately/selection': 3.20.0(react@18.3.1)
       '@react-stately/utils': 3.10.5(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
@@ -12424,118 +12059,106 @@ snapshots:
       '@swc/helpers': 0.5.15
       react: 18.3.1
 
-  '@react-types/button@3.11.0(react@18.3.1)':
-    dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      react: 18.3.1
-
   '@react-types/calendar@3.6.1(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.7.0
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@internationalized/date': 3.12.1
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/checkbox@3.9.2(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/color@3.0.3(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@react-types/slider': 3.7.9(react@18.3.1)
       react: 18.3.1
 
   '@react-types/combobox@3.13.3(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/datepicker@3.11.0(react@18.3.1)':
     dependencies:
-      '@internationalized/date': 3.7.0
+      '@internationalized/date': 3.12.1
       '@react-types/calendar': 3.6.1(react@18.3.1)
       '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
-      react: 18.3.1
-
-  '@react-types/dialog@3.5.16(react@18.3.1)':
-    dependencies:
-      '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/grid@3.3.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/menu@3.9.15(react@18.3.1)':
     dependencies:
       '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/numberfield@3.8.9(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/overlays@3.8.13(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/radio@3.8.7(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/searchfield@3.6.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       '@react-types/textfield': 3.12.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/select@3.9.10(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/shared@3.28.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
 
-  '@react-types/slider@3.7.9(react@18.3.1)':
+  '@react-types/shared@3.34.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
 
-  '@react-types/switch@3.5.9(react@18.3.1)':
+  '@react-types/slider@3.7.9(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/table@3.11.0(react@18.3.1)':
     dependencies:
       '@react-types/grid': 3.3.0(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/tabs@3.3.13(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/textfield@3.12.0(react@18.3.1)':
     dependencies:
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@react-types/tooltip@3.4.15(react@18.3.1)':
     dependencies:
       '@react-types/overlays': 3.8.13(react@18.3.1)
-      '@react-types/shared': 3.28.0(react@18.3.1)
+      '@react-types/shared': 3.34.0(react@18.3.1)
       react: 18.3.1
 
   '@remix-run/router@1.23.0': {}
@@ -13572,11 +13195,6 @@ snapshots:
     dependencies:
       '@types/node': 22.14.1
 
-  '@types/glob@8.1.0':
-    dependencies:
-      '@types/minimatch': 5.1.2
-      '@types/node': 22.14.1
-
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.14.1
@@ -13655,8 +13273,6 @@ snapshots:
   '@types/mime@1.3.5': {}
 
   '@types/minimatch@3.0.5': {}
-
-  '@types/minimatch@5.1.2': {}
 
   '@types/minimist@1.2.5': {}
 
@@ -14367,6 +13983,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.1.3:
     dependencies:
@@ -17032,13 +16652,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  intl-messageformat@10.7.16:
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.4
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/icu-messageformat-parser': 2.11.2
-      tslib: 2.8.1
 
   ip-address@9.0.5:
     dependencies:
@@ -19751,6 +19364,20 @@ snapshots:
 
   range-parser@1.2.1: {}
 
+  react-aria@3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@18.3.1)
+      '@swc/helpers': 0.5.15
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-stately: 3.46.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -19868,6 +19495,16 @@ snapshots:
       '@react-stately/tree': 3.8.8(react@18.3.1)
       '@react-types/shared': 3.28.0(react@18.3.1)
       react: 18.3.1
+
+  react-stately@3.46.0(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@18.3.1)
+      '@swc/helpers': 0.5.15
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
 
   react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,9 @@ allowBuilds:
 catalog:
   'react-compiler-runtime': '1.0.0'
   '@react-spring/web': '^10'
+  react-aria: '3.48.0'
+  react-stately: '3.46.0'
+
 minimumReleaseAge: 10080 # 7 days
 overrides:
   playwright: ^1.58.2

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     snapshotSerializers: ['./misc/test/vitest.snapshot-serializer.ts'],
     server: {
       deps: {
-        inline: [/@charcoal-ui\/(.*)/, /react-stately/, /react-aria/],
+        inline: [/@charcoal-ui\/(.*)/],
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,14 +8,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
+    snapshotSerializers: ['./misc/test/vitest.snapshot-serializer.ts'],
     server: {
       deps: {
-        inline: [
-          /@react-aria\/(.*)/,
-          /@react-stately\/(.*)/,
-          /react-stately/,
-          /@charcoal-ui\/(.*)/,
-        ],
+        inline: [/@charcoal-ui\/(.*)/, /react-stately/, /react-aria/],
       },
     },
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,8 +2,6 @@ import { beforeAll, vi } from 'vitest'
 import { setProjectAnnotations } from '@storybook/react-vite'
 import * as projectAnnotations from './.storybook/preview'
 
-import type { ReactPortal } from 'react'
-
 setProjectAnnotations(projectAnnotations)
 
 beforeAll(() => {
@@ -39,38 +37,4 @@ beforeAll(() => {
       dispatchEvent: vi.fn(),
     })),
   )
-
-  vi.mock('@react-aria/utils', async () => {
-    const utils = await vi.importActual('@react-aria/utils')
-
-    return {
-      ...utils,
-      useId: () => 'test-id',
-    }
-  })
-
-  vi.mock('@react-aria/overlays', async () => {
-    const overlays = await vi.importActual('@react-aria/overlays')
-
-    return {
-      ...overlays,
-      Overlay: vi.fn(({ children }) => children as ReactPortal),
-    }
-  })
-
-  vi.mock('react-stately', async () => {
-    const stately =
-      await vi.importActual<typeof import('react-stately')>('react-stately')
-
-    return {
-      ...stately,
-      useOverlayTriggerState: (
-        ...args: Parameters<typeof stately.useOverlayTriggerState>
-      ) => {
-        const state = stately.useOverlayTriggerState(...args)
-
-        return { ...state, isOpen: true }
-      },
-    }
-  })
 })


### PR DESCRIPTION
## やったこと

- react-aria 系を1.17+に更新
- subpath importに置き換え
- peer depsに調整

 https://react-aria.adobe.com/releases/v1-17-0#dependency-consolidation

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
