### PR TITLE
fix: textarea handle null value

### DIFF
--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -4,30 +4,16 @@ import TextArea from '.'
 import '@testing-library/jest-dom'
 
 describe('TextArea component', () => {
-  it('counts defaultValue when value is not provided', () => {
-    render(<TextArea showCount defaultValue="abc" />)
+  it.each`
+    name                                    | value                        | defaultValue | expectedValue | expectedCount
+    ${'uncontrolled defaultValue'}          | ${undefined}                 | ${'abc'}     | ${'abc'}      | ${'3'}
+    ${'controlled null'}                    | ${null as unknown as string} | ${undefined} | ${''}         | ${'0'}
+    ${'controlled null with defaultValue'}  | ${null as unknown as string} | ${'abc'}     | ${''}         | ${'0'}
+    ${'controlled value with defaultValue'} | ${'xy'}                      | ${'abc'}     | ${'xy'}       | ${'2'}
+  `('$name', ({ value, defaultValue, expectedValue, expectedCount }) => {
+    render(<TextArea showCount value={value} defaultValue={defaultValue} />)
 
-    expect(screen.getByRole('textbox')).toHaveValue('abc')
-    expect(screen.getByText('3')).toBeInTheDocument()
-  })
-
-  it('treats a null controlled value as empty for the counter', () => {
-    render(<TextArea showCount value={null as unknown as string} />)
-
-    expect(screen.getByRole('textbox')).toHaveValue('')
-    expect(screen.getByText('0')).toBeInTheDocument()
-  })
-
-  it('does not fall back to defaultValue when controlled value is null', () => {
-    render(
-      <TextArea
-        showCount
-        value={null as unknown as string}
-        defaultValue="abc"
-      />,
-    )
-
-    expect(screen.getByRole('textbox')).toHaveValue('')
-    expect(screen.getByText('0')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveValue(expectedValue)
+    expect(screen.getByText(expectedCount)).toBeInTheDocument()
   })
 })

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -8,7 +8,7 @@ describe('TextArea component', () => {
     name                                    | value                        | defaultValue | expectedValue | expectedCount
     ${'uncontrolled defaultValue'}          | ${undefined}                 | ${'abc'}     | ${'abc'}      | ${'3'}
     ${'controlled null'}                    | ${null as unknown as string} | ${undefined} | ${''}         | ${'0'}
-    ${'controlled null with defaultValue'}  | ${null as unknown as string} | ${'abc'}     | ${''}         | ${'0'}
+    ${'controlled null with defaultValue'}  | ${null as unknown as string} | ${'abc'}     | ${'abc'}      | ${'3'}
     ${'controlled value with defaultValue'} | ${'xy'}                      | ${'abc'}     | ${'xy'}       | ${'2'}
   `('$name', ({ value, defaultValue, expectedValue, expectedCount }) => {
     render(<TextArea showCount value={value} defaultValue={defaultValue} />)

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import TextArea from '.'
 
-import '@testing-library/jest-dom'
-
 describe('TextArea component', () => {
   it.each`
     name                                    | value                        | defaultValue | expectedValue | expectedCount

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import TextArea from '.'
+
+import '@testing-library/jest-dom'
+
+describe('TextArea component', () => {
+  it('counts defaultValue when value is not provided', () => {
+    render(<TextArea showCount defaultValue="abc" />)
+
+    expect(screen.getByRole('textbox')).toHaveValue('abc')
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('treats a null controlled value as empty for the counter', () => {
+    render(<TextArea showCount value={null as unknown as string} />)
+
+    expect(screen.getByRole('textbox')).toHaveValue('')
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('does not fall back to defaultValue when controlled value is null', () => {
+    render(
+      <TextArea
+        showCount
+        value={null as unknown as string}
+        defaultValue="abc"
+      />,
+    )
+
+    expect(screen.getByRole('textbox')).toHaveValue('')
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -79,15 +79,11 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     forwardRef,
   ) {
     const isUncontrolled = value === undefined
-    // `null` is invalid for TextAreaProps, but may arrive at runtime. Treat it
-    // as a controlled empty value so it never falls back to defaultValue.
-    const controlledValue = value ?? ''
+    // `null` is invalid for TextAreaProps, but may arrive at runtime. Keep the
+    // pre-f710d512 nullish fallback so getCount is never called with null.
+    const countValue = value ?? defaultValue?.toString() ?? ''
     const [rows, setRows] = useState(initialRows)
-    const [count, setCount] = useState(
-      getCount(
-        isUncontrolled ? (defaultValue?.toString() ?? '') : controlledValue,
-      ),
-    )
+    const [count, setCount] = useState(getCount(countValue))
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const containerRef = useRef(null)
@@ -177,7 +173,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     useEffect(() => {
       // 制御コンポーネントの時の挙動
       if (!isUncontrolled) {
-        setCount(getCount(controlledValue))
+        setCount(getCount(countValue))
       }
 
       //　autoHeight同期(valueが変更された時にsyncHeightしたい)
@@ -186,7 +182,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       }
     }, [
       isUncontrolled,
-      controlledValue,
+      countValue,
       getCount,
       isEnableAutoHeight,
       textareaRef,
@@ -224,9 +220,9 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             onChange={handleChange}
             ref={mergeRefs(forwardRef, textareaRef)}
             rows={rows}
-            value={isUncontrolled ? undefined : controlledValue}
+            value={value}
             disabled={disabled}
-            defaultValue={isUncontrolled ? defaultValue : undefined}
+            defaultValue={defaultValue}
             {...props}
           />
           {showCount && (

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -78,9 +78,13 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     forwardRef,
   ) {
+    const isUncontrolled = value === undefined
+    const controlledValue = value ?? ''
     const [rows, setRows] = useState(initialRows)
     const [count, setCount] = useState(
-      getCount(value ?? defaultValue?.toString() ?? ''),
+      getCount(
+        isUncontrolled ? defaultValue?.toString() ?? '' : controlledValue,
+      ),
     )
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -88,7 +92,6 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     useFocusWithClick(containerRef, textareaRef)
     const { visuallyHiddenProps } = useVisuallyHidden()
 
-    const isUncontrolled = value === undefined
     const isEnableAutoHeight = useMemo(
       () => autoHeight || (maxRows && maxRows >= 0),
       [autoHeight, maxRows],
@@ -172,7 +175,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     useEffect(() => {
       // 制御コンポーネントの時の挙動
       if (!isUncontrolled) {
-        setCount(getCount(value))
+        setCount(getCount(controlledValue))
       }
 
       //　autoHeight同期(valueが変更された時にsyncHeightしたい)
@@ -181,7 +184,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       }
     }, [
       isUncontrolled,
-      value,
+      controlledValue,
       getCount,
       isEnableAutoHeight,
       textareaRef,
@@ -219,9 +222,9 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             onChange={handleChange}
             ref={mergeRefs(forwardRef, textareaRef)}
             rows={rows}
-            value={value}
+            value={isUncontrolled ? undefined : controlledValue}
             disabled={disabled}
-            defaultValue={defaultValue}
+            defaultValue={isUncontrolled ? defaultValue : undefined}
             {...props}
           />
           {showCount && (

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -79,11 +79,13 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     forwardRef,
   ) {
     const isUncontrolled = value === undefined
+    // `null` is invalid for TextAreaProps, but may arrive at runtime. Treat it
+    // as a controlled empty value so it never falls back to defaultValue.
     const controlledValue = value ?? ''
     const [rows, setRows] = useState(initialRows)
     const [count, setCount] = useState(
       getCount(
-        isUncontrolled ? defaultValue?.toString() ?? '' : controlledValue,
+        isUncontrolled ? (defaultValue?.toString() ?? '') : controlledValue,
       ),
     )
 


### PR DESCRIPTION
## やったこと

- textarea should not throw even null value is passed
## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
