### PR TITLE
fix: workaround css external import

### DIFF
--- a/packages/react/src/components/Icon/index.tsx
+++ b/packages/react/src/components/Icon/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 
 import '@charcoal-ui/icons'
-import '@charcoal-ui/icons/css/icon.css'
+// tmp fix for https://github.com/rolldown/tsdown/pull/981
+import '../../../../icons/css/icon.css'
 import { calcActualSize } from '@charcoal-ui/icons'
 import type { IconSizing, PixivIcon, Props } from '@charcoal-ui/icons'
 


### PR DESCRIPTION
## やったこと

- workaround https://github.com/rolldown/tsdown/issues/959

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
