### PR TITLE
TextArea の制御 / 非制御時の同期処理の整理

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -5887,6 +5887,64 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowsAndRows 1`] 
 </div>
 `;
 
+exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowsOverInitialRow 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 7;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="6"
+        >
+          デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+        </textarea>
+        <span
+          class="charcoal-text-area-counter"
+        >
+          87
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/TextArea > react/TextArea > Placeholder 1`] = `
 <div>
   <div

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -5338,6 +5338,64 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeight 1`] = `
 </div>
 `;
 
+exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightAndDefaultValue 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 9;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="8"
+        >
+          デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+        </textarea>
+        <span
+          class="charcoal-text-area-counter"
+        >
+          87
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightAndRows 1`] = `
 <div>
   <div
@@ -5621,6 +5679,110 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > Label 1`] = `
           id="test-id"
           rows="4"
         />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowWorkingChangingValue 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button>
+      insert value
+    </button>
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 2;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="1"
+        />
+        <span
+          class="charcoal-text-area-counter"
+        >
+          0
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowWorkingChangingValueInRef 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button>
+      insert value
+    </button>
+    <div
+      aria-disabled="false"
+      class="charcoal-text-area-root"
+    >
+      <div
+        class="charcoal-field-label-root"
+        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+      >
+        <label
+          class="charcoal-field-label"
+          for="test-id"
+          id="test-id"
+        >
+          label
+        </label>
+        <div
+          class="charcoal-field-label-sub-label"
+        >
+          <span />
+        </div>
+      </div>
+      <div
+        aria-invalid="false"
+        class="charcoal-text-area-container"
+        style="--charcoal-text-area-rows: 2;"
+      >
+        <textarea
+          aria-labelledby="test-id"
+          class="charcoal-text-area-textarea"
+          data-no-bottom-padding="true"
+          id="test-id"
+          rows="1"
+        />
+        <span
+          class="charcoal-text-area-counter"
+        >
+          0
+        </span>
       </div>
     </div>
   </div>

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -89,6 +89,14 @@ export const ReadOnly: StoryObj<typeof TextArea> = {
   },
 }
 
+export const DefaultValue: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return (
+      <TextArea label="Label" defaultValue={'テスト用テキスト'} showCount />
+    )
+  },
+}
+
 export const AutoHeight: StoryObj<typeof TextArea> = {
   render: function Render() {
     return <TextArea autoHeight label="Label" />

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -1,6 +1,6 @@
 import { action } from 'storybook/actions'
 import Clickable from '../Clickable'
-import TextArea from '.'
+import TextArea, { type TextAreaImperativeHandle } from '.'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import { useCallback, useRef, useState } from 'react'
 
@@ -155,7 +155,7 @@ export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
         >
           insert value
         </button>
-        <TextArea rows={1} maxRows={3} label="label" value={value} showCount />
+        <TextArea rows={1} autoHeight label="label" value={value} showCount />
       </>
     )
   },
@@ -163,14 +163,12 @@ export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
 
 export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
   render: function Render() {
-    const ref = useRef<HTMLTextAreaElement>(null)
+    const imperativeRef = useRef<TextAreaImperativeHandle>(null)
     const handleClick = useCallback(() => {
-      ref.current?.value
-      if (ref.current) {
-        ref.current.value =
-          'test\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest'
-      }
-    }, [ref])
+      imperativeRef.current?.setValue(
+        'test\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest',
+      )
+    }, [])
     return (
       <>
         <button
@@ -180,7 +178,13 @@ export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
         >
           insert value
         </button>
-        <TextArea rows={1} maxRows={3} label="label" showCount ref={ref} />
+        <TextArea
+          rows={1}
+          label="label"
+          showCount
+          autoHeight
+          imperativeRef={imperativeRef}
+        />
       </>
     )
   },

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -2,6 +2,7 @@ import { action } from 'storybook/actions'
 import Clickable from '../Clickable'
 import TextArea from '.'
 import { Meta, StoryObj } from '@storybook/react-vite'
+import { useCallback, useRef, useState } from 'react'
 
 export default {
   title: 'react/TextArea',
@@ -125,6 +126,54 @@ export const DefaultValue: StoryObj<typeof TextArea> = {
   render: function Render() {
     return (
       <TextArea label="Label" defaultValue={'テスト用テキスト'} showCount />
+    )
+  },
+}
+
+export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    const [value, setValue] = useState('')
+    const handleClick = useCallback(() => {
+      setValue(
+        'test\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest',
+      )
+    }, [])
+    return (
+      <>
+        <button
+          onClick={() => {
+            handleClick()
+          }}
+        >
+          insert value
+        </button>
+        <TextArea rows={1} maxRows={3} label="label" value={value} showCount />
+      </>
+    )
+  },
+}
+
+export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    const ref = useRef<HTMLTextAreaElement>(null)
+    const handleClick = useCallback(() => {
+      ref.current?.value
+      if (ref.current) {
+        ref.current.value =
+          'test\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest\ntest'
+      }
+    }, [ref])
+    return (
+      <>
+        <button
+          onClick={() => {
+            handleClick()
+          }}
+        >
+          insert value
+        </button>
+        <TextArea rows={1} maxRows={3} label="label" showCount ref={ref} />
+      </>
     )
   },
 }

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -122,14 +122,6 @@ export const MaxRowsAndRows: StoryObj<typeof TextArea> = {
   },
 }
 
-export const DefaultValue: StoryObj<typeof TextArea> = {
-  render: function Render() {
-    return (
-      <TextArea label="Label" defaultValue={'テスト用テキスト'} showCount />
-    )
-  },
-}
-
 export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
   render: function Render() {
     const [value, setValue] = useState('')

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -110,6 +110,22 @@ export const AutoHeightAndRows: StoryObj<typeof TextArea> = {
   },
 }
 
+export const AutoHeightAndDefaultValue: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return (
+      <TextArea
+        rows={3}
+        autoHeight
+        label="label"
+        showCount
+        defaultValue={
+          'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
+        }
+      />
+    )
+  },
+}
+
 export const MaxRows: StoryObj<typeof TextArea> = {
   render: function Render() {
     return <TextArea maxRows={6} label="label" showCount />

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -138,6 +138,22 @@ export const MaxRowsAndRows: StoryObj<typeof TextArea> = {
   },
 }
 
+export const MaxRowsOverInitialRow: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    return (
+      <TextArea
+        rows={3}
+        maxRows={6}
+        label="label"
+        showCount
+        defaultValue={
+          'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
+        }
+      />
+    )
+  },
+}
+
 export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
   render: function Render() {
     const [value, setValue] = useState('')

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -61,16 +61,24 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     forwardRef,
   ) {
-    const { visuallyHiddenProps } = useVisuallyHidden()
-    const textareaRef = useRef<HTMLTextAreaElement>(null)
+    const [rows, setRows] = useState(initialRows)
     const [count, setCount] = useState(
       getCount(value ?? defaultValue?.toString() ?? ''),
     )
-    const [rows, setRows] = useState(initialRows)
+
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+    const containerRef = useRef(null)
+    useFocusWithClick(containerRef, textareaRef)
+    const { visuallyHiddenProps } = useVisuallyHidden()
+
+    const isUncontrolled = value === undefined
     const isEnableAutoHeight = useMemo(
       () => autoHeight || (maxRows && maxRows >= 0),
       [autoHeight, maxRows],
     )
+    const classNames = useClassNames('charcoal-text-area-root', className)
+    const showAssistiveText =
+      assistiveText != null && assistiveText.length !== 0
 
     const syncHeight = useCallback(
       (textarea: HTMLTextAreaElement) => {
@@ -89,7 +97,6 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       [initialRows, maxRows],
     )
 
-    const nonControlled = value === undefined
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const value = e.target.value
@@ -97,46 +104,56 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         if (maxLength !== undefined && count > maxLength) {
           return
         }
-        if (nonControlled) {
+
+        if (isUncontrolled) {
           setCount(count)
+
+          if (isEnableAutoHeight && textareaRef.current !== null) {
+            syncHeight(textareaRef.current)
+          }
         }
-        if (isEnableAutoHeight && textareaRef.current !== null) {
-          syncHeight(textareaRef.current)
-        }
+
         onChange?.(value)
       },
       [
         isEnableAutoHeight,
         getCount,
         maxLength,
-        nonControlled,
+        isUncontrolled,
         onChange,
         syncHeight,
       ],
     )
 
-    useEffect(() => {
-      setCount(getCount(value ?? defaultValue?.toString() ?? ''))
-    }, [getCount, value, defaultValue])
-
-    useEffect(() => {
-      if (isEnableAutoHeight && textareaRef.current !== null) {
-        syncHeight(textareaRef.current)
-      }
-    }, [isEnableAutoHeight, syncHeight])
-
-    const containerRef = useRef(null)
-
-    useFocusWithClick(containerRef, textareaRef)
-
     const textAreaId = useId(props.id)
     const describedbyId = useId()
     const labelledbyId = useId()
 
-    const classNames = useClassNames('charcoal-text-area-root', className)
+    useEffect(() => {
+      if (!isUncontrolled) {
+        setCount(getCount(value))
+        if (isEnableAutoHeight && textareaRef.current !== null) {
+          syncHeight(textareaRef.current)
+        }
+      }
+    }, [
+      isUncontrolled,
+      value,
+      getCount,
+      isEnableAutoHeight,
+      textareaRef,
+      syncHeight,
+    ])
 
-    const showAssistiveText =
-      assistiveText != null && assistiveText.length !== 0
+    useEffect(() => {
+      if (
+        isUncontrolled &&
+        isEnableAutoHeight &&
+        textareaRef.current !== null
+      ) {
+        syncHeight(textareaRef.current)
+      }
+    }, [isUncontrolled, isEnableAutoHeight, textareaRef, syncHeight])
 
     return (
       <div className={classNames} aria-disabled={disabled}>

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -5,6 +5,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -16,9 +17,15 @@ import { useId } from '@react-aria/utils'
 import { AssistiveText } from '../TextField/AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
 
+export type TextAreaImperativeHandle = {
+  setValue: (value: string) => void
+  sync: () => void
+}
+
 export type TextAreaProps = {
   value?: string
   onChange?: (value: string) => void
+  imperativeRef?: React.Ref<TextAreaImperativeHandle>
 
   showCount?: boolean
   showLabel?: boolean
@@ -57,6 +64,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       invalid,
       getCount = countCodePointsInString,
       defaultValue,
+      imperativeRef,
       ...props
     },
     forwardRef,
@@ -97,32 +105,55 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       [initialRows, maxRows],
     )
 
+    const syncTextAreaState = useCallback(
+      (textarea: HTMLTextAreaElement) => {
+        const count = getCount(textarea.value)
+
+        if (isUncontrolled) {
+          setCount(count)
+        }
+
+        if (isEnableAutoHeight) {
+          syncHeight(textarea)
+        }
+
+        return count
+      },
+      [getCount, isEnableAutoHeight, isUncontrolled, syncHeight],
+    )
+
     const handleChange = useCallback(
       (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const value = e.target.value
+        const value = e.currentTarget.value
         const count = getCount(value)
         if (maxLength !== undefined && count > maxLength) {
           return
         }
 
-        if (isUncontrolled) {
-          setCount(count)
-
-          if (isEnableAutoHeight && textareaRef.current !== null) {
-            syncHeight(textareaRef.current)
-          }
-        }
-
+        syncTextAreaState(e.currentTarget)
         onChange?.(value)
       },
-      [
-        isEnableAutoHeight,
-        getCount,
-        maxLength,
-        isUncontrolled,
-        onChange,
-        syncHeight,
-      ],
+      [getCount, maxLength, onChange, syncTextAreaState],
+    )
+
+    useImperativeHandle(
+      imperativeRef,
+      () => ({
+        setValue: (value: string) => {
+          if (textareaRef.current === null) {
+            return
+          }
+
+          textareaRef.current.value = value
+          syncTextAreaState(textareaRef.current)
+        },
+        sync: () => {
+          if (textareaRef.current !== null) {
+            syncTextAreaState(textareaRef.current)
+          }
+        },
+      }),
+      [syncTextAreaState],
     )
 
     const textAreaId = useId(props.id)

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -161,11 +161,21 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const labelledbyId = useId()
 
     useEffect(() => {
+      // 制御コンポーネントの時の挙動
       if (!isUncontrolled) {
         setCount(getCount(value))
         if (isEnableAutoHeight && textareaRef.current !== null) {
           syncHeight(textareaRef.current)
         }
+      }
+
+      //　非制御コンポーネント時のautoHeight同期
+      if (
+        isUncontrolled &&
+        isEnableAutoHeight &&
+        textareaRef.current !== null
+      ) {
+        syncHeight(textareaRef.current)
       }
     }, [
       isUncontrolled,
@@ -175,16 +185,6 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       textareaRef,
       syncHeight,
     ])
-
-    useEffect(() => {
-      if (
-        isUncontrolled &&
-        isEnableAutoHeight &&
-        textareaRef.current !== null
-      ) {
-        syncHeight(textareaRef.current)
-      }
-    }, [isUncontrolled, isEnableAutoHeight, textareaRef, syncHeight])
 
     return (
       <div className={classNames} aria-disabled={disabled}>

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -95,12 +95,12 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
         const hasValidMaxRows = maxRows !== undefined && maxRows >= 1
         const nextRows = initialRows <= currentRows ? currentRows : initialRows
 
-        if (!hasValidMaxRows || maxRows <= initialRows) {
+        if (!hasValidMaxRows) {
           setRows(nextRows)
           return
         }
 
-        setRows(nextRows <= maxRows ? nextRows : maxRows)
+        setRows(Math.min(nextRows, maxRows))
       },
       [initialRows, maxRows],
     )

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -17,8 +17,17 @@ import { useId } from '@react-aria/utils'
 import { AssistiveText } from '../TextField/AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
 
+/**
+ * `TextArea` を `imperativeRef` から操作するためのハンドル
+ */
 export type TextAreaImperativeHandle = {
+  /**
+   * textarea の値を更新し、文字数や高さなどの内部状態を同期する
+   */
   setValue: (value: string) => void
+  /**
+   * textarea の現在の値をもとに、文字数や高さなどの内部状態を同期する
+   */
   sync: () => void
 }
 

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -173,17 +173,10 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       // 制御コンポーネントの時の挙動
       if (!isUncontrolled) {
         setCount(getCount(value))
-        if (isEnableAutoHeight && textareaRef.current !== null) {
-          syncHeight(textareaRef.current)
-        }
       }
 
-      //　非制御コンポーネント時のautoHeight同期
-      if (
-        isUncontrolled &&
-        isEnableAutoHeight &&
-        textareaRef.current !== null
-      ) {
+      //　autoHeight同期(valueが変更された時にsyncHeightしたい)
+      if (isEnableAutoHeight && textareaRef.current !== null) {
         syncHeight(textareaRef.current)
       }
     }, [

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -38,7 +38,11 @@ export {
   default as TextField,
   type TextFieldProps,
 } from './components/TextField'
-export { default as TextArea, type TextAreaProps } from './components/TextArea'
+export {
+  default as TextArea,
+  type TextAreaImperativeHandle,
+  type TextAreaProps,
+} from './components/TextArea'
 export { default as Icon, type IconProps } from './components/Icon'
 export {
   default as Modal,


### PR DESCRIPTION
## やったこと
TextArea の制御 / 非制御時の同期処理を整理しました。
- 制御コンポーネント時は `value` 更新に合わせて count / height を同期
- 非制御コンポーネント時は入力イベントに合わせて count / height を同期
- ref 経由の値更新用に `imperativeRef` を追加
- `setValue` / `sync` で count と auto height を明示的に同期可能に
- defaultValue + autoHeight の story を追加
## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] 追加したコンポーネントが index.ts から再 export されている
- [x] README やドキュメントに影響があることを確認した
