### PR TITLE
fix: support Apple Pencil tap on DropdownSelector

### DIFF
--- a/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react'
+import { ForwardedRef, forwardRef, useRef } from 'react'
 import ListItem, { ListItemProps } from '../ListItem'
 import { useMenuItemHandleKeyDown } from './internals/useMenuItemHandleKeyDown'
 
@@ -18,6 +18,8 @@ const MenuItem = forwardRef(function MenuItem<
   ref: ForwardedRef<HTMLLIElement>,
 ) {
   const [handleKeyDown, setContextValue] = useMenuItemHandleKeyDown(value)
+  const penHandledRef = useRef(false)
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null)
   return (
     // @ts-expect-error TODO: fix mismatch between MenuItemProps and ListItemProps
     <ListItem
@@ -25,7 +27,29 @@ const MenuItem = forwardRef(function MenuItem<
       ref={ref}
       data-key={value}
       onKeyDown={handleKeyDown}
-      onClick={disabled === true ? undefined : setContextValue}
+      onPointerDown={(e: React.PointerEvent<HTMLLIElement>) => {
+        if (e.pointerType === 'pen') {
+          pointerStartRef.current = { x: e.clientX, y: e.clientY }
+        }
+      }}
+      onPointerUp={(e: React.PointerEvent<HTMLLIElement>) => {
+        if (e.pointerType !== 'pen' || disabled === true) return
+        const start = pointerStartRef.current
+        if (!start) return
+        const dx = Math.abs(e.clientX - start.x)
+        const dy = Math.abs(e.clientY - start.y)
+        if (dx > 8 || dy > 8) return
+        penHandledRef.current = true
+        setContextValue()
+      }}
+      onClick={() => {
+        if (penHandledRef.current) {
+          penHandledRef.current = false
+          return
+        }
+        if (disabled === true) return
+        setContextValue()
+      }}
       tabIndex={-1}
       aria-disabled={disabled}
       role="option"

--- a/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef, useRef } from 'react'
+import { ForwardedRef, forwardRef, useCallback, useRef } from 'react'
 import ListItem, { ListItemProps } from '../ListItem'
 import { useMenuItemHandleKeyDown } from './internals/useMenuItemHandleKeyDown'
 
@@ -20,6 +20,40 @@ const MenuItem = forwardRef(function MenuItem<
   const [handleKeyDown, setContextValue] = useMenuItemHandleKeyDown(value)
   const penHandledRef = useRef(false)
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null)
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLLIElement>) => {
+      if (e.pointerType === 'pen') {
+        pointerStartRef.current = { x: e.clientX, y: e.clientY }
+      }
+    },
+    [],
+  )
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLLIElement>) => {
+      if (e.pointerType !== 'pen' || disabled === true) return
+      const start = pointerStartRef.current
+      if (!start) return
+      const dx = Math.abs(e.clientX - start.x)
+      const dy = Math.abs(e.clientY - start.y)
+      // タップとドラッグを区別するための許容量
+      if (dx > 8 || dy > 8) return
+      penHandledRef.current = true
+      setContextValue()
+    },
+    [disabled, setContextValue],
+  )
+
+  const handleClick = useCallback(() => {
+    if (penHandledRef.current) {
+      penHandledRef.current = false
+      return
+    }
+    if (disabled === true) return
+    setContextValue()
+  }, [disabled, setContextValue])
+
   return (
     // @ts-expect-error TODO: fix mismatch between MenuItemProps and ListItemProps
     <ListItem
@@ -27,29 +61,9 @@ const MenuItem = forwardRef(function MenuItem<
       ref={ref}
       data-key={value}
       onKeyDown={handleKeyDown}
-      onPointerDown={(e: React.PointerEvent<HTMLLIElement>) => {
-        if (e.pointerType === 'pen') {
-          pointerStartRef.current = { x: e.clientX, y: e.clientY }
-        }
-      }}
-      onPointerUp={(e: React.PointerEvent<HTMLLIElement>) => {
-        if (e.pointerType !== 'pen' || disabled === true) return
-        const start = pointerStartRef.current
-        if (!start) return
-        const dx = Math.abs(e.clientX - start.x)
-        const dy = Math.abs(e.clientY - start.y)
-        if (dx > 8 || dy > 8) return
-        penHandledRef.current = true
-        setContextValue()
-      }}
-      onClick={() => {
-        if (penHandledRef.current) {
-          penHandledRef.current = false
-          return
-        }
-        if (disabled === true) return
-        setContextValue()
-      }}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onClick={handleClick}
       tabIndex={-1}
       aria-disabled={disabled}
       role="option"

--- a/packages/react/src/components/DropdownSelector/Popover/index.tsx
+++ b/packages/react/src/components/DropdownSelector/Popover/index.tsx
@@ -1,6 +1,6 @@
 import './index.css'
 
-import { RefObject, useContext, useRef, ReactNode } from 'react'
+import { RefObject, useContext, useEffect, useRef, ReactNode } from 'react'
 import { ModalBackgroundContext } from '../../Modal/ModalBackgroundContext'
 import { usePreventScroll } from './usePreventScroll'
 import { DismissButton, Overlay } from 'react-aria/Overlay'
@@ -53,6 +53,25 @@ export default function Popover(props: PopoverProps) {
 
   const modalBackground = useContext(ModalBackgroundContext)
   usePreventScroll(modalBackground, props.isOpen)
+
+  // iOS Safari は非インタラクティブな要素へのペン入力で click を合成しないため、
+  // click に依存する react-aria の外側判定ではペンで閉じられない。
+  // underlay 側では拾えない: react-aria が modal 時に外側を inert にするので
+  // underlay 自身がイベントを受け取らなくなる。
+  const { isOpen, onClose } = props
+  useEffect(() => {
+    if (!isOpen) return
+    const handlePointerUp = (e: PointerEvent) => {
+      if (e.pointerType !== 'pen') return
+      const popover = finalPopoverRef.current
+      if (popover !== null && e.composedPath().includes(popover)) return
+      onClose()
+    }
+    document.addEventListener('pointerup', handlePointerUp, true)
+    return () => {
+      document.removeEventListener('pointerup', handlePointerUp, true)
+    }
+  }, [isOpen, onClose, finalPopoverRef])
 
   if (!props.isOpen) return null
 

--- a/packages/react/src/components/DropdownSelector/index.browser.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.browser.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Apple Pencil (pointerType: 'pen') での overlay 解除テスト
+ *
+ * jsdom では検証できないため実ブラウザで実行する:
+ *
+ * 1. jsdom は inert を実装していない (`'inert' in HTMLElement.prototype` が false)。
+ *    そのため react-aria の ariaHideOutside は aria-hidden にフォールバックし、
+ *    「inert 要素はポインタイベントを受け取らない」という本番の挙動が再現されない。
+ * 2. jsdom は PointerEvent を実装しておらず pointerType が落ちる。
+ *
+ * iOS Safari は非インタラクティブな要素へのペン入力で click を合成しないため、
+ * click に依存する react-aria の外側判定では overlay を閉じられない。
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import DropdownSelector from '.'
+import DropdownMenuItem from './DropdownMenuItem'
+
+/** Apple Pencil のタップは iOS Safari で click を伴わない */
+const penTap = (element: Element) => {
+  const init = { pointerType: 'pen', button: 0, composed: true }
+  fireEvent.pointerDown(element, init)
+  fireEvent.pointerUp(element, init)
+}
+
+const popover = () => document.querySelector('.charcoal-popover')
+
+const getUnderlay = () => {
+  const underlay = popover()?.previousElementSibling
+  if (!(underlay instanceof HTMLElement)) throw new Error('underlay not found')
+  return underlay
+}
+
+/** ブラウザが実際にヒットテストする要素。inert / pointer-events を反映する */
+const hitTestOutsidePopover = () => {
+  const rect = popover()?.getBoundingClientRect()
+  if (!rect) throw new Error('popover not found')
+  const target = document.elementFromPoint(
+    Math.round(rect.left + rect.width / 2),
+    Math.round(rect.bottom + 40),
+  )
+  if (target === null) throw new Error('no element at point')
+  return target
+}
+
+const renderSelector = (inertWorkaround: boolean) =>
+  render(
+    <DropdownSelector
+      label="Label"
+      value="1"
+      onChange={vi.fn()}
+      inertWorkaround={inertWorkaround}
+    >
+      <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+      <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+    </DropdownSelector>,
+  )
+
+describe.each([
+  ['inertWorkaround が無効', false],
+  ['inertWorkaround が有効', true],
+])('%s なとき', (_, inertWorkaround) => {
+  it('Apple Pencil で overlay の外側をタップすると閉じる', () => {
+    renderSelector(inertWorkaround)
+
+    penTap(screen.getByRole('button'))
+    expect(popover()).not.toBeNull()
+
+    penTap(hitTestOutsidePopover())
+
+    expect(popover()).toBeNull()
+  })
+
+  // 選択肢のタップは onChange 経由で閉じるのが仕様なので、余白部分を叩く
+  it('Apple Pencil で popover の余白をタップしても閉じない', () => {
+    renderSelector(inertWorkaround)
+
+    penTap(screen.getByRole('button'))
+    const inside = popover()
+    if (inside === null) throw new Error('popover not found')
+
+    penTap(inside)
+
+    expect(popover()).not.toBeNull()
+  })
+})
+
+it('underlay は inertWorkaround が無効なとき inert になる', () => {
+  renderSelector(false)
+  penTap(screen.getByRole('button'))
+
+  expect('inert' in HTMLElement.prototype).toBe(true)
+  expect(getUnderlay().inert).toBe(true)
+})

--- a/packages/react/src/components/DropdownSelector/index.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.test.tsx
@@ -1,7 +1,33 @@
-import { render, screen } from '@testing-library/react'
-import { vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, vi } from 'vitest'
 import DropdownSelector from '.'
 import DropdownMenuItem from './DropdownMenuItem'
+
+// Apple Pencil (pointerType: 'pen') の解除は index.browser.test.tsx で検証する。
+// jsdom は inert を実装しておらず、react-aria が外側を inert にする本番の挙動を
+// 再現できないため、ここでペンを扱うと通ってしまい実機の退行を見逃す。
+
+// jsdom は PointerEvent を実装しておらず pointerType が落ちるため補う
+class PointerEventPolyfill extends MouseEvent {
+  readonly pointerType: string
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init)
+    this.pointerType = init.pointerType ?? ''
+  }
+}
+
+beforeAll(() => {
+  vi.stubGlobal('PointerEvent', PointerEventPolyfill)
+})
+
+const getUnderlay = () => {
+  const popover = document.querySelector('.charcoal-popover')
+  const underlay = popover?.previousElementSibling
+  if (!(underlay instanceof HTMLElement)) {
+    throw new Error('underlay not found')
+  }
+  return underlay
+}
 
 describe('DropdownSelector', () => {
   describe('when `value` does not match any child `DropdownMenuItem`', () => {
@@ -25,6 +51,35 @@ describe('DropdownSelector', () => {
       expect(select).not.toBeNull()
       expect(select?.value).toBe('missing-value')
       expect(button.textContent).toContain('Select an option')
+    })
+  })
+
+  describe.each([
+    ['inertWorkaround が無効', false],
+    ['inertWorkaround が有効', true],
+  ])('%s なとき', (_, inertWorkaround) => {
+    it('マウスで overlay をクリックすると閉じる', () => {
+      render(
+        <DropdownSelector
+          label="Label"
+          value="1"
+          onChange={vi.fn()}
+          inertWorkaround={inertWorkaround}
+        >
+          <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+          <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+        </DropdownSelector>,
+      )
+
+      fireEvent.click(screen.getByRole('button'))
+      expect(document.querySelector('.charcoal-popover')).not.toBeNull()
+
+      const underlay = getUnderlay()
+      fireEvent.pointerDown(underlay, { pointerType: 'mouse', button: 0 })
+      fireEvent.pointerUp(underlay, { pointerType: 'mouse', button: 0 })
+      fireEvent.click(underlay, { button: 0 })
+
+      expect(document.querySelector('.charcoal-popover')).toBeNull()
     })
   })
 })

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -42,6 +42,7 @@ export default function DropdownSelector({
   ...props
 }: DropdownSelectorProps) {
   const triggerRef = useRef<HTMLButtonElement>(null)
+  const penHandledRef = useRef(false)
   const [isOpen, setIsOpen] = useState(false)
   const preview = findPreviewRecursive(props.children, props.value)
 
@@ -116,7 +117,17 @@ export default function DropdownSelector({
           props.assistiveText !== undefined ? describedbyId : undefined
         }
         disabled={props.disabled}
+        onPointerUp={(e) => {
+          if (e.pointerType !== 'pen') return
+          if (props.disabled === true) return
+          penHandledRef.current = true
+          setIsOpen(true)
+        }}
         onClick={() => {
+          if (penHandledRef.current) {
+            penHandledRef.current = false
+            return
+          }
           if (props.disabled === true) return
           setIsOpen(true)
         }}

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -66,6 +66,11 @@ export default function DropdownSelector({
     [onChange],
   )
 
+  // Popover が document listener の登録に使うため、識別子を安定させる
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
   const labelId = useId()
   const describedbyId = useId()
 
@@ -146,7 +151,7 @@ export default function DropdownSelector({
       {isOpen && (
         <DropdownPopover
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onClose={handleClose}
           triggerRef={triggerRef}
           value={props.value}
           inertWorkaround={props.inertWorkaround}

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -71,6 +71,33 @@ export default function DropdownSelector({
     setIsOpen(false)
   }, [])
 
+  const handleSelect = useCallback(
+    (v: string) => {
+      onChange(v)
+      setIsOpen(false)
+    },
+    [onChange],
+  )
+
+  const handleTriggerPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.pointerType !== 'pen') return
+      if (props.disabled === true) return
+      penHandledRef.current = true
+      setIsOpen(true)
+    },
+    [props.disabled],
+  )
+
+  const handleTriggerClick = useCallback(() => {
+    if (penHandledRef.current) {
+      penHandledRef.current = false
+      return
+    }
+    if (props.disabled === true) return
+    setIsOpen(true)
+  }, [props.disabled])
+
   const labelId = useId()
   const describedbyId = useId()
 
@@ -122,20 +149,8 @@ export default function DropdownSelector({
           props.assistiveText !== undefined ? describedbyId : undefined
         }
         disabled={props.disabled}
-        onPointerUp={(e) => {
-          if (e.pointerType !== 'pen') return
-          if (props.disabled === true) return
-          penHandledRef.current = true
-          setIsOpen(true)
-        }}
-        onClick={() => {
-          if (penHandledRef.current) {
-            penHandledRef.current = false
-            return
-          }
-          if (props.disabled === true) return
-          setIsOpen(true)
-        }}
+        onPointerUp={handleTriggerPointerUp}
+        onClick={handleTriggerClick}
         ref={triggerRef}
         type="button"
         data-active={isOpen}
@@ -156,13 +171,7 @@ export default function DropdownSelector({
           value={props.value}
           inertWorkaround={props.inertWorkaround}
         >
-          <MenuList
-            value={props.value}
-            onChange={(v) => {
-              onChange(v)
-              setIsOpen(false)
-            }}
-          >
+          <MenuList value={props.value} onChange={handleSelect}>
             {props.children}
           </MenuList>
         </DropdownPopover>


### PR DESCRIPTION
## やったこと

- apple pencilでDropdownSelectorのメニューがタップできないので修正した
- safariではapple pencilでタップしたときonclickではなくonPointerDownしか発行されないためイベントを追加した

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
