### PR TITLE
feat: switch to data hidden to workaround tailwind preflight reset

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -3570,10 +3570,10 @@ exports[`Storybook Tests > react/Pagination > react/Pagination > FirstPage 1`] =
         aria-label="Previous"
         class="charcoal-icon-button charcoal-pagination-nav-button"
         data-active="false"
+        data-hidden="true"
         data-size="M"
         data-variant="Default"
         disabled=""
-        hidden=""
       >
         <pixiv-icon
           name="24/Prev"
@@ -3714,10 +3714,10 @@ exports[`Storybook Tests > react/Pagination > react/Pagination > LastPage 1`] = 
         aria-label="Next"
         class="charcoal-icon-button charcoal-pagination-nav-button"
         data-active="false"
+        data-hidden="true"
         data-size="M"
         data-variant="Default"
         disabled=""
-        hidden=""
       >
         <pixiv-icon
           name="24/Next"

--- a/packages/react/src/__tests__/css-output.test.ts
+++ b/packages/react/src/__tests__/css-output.test.ts
@@ -72,7 +72,6 @@ describe('CSS nesting output equivalence', () => {
       '__snapshots__',
       'index.css.snap',
     )
-    const expected = await fs.readFile(snapshotPath, 'utf-8')
-    expect(canonicalize(result.root)).toBe(expected)
+    await expect(canonicalize(result.root)).toMatchFileSnapshot(snapshotPath)
   })
 })

--- a/packages/react/src/components/Pagination/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Pagination/__snapshots__/index.css.snap
@@ -97,9 +97,10 @@
 
 /* Kept flat: different root class from .charcoal-pagination-button */
 
-.charcoal-pagination-nav-button[hidden] {
+/* Use data-hidden, not [hidden]: Tailwind preflight's `[hidden] { display: none !important }` would clobber `visibility: hidden` and collapse the layout space. */
+
+.charcoal-pagination-nav-button[data-hidden] {
   visibility: hidden;
-  display: block;
 }
 
 .charcoal-pagination-spacer, .charcoal-pagination-spacer:hover, .charcoal-pagination-spacer:active {

--- a/packages/react/src/components/Pagination/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Pagination/__snapshots__/index.css.snap
@@ -95,10 +95,6 @@
 }
 /* stylelint-enable no-descending-specificity */
 
-/* Kept flat: different root class from .charcoal-pagination-button */
-
-/* Use data-hidden, not [hidden]: Tailwind preflight's `[hidden] { display: none !important }` would clobber `visibility: hidden` and collapse the layout space. */
-
 .charcoal-pagination-nav-button[data-hidden] {
   visibility: hidden;
 }

--- a/packages/react/src/components/Pagination/index.css
+++ b/packages/react/src/components/Pagination/index.css
@@ -103,8 +103,6 @@
 }
 /* stylelint-enable no-descending-specificity */
 
-/* Kept flat: different root class from .charcoal-pagination-button */
-/* Use data-hidden, not [hidden]: Tailwind preflight's `[hidden] { display: none !important }` would clobber `visibility: hidden` and collapse the layout space. */
 .charcoal-pagination-nav-button[data-hidden] {
   visibility: hidden;
 }

--- a/packages/react/src/components/Pagination/index.css
+++ b/packages/react/src/components/Pagination/index.css
@@ -104,9 +104,9 @@
 /* stylelint-enable no-descending-specificity */
 
 /* Kept flat: different root class from .charcoal-pagination-button */
-.charcoal-pagination-nav-button[hidden] {
+/* Use data-hidden, not [hidden]: Tailwind preflight's `[hidden] { display: none !important }` would clobber `visibility: hidden` and collapse the layout space. */
+.charcoal-pagination-nav-button[data-hidden] {
   visibility: hidden;
-  display: block;
 }
 
 .charcoal-pagination-spacer {

--- a/packages/react/src/components/Pagination/index.tsx
+++ b/packages/react/src/components/Pagination/index.tsx
@@ -44,6 +44,7 @@ function NavButton({ direction, ariaLabel }: NavButtonProps) {
     <IconButton
       icon={isPrev ? '24/Prev' : '24/Next'}
       size={size}
+      /* Use data-hidden, not [hidden]: Tailwind preflight's `[hidden] { display: none !important }` would clobber `visibility: hidden` and collapse the layout space. */
       data-hidden={disabled || undefined}
       aria-label={ariaLabel}
       {...(isLinkMode && makeUrl

--- a/packages/react/src/components/Pagination/index.tsx
+++ b/packages/react/src/components/Pagination/index.tsx
@@ -44,7 +44,7 @@ function NavButton({ direction, ariaLabel }: NavButtonProps) {
     <IconButton
       icon={isPrev ? '24/Prev' : '24/Next'}
       size={size}
-      hidden={disabled}
+      data-hidden={disabled || undefined}
       aria-label={ariaLabel}
       {...(isLinkMode && makeUrl
         ? {


### PR DESCRIPTION
## やったこと

- use data-hidden instead of hidden to avoid tailwind reset `!important`

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
