### PR TITLE
カルーセルを children で受け取る sandbox 互換 API に変更

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -469,7 +469,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -478,7 +478,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -487,7 +487,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -496,7 +496,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -505,7 +505,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -514,7 +514,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>
@@ -627,7 +627,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -636,7 +636,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -645,7 +645,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -654,7 +654,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -663,7 +663,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -672,7 +672,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -681,7 +681,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -690,7 +690,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -699,7 +699,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -708,7 +708,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -717,7 +717,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -726,7 +726,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -735,7 +735,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -744,7 +744,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -753,7 +753,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -762,7 +762,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -771,7 +771,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -780,7 +780,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -789,7 +789,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -798,7 +798,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -985,7 +985,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -994,7 +994,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1003,7 +1003,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1012,7 +1012,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1021,7 +1021,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1030,7 +1030,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>
@@ -1143,7 +1143,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -1152,7 +1152,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -1161,7 +1161,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -1170,7 +1170,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -1179,7 +1179,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -1188,7 +1188,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -1197,7 +1197,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -1206,7 +1206,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -1215,7 +1215,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -1224,7 +1224,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -1233,7 +1233,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -1242,7 +1242,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -1251,7 +1251,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -1260,7 +1260,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -1269,7 +1269,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -1278,7 +1278,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -1287,7 +1287,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -1296,7 +1296,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -1305,7 +1305,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -1314,7 +1314,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -1501,7 +1501,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1510,7 +1510,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1519,7 +1519,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1528,7 +1528,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1537,7 +1537,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1546,7 +1546,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>
@@ -1659,7 +1659,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               1
             </div>
@@ -1668,7 +1668,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               2
             </div>
@@ -1677,7 +1677,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               3
             </div>
@@ -1686,7 +1686,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               4
             </div>
@@ -1695,7 +1695,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               5
             </div>
@@ -1704,7 +1704,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               6
             </div>
@@ -1713,7 +1713,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               7
             </div>
@@ -1722,7 +1722,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               8
             </div>
@@ -1731,7 +1731,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               9
             </div>
@@ -1740,7 +1740,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               10
             </div>
@@ -1877,7 +1877,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1886,7 +1886,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1895,7 +1895,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1904,7 +1904,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1913,7 +1913,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -1922,7 +1922,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>
@@ -2037,7 +2037,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -2046,7 +2046,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -2055,7 +2055,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -2064,7 +2064,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -2073,7 +2073,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -2082,7 +2082,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
         </div>
@@ -2195,7 +2195,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -2204,7 +2204,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -2213,7 +2213,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -2222,7 +2222,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -2231,7 +2231,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -2240,7 +2240,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -2249,7 +2249,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -2258,7 +2258,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -2267,7 +2267,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -2276,7 +2276,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -2285,7 +2285,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -2294,7 +2294,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -2303,7 +2303,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -2312,7 +2312,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -2321,7 +2321,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -2330,7 +2330,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -2339,7 +2339,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -2348,7 +2348,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -2357,7 +2357,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -2366,7 +2366,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -2551,7 +2551,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -2560,7 +2560,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -2569,7 +2569,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -2578,7 +2578,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -2587,7 +2587,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -2596,7 +2596,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -2605,7 +2605,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -2614,7 +2614,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -2623,7 +2623,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -2632,7 +2632,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -2641,7 +2641,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -2650,7 +2650,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -2659,7 +2659,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -2668,7 +2668,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -2677,7 +2677,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -2686,7 +2686,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -2695,7 +2695,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -2704,7 +2704,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -2713,7 +2713,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -2722,7 +2722,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -2909,7 +2909,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -2918,7 +2918,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -2927,7 +2927,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -2936,7 +2936,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -2945,7 +2945,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -2954,7 +2954,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>
@@ -3069,7 +3069,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -3078,7 +3078,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -3087,7 +3087,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -3096,7 +3096,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -3105,7 +3105,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
           <div
@@ -3114,7 +3114,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 100%; height: 100%;"
             />
           </div>
         </div>
@@ -3229,7 +3229,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -3238,7 +3238,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -3247,7 +3247,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -3256,7 +3256,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -3265,7 +3265,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
           <div
@@ -3274,7 +3274,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="width: 100%; height: 100%; object-fit: cover; display: block;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
             />
           </div>
         </div>

--- a/packages/react/src/components/Carousel/MIGRATION.md
+++ b/packages/react/src/components/Carousel/MIGRATION.md
@@ -6,7 +6,8 @@
 ## 移行の要点
 
 - **import 差し替えがほぼ唯一の必須変更**。`children` はそのまま渡せる（ただし自前の
-  `flex` ラッパーは外して **1 スライド 1 直接子要素**にする）。
+  `flex` ラッパーは外して **1 スライド 1 直接子要素**にし、ラッパーの `gap` は
+  各スライドの `margin` に置き換える）。
 - `onScroll` / `onResize` / `onScrollStateChange` / `ref`（`resetScroll()`）/ `defaultScroll` /
   `hasGradient` は **sandbox と同じシグネチャ**で利用できる（drop-in 互換）。
 - `scrollAmountCoef` は `scrollStep`（関数も可）に名称変更。`fadeInGradient` / `buttonOffset` 系 /
@@ -34,9 +35,10 @@
 
 ## 子要素: `children`（そのまま渡せる）
 
-sandbox と同じく子ノードを直接渡す。ただし sandbox では自前で `flex` ラッパーや `gap` を
-組んでいたが、新版はレイアウト（`gap: 24px`、S は `0`）をコンポーネント側 CSS が持ち、
-**直接子要素 1 つを 1 スライド**として数えるので、ラッパーは外す。
+sandbox と同じく子ノードを直接渡し、スライドの寸法・間隔も sandbox 同様に利用者が持つ
+（コンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ）。
+ただし**直接子要素 1 つを 1 スライド**として数えるので、`flex` ラッパーは外し、
+`gap` の代わりに各スライドの `margin` などで間隔を注入する。
 
 ```diff
 - <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollAmountCoef={0.75}>
@@ -48,7 +50,7 @@ sandbox と同じく子ノードを直接渡す。ただし sandbox では自前
 - </Carousel>
 + <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollStep={0.75}>
 +   {items.map((i) => (
-+     <Slide key={i} />
++     <Slide key={i} style={{ marginInlineEnd: 8 }} />
 +   ))}
 + </Carousel>
 ```
@@ -65,7 +67,7 @@ sandbox と同じく子ノードを直接渡す。ただし sandbox では自前
 | `hasGradient`                                     | `hasGradient`（既定 `false`）               | 実装が mask → 背景色オーバーレイに変更                                                                    |
 | `fadeInGradient`                                  | （廃止）                                    | 常にオーバーレイ式フェード                                                                                |
 | `buttonOffset` / `buttonPadding` / `bottomOffset` | （廃止）                                    | ボタン配置は CSS グリッド（左右 72px ゾーン）に固定                                                       |
-| `centerItems`                                     | （廃止）                                    | レイアウトは `flex` + `gap` 固定                                                                          |
+| `centerItems`                                     | （廃止）                                    | スライドの寸法・間隔は children 側で注入する（sandbox 同様）                                              |
 | `onScroll(left)`                                  | `onScroll(left)`                            | ✅ そのまま対応（scroll で発火）                                                                          |
 | `onResize(width)`                                 | `onResize(width)`                           | ✅ scroller 幅の変化で発火                                                                                |
 | `onScrollStateChange(canScroll)`                  | `onScrollStateChange(canScroll)`            | ✅ `canPrev \|\| canNext` の変化で発火                                                                    |

--- a/packages/react/src/components/Carousel/MIGRATION.md
+++ b/packages/react/src/components/Carousel/MIGRATION.md
@@ -5,7 +5,8 @@
 
 ## 移行の要点
 
-- **import 差し替え + `children` → `items` がほぼ唯一の必須変更**。
+- **import 差し替えがほぼ唯一の必須変更**。`children` はそのまま渡せる（ただし自前の
+  `flex` ラッパーは外して **1 スライド 1 直接子要素**にする）。
 - `onScroll` / `onResize` / `onScrollStateChange` / `ref`（`resetScroll()`）/ `defaultScroll` /
   `hasGradient` は **sandbox と同じシグネチャ**で利用できる（drop-in 互換）。
 - `scrollAmountCoef` は `scrollStep`（関数も可）に名称変更。`fadeInGradient` / `buttonOffset` 系 /
@@ -17,7 +18,7 @@
 |                | sandbox (`@charcoal-ui/react-sandbox`) | react (`@charcoal-ui/react`)                    |
 | -------------- | -------------------------------------- | ----------------------------------------------- |
 | スクロール     | react-spring による JS アニメーション  | ネイティブ overflow + CSS `scroll-snap`         |
-| 子要素         | `children`（任意のノード）             | `items: { id; children }[]`                     |
+| 子要素         | `children`（任意のノード）             | `children`（1 直接子要素 = 1 スライド）         |
 | インジケーター | なし                                   | CSS `::scroll-marker` / JS フォールバックの dot |
 | スタイル       | styled-components                      | プレーン CSS（`index.css`）                     |
 
@@ -28,14 +29,14 @@
 + import { Carousel } from '@charcoal-ui/react'
 ```
 
-公開型: `CarouselProps` / `CarouselItem` / `CarouselHandlerRef` / `ScrollAlign` / `ScrollStep` /
+公開型: `CarouselProps` / `CarouselHandlerRef` / `ScrollAlign` / `ScrollStep` /
 `ScrollStepContext` / `ScrollSnap` / `ScrollSnapType` / `ScrollSnapAlign`。
 
-## 子要素: `children` → `items`
+## 子要素: `children`（そのまま渡せる）
 
-最大の変更点。子ノードを直接渡す形から、`id` 付きの配列に変える。
-sandbox では自前で `flex` ラッパーや `gap` を組んでいたが、新版はレイアウト（`gap: 24px`、S は `0`）を
-コンポーネント側 CSS が持つので、**ラッパーで囲まず 1 スライド 1 要素**で渡す。
+sandbox と同じく子ノードを直接渡す。ただし sandbox では自前で `flex` ラッパーや `gap` を
+組んでいたが、新版はレイアウト（`gap: 24px`、S は `0`）をコンポーネント側 CSS が持ち、
+**直接子要素 1 つを 1 スライド**として数えるので、ラッパーは外す。
 
 ```diff
 - <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollAmountCoef={0.75}>
@@ -45,38 +46,36 @@ sandbox では自前で `flex` ラッパーや `gap` を組んでいたが、新
 -     ))}
 -   </div>
 - </Carousel>
-+ <Carousel
-+   size="M"
-+   hasGradient
-+   defaultScroll={{ align: 'center' }}
-+   scrollStep={0.75}
-+   items={items.map((i) => ({ id: String(i), children: <Slide /> }))}
-+ />
++ <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollStep={0.75}>
++   {items.map((i) => (
++     <Slide key={i} />
++   ))}
++ </Carousel>
 ```
 
-`id` はキー安定化（再レンダー・スクロール命令の宛先識別）に使うので、配列内で一意かつ安定した値にする。
+`key` は再レンダー時のスライド識別に使うので、一意かつ安定した値にする。
 
 ## props 対応表
 
-| sandbox                                           | react                                          | 備考                                                                                                      |
-| ------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `children`                                        | `items: { id: string; children: ReactNode }[]` | 上記参照                                                                                                  |
-| `scrollAmountCoef`（既定 `0.75`）                 | `scrollStep`（既定 `0.75`）                    | `number`（表示幅比）に加え `(ctx) => px` の関数も渡せる                                                   |
-| `defaultScroll: { align, offset }`                | `defaultScroll: { align, offset }`             | `align` は `'left' \| 'center' \| 'right'`。ほぼ同等                                                      |
-| `hasGradient`                                     | `hasGradient`（既定 `false`）                  | 実装が mask → 背景色オーバーレイに変更                                                                    |
-| `fadeInGradient`                                  | （廃止）                                       | 常にオーバーレイ式フェード                                                                                |
-| `buttonOffset` / `buttonPadding` / `bottomOffset` | （廃止）                                       | ボタン配置は CSS グリッド（左右 72px ゾーン）に固定                                                       |
-| `centerItems`                                     | （廃止）                                       | レイアウトは `flex` + `gap` 固定                                                                          |
-| `onScroll(left)`                                  | `onScroll(left)`                               | ✅ そのまま対応（scroll で発火）                                                                          |
-| `onResize(width)`                                 | `onResize(width)`                              | ✅ scroller 幅の変化で発火                                                                                |
-| `onScrollStateChange(canScroll)`                  | `onScrollStateChange(canScroll)`               | ✅ `canPrev \|\| canNext` の変化で発火                                                                    |
-| `ref`（`CarouselHandlerRef.resetScroll()`）       | `ref`（`CarouselHandlerRef.resetScroll()`）    | ✅ `forwardRef` で対応。`defaultScroll` の初期位置へ戻す                                                  |
-| —                                                 | `size: 'S' \| 'M'`（既定 `'M'`）               | 新規。`S` は 1 枚全幅 + `mandatory` スナップ                                                              |
-| —                                                 | `navigationButtons?: boolean`                  | 既定は `size === 'M'`                                                                                     |
-| —                                                 | `indicator?: boolean`                          | 既定は `size === 'S'`                                                                                     |
-| —                                                 | `fullWidth?: boolean`（既定 `false`）          | `100vw` 表示                                                                                              |
-| —                                                 | `className?: string`                           | ルートに付与                                                                                              |
-| —                                                 | `scrollSnap?: { type?; align? }`               | `type`: `none`/`proximity`/`mandatory`、`align`: `center`/`start`。未指定で M=none / S=mandatory / center |
+| sandbox                                           | react                                       | 備考                                                                                                      |
+| ------------------------------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `children`                                        | `children`                                  | ✅ そのまま対応（1 直接子要素 = 1 スライド。ラッパーは外す。上記参照）                                    |
+| `scrollAmountCoef`（既定 `0.75`）                 | `scrollStep`（既定 `0.75`）                 | `number`（表示幅比）に加え `(ctx) => px` の関数も渡せる                                                   |
+| `defaultScroll: { align, offset }`                | `defaultScroll: { align, offset }`          | `align` は `'left' \| 'center' \| 'right'`。ほぼ同等                                                      |
+| `hasGradient`                                     | `hasGradient`（既定 `false`）               | 実装が mask → 背景色オーバーレイに変更                                                                    |
+| `fadeInGradient`                                  | （廃止）                                    | 常にオーバーレイ式フェード                                                                                |
+| `buttonOffset` / `buttonPadding` / `bottomOffset` | （廃止）                                    | ボタン配置は CSS グリッド（左右 72px ゾーン）に固定                                                       |
+| `centerItems`                                     | （廃止）                                    | レイアウトは `flex` + `gap` 固定                                                                          |
+| `onScroll(left)`                                  | `onScroll(left)`                            | ✅ そのまま対応（scroll で発火）                                                                          |
+| `onResize(width)`                                 | `onResize(width)`                           | ✅ scroller 幅の変化で発火                                                                                |
+| `onScrollStateChange(canScroll)`                  | `onScrollStateChange(canScroll)`            | ✅ `canPrev \|\| canNext` の変化で発火                                                                    |
+| `ref`（`CarouselHandlerRef.resetScroll()`）       | `ref`（`CarouselHandlerRef.resetScroll()`） | ✅ `forwardRef` で対応。`defaultScroll` の初期位置へ戻す                                                  |
+| —                                                 | `size: 'S' \| 'M'`（既定 `'M'`）            | 新規。`S` は 1 枚全幅 + `mandatory` スナップ                                                              |
+| —                                                 | `navigationButtons?: boolean`               | 既定は `size === 'M'`                                                                                     |
+| —                                                 | `indicator?: boolean`                       | 既定は `size === 'S'`                                                                                     |
+| —                                                 | `fullWidth?: boolean`（既定 `false`）       | `100vw` 表示                                                                                              |
+| —                                                 | `className?: string`                        | ルートに付与                                                                                              |
+| —                                                 | `scrollSnap?: { type?; align? }`            | `type`: `none`/`proximity`/`mandatory`、`align`: `center`/`start`。未指定で M=none / S=mandatory / center |
 
 ## 挙動の変更（移行時に確認すること）
 
@@ -101,17 +100,18 @@ sandbox では自前で `flex` ラッパーや `gap` を組んでいたが、新
 
 ```tsx
 // 表示幅の比率（sandbox の scrollAmountCoef 相当）
-<Carousel items={items} scrollStep={0.5} />
+<Carousel scrollStep={0.5}>{slides}</Carousel>
 
 // 進む px を直接返す（端は残り全部、など）
 <Carousel
-  items={items}
   scrollStep={({ clientWidth, scrollWidth, scrollLeft, direction }) =>
     direction === 'next'
       ? Math.min(clientWidth * 0.8, scrollWidth - clientWidth - scrollLeft)
       : Math.min(clientWidth * 0.8, scrollLeft)
   }
-/>
+>
+  {slides}
+</Carousel>
 ```
 
 戻り値は「進む量の絶対値（px）」。符号（prev / next）はコンポーネント側で付与する。

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -12,10 +12,12 @@
   position: relative;
 }
 
+/* スライド間隔は所有しない（sandbox 同様、利用者が children 側で注入する）。
+   このコンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ。 */
+
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: 24px;
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;
@@ -30,10 +32,6 @@
 
 .charcoal-carousel__scroller[data-focus-visible] {
   box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
-}
-
-.charcoal-carousel[data-size='S'] .charcoal-carousel__scroller {
-  gap: 0;
 }
 
 /* スクロールスナップ type は prop（scrollSnap.type）で scroller に出し分ける。

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -12,10 +12,11 @@
   position: relative;
 }
 
+/* スライド間隔は所有しない（sandbox 同様、利用者が children 側で注入する）。
+   このコンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ。 */
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: 24px;
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;
@@ -30,10 +31,6 @@
   &[data-focus-visible] {
     box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
   }
-}
-
-.charcoal-carousel[data-size='S'] .charcoal-carousel__scroller {
-  gap: 0;
 }
 
 /* スクロールスナップ type は prop（scrollSnap.type）で scroller に出し分ける。

--- a/packages/react/src/components/Carousel/index.story.tsx
+++ b/packages/react/src/components/Carousel/index.story.tsx
@@ -15,13 +15,15 @@ const sampleImages = Array.from({ length: 6 }, (_, i) => (
   />
 ))
 
-// 横幅が確定したスロット（defaultScroll の初期位置計算と 0.75 ページ送りを確認するため）
+// 横幅が確定したスロット（defaultScroll の初期位置計算と 0.75 ページ送りを確認するため）。
+// スライド間隔はコンポーネントが所有しないので、利用者側の margin で注入する。
 const numberedSlides = Array.from({ length: 20 }, (_, i) => (
   <div
     key={`num-${i + 1}`}
     style={{
       width: 200,
       height: 120,
+      marginInlineEnd: 24,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -127,6 +129,7 @@ const darkTiles = Array.from({ length: 10 }, (_, i) => (
     style={{
       width: 220,
       height: 140,
+      marginInlineEnd: 24,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/packages/react/src/components/Carousel/index.story.tsx
+++ b/packages/react/src/components/Carousel/index.story.tsx
@@ -1,8 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react-vite'
-import Carousel, { type CarouselItem } from '.'
+import Carousel from '.'
 
-const sampleImage = (
+const sampleImages = Array.from({ length: 6 }, (_, i) => (
   <img
+    key={`item-${i + 1}`}
     src="/carousel-sample.png"
     alt="サンプル画像"
     style={{
@@ -12,34 +13,27 @@ const sampleImage = (
       display: 'block',
     }}
   />
-)
-
-const items: CarouselItem[] = Array.from({ length: 6 }, (_, i) => ({
-  id: `item-${i + 1}`,
-  children: sampleImage,
-}))
+))
 
 // 横幅が確定したスロット（defaultScroll の初期位置計算と 0.75 ページ送りを確認するため）
-const numberedItems: CarouselItem[] = Array.from({ length: 20 }, (_, i) => ({
-  id: `num-${i + 1}`,
-  children: (
-    <div
-      style={{
-        width: 200,
-        height: 120,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: i % 2 === 0 ? '#cfe3ff' : '#ffe3cf',
-        borderRadius: 8,
-        font: 'bold 32px sans-serif',
-        color: '#333',
-      }}
-    >
-      {i + 1}
-    </div>
-  ),
-}))
+const numberedSlides = Array.from({ length: 20 }, (_, i) => (
+  <div
+    key={`num-${i + 1}`}
+    style={{
+      width: 200,
+      height: 120,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: i % 2 === 0 ? '#cfe3ff' : '#ffe3cf',
+      borderRadius: 8,
+      font: 'bold 32px sans-serif',
+      color: '#333',
+    }}
+  >
+    {i + 1}
+  </div>
+))
 
 export default {
   title: 'react/Carousel',
@@ -48,13 +42,14 @@ export default {
     layout: 'padded',
   },
   args: {
-    items,
+    children: sampleImages,
     size: 'M',
     hasGradient: false,
     fullWidth: false,
     scrollStep: 0.75,
   },
   argTypes: {
+    children: { control: false },
     size: {
       control: { type: 'radio' },
       options: ['S', 'M'],
@@ -101,42 +96,52 @@ export const IndicatorOnSizeM: StoryObj<typeof Carousel> = {
 
 // 横幅が確定したスロット（番号付き）
 export const DefaultScrollCenter: StoryObj<typeof Carousel> = {
-  args: { size: 'M', items: numberedItems, defaultScroll: { align: 'center' } },
+  args: {
+    size: 'M',
+    children: numberedSlides,
+    defaultScroll: { align: 'center' },
+  },
 }
 
 export const DefaultScrollRight: StoryObj<typeof Carousel> = {
-  args: { size: 'M', items: numberedItems, defaultScroll: { align: 'right' } },
+  args: {
+    size: 'M',
+    children: numberedSlides,
+    defaultScroll: { align: 'right' },
+  },
 }
 
 // 遅延読み込み画像（マウント時に幅が未確定）でも初期位置が効くことの確認
 export const DefaultScrollCenterAsyncImages: StoryObj<typeof Carousel> = {
-  args: { size: 'M', items, defaultScroll: { align: 'center' } },
+  args: {
+    size: 'M',
+    children: sampleImages,
+    defaultScroll: { align: 'center' },
+  },
 }
 
 // 白フェードが見えることの確認用（暗色コンテンツなら白フェードが明確に出る）
-const darkTiles: CarouselItem[] = Array.from({ length: 10 }, (_, i) => ({
-  id: `dark-${i + 1}`,
-  children: (
-    <div
-      style={{
-        width: 220,
-        height: 140,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: '#2a3b8f',
-        color: '#fff',
-        borderRadius: 4,
-        font: 'bold 28px sans-serif',
-      }}
-    >
-      {i + 1}
-    </div>
-  ),
-}))
+const darkTiles = Array.from({ length: 10 }, (_, i) => (
+  <div
+    key={`dark-${i + 1}`}
+    style={{
+      width: 220,
+      height: 140,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: '#2a3b8f',
+      color: '#fff',
+      borderRadius: 4,
+      font: 'bold 28px sans-serif',
+    }}
+  >
+    {i + 1}
+  </div>
+))
 
 export const GradientOnDarkContent: StoryObj<typeof Carousel> = {
-  args: { size: 'M', hasGradient: true, items: darkTiles },
+  args: { size: 'M', hasGradient: true, children: darkTiles },
 }
 
 // scrollStep に関数を渡してフル制御する例（送り量を clientWidth - 48px に固定）。
@@ -144,7 +149,7 @@ export const GradientOnDarkContent: StoryObj<typeof Carousel> = {
 export const ScrollStepFunction: StoryObj<typeof Carousel> = {
   args: {
     size: 'M',
-    items: numberedItems,
+    children: numberedSlides,
     scrollStep: ({ clientWidth }) => clientWidth - 48,
   },
 }
@@ -153,7 +158,7 @@ export const ScrollStepFunction: StoryObj<typeof Carousel> = {
 export const ScrollSnapPerItem: StoryObj<typeof Carousel> = {
   args: {
     size: 'M',
-    items: numberedItems,
+    children: numberedSlides,
     scrollSnap: { type: 'mandatory', align: 'start' },
   },
 }

--- a/packages/react/src/components/Carousel/index.story.tsx
+++ b/packages/react/src/components/Carousel/index.story.tsx
@@ -1,19 +1,30 @@
 import { Meta, StoryObj } from '@storybook/react-vite'
+import type { CSSProperties } from 'react'
 import Carousel from '.'
 
-const sampleImages = Array.from({ length: 6 }, (_, i) => (
-  <img
-    key={`item-${i + 1}`}
-    src="/carousel-sample.png"
-    alt="サンプル画像"
-    style={{
-      width: '100%',
-      height: '100%',
-      objectFit: 'cover',
-      display: 'block',
-    }}
-  />
-))
+const makeSampleImages = (style: CSSProperties) =>
+  Array.from({ length: 6 }, (_, i) => (
+    <img
+      key={`item-${i + 1}`}
+      src="/carousel-sample.png"
+      alt="サンプル画像"
+      style={{
+        objectFit: 'cover',
+        display: 'block',
+        ...style,
+      }}
+    />
+  ))
+
+// M 用: スライド間隔はコンポーネントが所有しないので、利用者側の margin で注入する。
+// width: 100% と margin の併用はラッパーとの循環サイズ解決で間隔が潰れるため、明示サイズにする。
+const spacedImages = makeSampleImages({
+  width: 280,
+  height: 210,
+  marginInlineEnd: 24,
+})
+// S 用: 1 枚全幅ページングのため間隔なし
+const fullWidthImages = makeSampleImages({ width: '100%', height: '100%' })
 
 // 横幅が確定したスロット（defaultScroll の初期位置計算と 0.75 ページ送りを確認するため）。
 // スライド間隔はコンポーネントが所有しないので、利用者側の margin で注入する。
@@ -44,7 +55,7 @@ export default {
     layout: 'padded',
   },
   args: {
-    children: sampleImages,
+    children: spacedImages,
     size: 'M',
     hasGradient: false,
     fullWidth: false,
@@ -77,7 +88,7 @@ export const SizeM: StoryObj<typeof Carousel> = {
 }
 
 export const SizeS: StoryObj<typeof Carousel> = {
-  args: { size: 'S' },
+  args: { size: 'S', children: fullWidthImages },
 }
 
 export const WithGradient: StoryObj<typeof Carousel> = {
@@ -89,7 +100,7 @@ export const FullWidth: StoryObj<typeof Carousel> = {
 }
 
 export const NavigationButtonsOnSizeS: StoryObj<typeof Carousel> = {
-  args: { size: 'S', navigationButtons: true },
+  args: { size: 'S', navigationButtons: true, children: fullWidthImages },
 }
 
 export const IndicatorOnSizeM: StoryObj<typeof Carousel> = {
@@ -117,7 +128,7 @@ export const DefaultScrollRight: StoryObj<typeof Carousel> = {
 export const DefaultScrollCenterAsyncImages: StoryObj<typeof Carousel> = {
   args: {
     size: 'M',
-    children: sampleImages,
+    children: spacedImages,
     defaultScroll: { align: 'center' },
   },
 }

--- a/packages/react/src/components/Carousel/index.test.tsx
+++ b/packages/react/src/components/Carousel/index.test.tsx
@@ -2,12 +2,13 @@ import { createRef } from 'react'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { renderToString } from 'react-dom/server'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
-import Carousel, { type CarouselItem, type CarouselHandlerRef } from '.'
+import Carousel, { type CarouselHandlerRef } from '.'
 
-const items: CarouselItem[] = Array.from({ length: 6 }, (_, i) => ({
-  id: `item-${i}`,
-  children: <div data-testid={`slide-${i}`}>Slide {i}</div>,
-}))
+const slides = Array.from({ length: 6 }, (_, i) => (
+  <div key={`item-${i}`} data-testid={`slide-${i}`}>
+    Slide {i}
+  </div>
+))
 
 function mockScrollerGeometry(
   el: HTMLElement,
@@ -77,14 +78,14 @@ function fireIntersect(el: Element) {
 describe('Carousel', () => {
   describe('rendering', () => {
     it('renders all items', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       for (let i = 0; i < 6; i++) {
         expect(screen.getByTestId(`slide-${i}`)).toBeInTheDocument()
       }
     })
 
     it('has carousel ARIA attributes', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const region = screen.getByRole('region')
       expect(region).toHaveAttribute('aria-roledescription', 'carousel')
       expect(region).toHaveAttribute('aria-label', 'Carousel')
@@ -93,7 +94,7 @@ describe('Carousel', () => {
 
   describe('Size M (default)', () => {
     it('shows navigation buttons', () => {
-      render(<Carousel items={items} size="M" />)
+      render(<Carousel size="M">{slides}</Carousel>)
       expect(
         screen.getByRole('button', { name: 'Previous' }),
       ).toBeInTheDocument()
@@ -101,7 +102,7 @@ describe('Carousel', () => {
     })
 
     it('hides indicator by default', () => {
-      const { container } = render(<Carousel items={items} size="M" />)
+      const { container } = render(<Carousel size="M">{slides}</Carousel>)
       const indicator = container.querySelector('.charcoal-carousel__indicator')
       expect(indicator).toHaveAttribute('data-visible', 'false')
     })
@@ -109,7 +110,7 @@ describe('Carousel', () => {
 
   describe('Size S', () => {
     it('hides navigation buttons by default', () => {
-      const { container } = render(<Carousel items={items} size="S" />)
+      const { container } = render(<Carousel size="S">{slides}</Carousel>)
       const nav = container.querySelector('.charcoal-carousel__navigation')
       expect(nav).toHaveAttribute('data-visible', 'false')
     })
@@ -117,13 +118,13 @@ describe('Carousel', () => {
 
   describe('navigation button state', () => {
     it('disables prev button at scroll start', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const prev = screen.getByRole('button', { name: 'Previous' })
       expect(prev).toBeDisabled()
     })
 
     it('enables next button when scrollable content exists', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 0 })
       act(() => {
@@ -136,7 +137,7 @@ describe('Carousel', () => {
 
   describe('scrollByStep (0.75x viewport)', () => {
     it('calls scrollBy with 0.75x viewport width on next button click', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
       act(() => {
@@ -156,7 +157,7 @@ describe('Carousel', () => {
     })
 
     it('calls scrollBy with negative 0.75x on prev button click', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 400 })
       act(() => {
@@ -176,7 +177,7 @@ describe('Carousel', () => {
     })
 
     it('respects custom scrollStep ratio (number)', () => {
-      render(<Carousel items={items} scrollStep={0.5} />)
+      render(<Carousel scrollStep={0.5}>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
       act(() => {
@@ -199,7 +200,7 @@ describe('Carousel', () => {
       const scrollStep = vi.fn(
         ({ clientWidth }: { clientWidth: number }) => clientWidth - 48,
       )
-      render(<Carousel items={items} scrollStep={scrollStep} />)
+      render(<Carousel scrollStep={scrollStep}>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
       act(() => {
@@ -228,7 +229,7 @@ describe('Carousel', () => {
 
   describe('keyboard navigation', () => {
     it('scrolls next by 0.75x viewport on ArrowRight', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
       act(() => {
@@ -247,7 +248,7 @@ describe('Carousel', () => {
     })
 
     it('scrolls prev by negative 0.75x viewport on ArrowLeft', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 400 })
       act(() => {
@@ -266,7 +267,7 @@ describe('Carousel', () => {
     })
 
     it('ignores unrelated keys', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
 
@@ -284,7 +285,7 @@ describe('Carousel', () => {
       // jsdom には scrollIntoView が無いのでモックを定義する。
       const scrollIntoView = vi.fn()
       Element.prototype.scrollIntoView = scrollIntoView
-      const { container } = render(<Carousel items={items} size="S" />)
+      const { container } = render(<Carousel size="S">{slides}</Carousel>)
 
       const dots = container.querySelectorAll(
         '.charcoal-carousel__indicator__item',
@@ -311,7 +312,9 @@ describe('Carousel', () => {
     it('item が中央に入ると activeIndex が更新され indicator に反映される', () => {
       const restore = installIOMock()
       const { container } = render(
-        <Carousel items={items} size="M" indicator />,
+        <Carousel size="M" indicator>
+          {slides}
+        </Carousel>,
       )
       const itemEls = container.querySelectorAll('.charcoal-carousel__item')
       act(() => {
@@ -327,7 +330,7 @@ describe('Carousel', () => {
 
   describe('scroll-state data attributes (mask)', () => {
     it('reflects canPrev/canNext on the root element', () => {
-      const { container } = render(<Carousel items={items} hasGradient />)
+      const { container } = render(<Carousel hasGradient>{slides}</Carousel>)
       const root = container.querySelector('.charcoal-carousel')
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
@@ -339,7 +342,7 @@ describe('Carousel', () => {
     })
 
     it('marks data-can-prev false at the start edge', () => {
-      const { container } = render(<Carousel items={items} hasGradient />)
+      const { container } = render(<Carousel hasGradient>{slides}</Carousel>)
       const root = container.querySelector('.charcoal-carousel')
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 0 })
@@ -378,26 +381,25 @@ describe('Carousel', () => {
     })
 
     it('defaults to the left edge (0)', () => {
-      render(<Carousel items={items} />)
+      render(<Carousel>{slides}</Carousel>)
       expect(lastSetLeft).toBe(0)
     })
 
     it('centers the content when align=center (maxScroll / 2)', () => {
-      render(<Carousel items={items} defaultScroll={{ align: 'center' }} />)
+      render(<Carousel defaultScroll={{ align: 'center' }}>{slides}</Carousel>)
       expect(lastSetLeft).toBe(800)
     })
 
     it('aligns to the right edge when align=right (maxScroll)', () => {
-      render(<Carousel items={items} defaultScroll={{ align: 'right' }} />)
+      render(<Carousel defaultScroll={{ align: 'right' }}>{slides}</Carousel>)
       expect(lastSetLeft).toBe(1600)
     })
 
     it('applies offset from the base position', () => {
       render(
-        <Carousel
-          items={items}
-          defaultScroll={{ align: 'left', offset: 100 }}
-        />,
+        <Carousel defaultScroll={{ align: 'left', offset: 100 }}>
+          {slides}
+        </Carousel>,
       )
       expect(lastSetLeft).toBe(100)
     })
@@ -444,7 +446,7 @@ describe('Carousel', () => {
     })
 
     it('re-applies the initial position when content width settles later', () => {
-      render(<Carousel items={items} defaultScroll={{ align: 'right' }} />)
+      render(<Carousel defaultScroll={{ align: 'right' }}>{slides}</Carousel>)
       // at mount the content is not laid out yet (maxScroll 0) -> right -> 0
       expect(lastSetLeft).toBe(0)
 
@@ -460,7 +462,7 @@ describe('Carousel', () => {
     })
 
     it('stops re-applying once the user interacts', () => {
-      render(<Carousel items={items} defaultScroll={{ align: 'right' }} />)
+      render(<Carousel defaultScroll={{ align: 'right' }}>{slides}</Carousel>)
 
       // user interacts (pointerdown on the scroller) before the content settles
       fireEvent.pointerDown(getScroller())
@@ -476,16 +478,31 @@ describe('Carousel', () => {
     })
   })
 
+  describe('children (sandbox-compatible API)', () => {
+    it('renders each direct child as one slide', () => {
+      const { container } = render(<Carousel>{slides}</Carousel>)
+      expect(
+        container.querySelectorAll('.charcoal-carousel__item'),
+      ).toHaveLength(6)
+    })
+  })
+
   describe('props override defaults', () => {
     it('shows indicator on Size M when prop is true', () => {
       const { container } = render(
-        <Carousel items={items} size="M" indicator />,
+        <Carousel size="M" indicator>
+          {slides}
+        </Carousel>,
       )
       expect(container.querySelector("[data-indicator='true']")).toBeTruthy()
     })
 
     it('shows navigation on Size S when prop is true', () => {
-      render(<Carousel items={items} size="S" navigationButtons />)
+      render(
+        <Carousel size="S" navigationButtons>
+          {slides}
+        </Carousel>,
+      )
       const nav = document.querySelector('.charcoal-carousel__navigation')
       expect(nav).toHaveAttribute('data-visible', 'true')
     })
@@ -493,12 +510,12 @@ describe('Carousel', () => {
 
   describe('variant data attributes', () => {
     it('sets gradient data attribute', () => {
-      const { container } = render(<Carousel items={items} hasGradient />)
+      const { container } = render(<Carousel hasGradient>{slides}</Carousel>)
       expect(container.querySelector("[data-has-gradient='true']")).toBeTruthy()
     })
 
     it('sets full-width data attribute', () => {
-      const { container } = render(<Carousel items={items} fullWidth />)
+      const { container } = render(<Carousel fullWidth>{slides}</Carousel>)
       expect(container.querySelector("[data-full-width='true']")).toBeTruthy()
     })
   })
@@ -507,30 +524,32 @@ describe('Carousel', () => {
     const getRegion = () => screen.getByRole('region')
 
     it('defaults to none / center on Size M (sandbox 同等の 0.75)', () => {
-      render(<Carousel items={items} size="M" />)
+      render(<Carousel size="M">{slides}</Carousel>)
       expect(getRegion()).toHaveAttribute('data-scroll-snap-type', 'none')
       expect(getRegion()).toHaveAttribute('data-scroll-snap-align', 'center')
     })
 
     it('defaults to mandatory on Size S', () => {
-      render(<Carousel items={items} size="S" />)
+      render(<Carousel size="S">{slides}</Carousel>)
       expect(getRegion()).toHaveAttribute('data-scroll-snap-type', 'mandatory')
     })
 
     it('overrides type per prop (item-ごと mandatory)', () => {
       render(
-        <Carousel items={items} size="M" scrollSnap={{ type: 'mandatory' }} />,
+        <Carousel size="M" scrollSnap={{ type: 'mandatory' }}>
+          {slides}
+        </Carousel>,
       )
       expect(getRegion()).toHaveAttribute('data-scroll-snap-type', 'mandatory')
     })
 
     it('overrides align per prop', () => {
-      render(<Carousel items={items} scrollSnap={{ align: 'start' }} />)
+      render(<Carousel scrollSnap={{ align: 'start' }}>{slides}</Carousel>)
       expect(getRegion()).toHaveAttribute('data-scroll-snap-align', 'start')
     })
 
     it('supports disabling snap (none)', () => {
-      render(<Carousel items={items} scrollSnap={{ type: 'none' }} />)
+      render(<Carousel scrollSnap={{ type: 'none' }}>{slides}</Carousel>)
       expect(getRegion()).toHaveAttribute('data-scroll-snap-type', 'none')
     })
   })
@@ -538,7 +557,7 @@ describe('Carousel', () => {
   describe('react-sandbox compat (callbacks / ref)', () => {
     it('calls onScroll with scrollLeft on scroll', () => {
       const onScroll = vi.fn()
-      render(<Carousel items={items} onScroll={onScroll} />)
+      render(<Carousel onScroll={onScroll}>{slides}</Carousel>)
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 240 })
       act(() => {
@@ -550,7 +569,7 @@ describe('Carousel', () => {
     it('calls onScrollStateChange when scrollability changes', () => {
       const onScrollStateChange = vi.fn()
       render(
-        <Carousel items={items} onScrollStateChange={onScrollStateChange} />,
+        <Carousel onScrollStateChange={onScrollStateChange}>{slides}</Carousel>,
       )
       const scroller = getScroller()
       mockScrollerGeometry(scroller, { scrollLeft: 100 })
@@ -577,7 +596,9 @@ describe('Carousel', () => {
       ]
       const ref = createRef<CarouselHandlerRef>()
       render(
-        <Carousel ref={ref} items={items} defaultScroll={{ align: 'right' }} />,
+        <Carousel ref={ref} defaultScroll={{ align: 'right' }}>
+          {slides}
+        </Carousel>,
       )
       lastSetLeft = undefined
       act(() => {
@@ -603,7 +624,7 @@ describe('Carousel', () => {
         .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
         .mockReturnValue(640)
       const onResize = vi.fn()
-      render(<Carousel items={items} onResize={onResize} />)
+      render(<Carousel onResize={onResize}>{slides}</Carousel>)
       act(() => {
         roCallbacks.forEach((cb) => cb([]))
       })
@@ -641,13 +662,13 @@ describe('Carousel', () => {
       // getServerSnapshot を使うため、サーバー描画でブラウザ API に触れない。
       expect(() =>
         renderToString(
-          <Carousel items={items} defaultScroll={{ align: 'center' }} />,
+          <Carousel defaultScroll={{ align: 'center' }}>{slides}</Carousel>,
         ),
       ).not.toThrow()
     })
 
     it('uses the server snapshot (canPrev/canNext = false) and renders items + indicator', () => {
-      const html = renderToString(<Carousel items={items} size="M" />)
+      const html = renderToString(<Carousel size="M">{slides}</Carousel>)
 
       // サーバースナップショットでは canPrev/canNext は false。
       expect(html).toContain('data-can-prev="false"')

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -1,7 +1,9 @@
 import './index.css'
 
 import {
+  Children,
   forwardRef,
+  isValidElement,
   memo,
   useCallback,
   useImperativeHandle,
@@ -22,11 +24,6 @@ import {
 import { useCarouselScroller } from './useCarouselScroller'
 
 const getServerSnapshot = (): CarouselState => INITIAL_CAROUSEL_STATE
-
-export type CarouselItem = {
-  id: string
-  children: ReactNode
-}
 
 export type ScrollAlign = 'left' | 'center' | 'right'
 
@@ -70,7 +67,8 @@ export type CarouselProps = Readonly<{
   onResize?: (width: number) => void
   onScrollStateChange?: (canScroll: boolean) => void
   defaultScroll?: { align?: ScrollAlign; offset?: number }
-  items: CarouselItem[]
+  // 1 直接子要素 = 1 スライド（react-sandbox 互換）。
+  children: ReactNode
 }>
 
 type Direction = 'prev' | 'next'
@@ -149,6 +147,7 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
     onResize,
     onScrollStateChange,
     defaultScroll: { align = 'left', offset = 0 } = {},
+    children,
     ...props
   }: CarouselProps,
   ref,
@@ -159,13 +158,20 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
   const snapType = scrollSnap?.type ?? (size === 'S' ? 'mandatory' : 'none')
   const snapAlign = scrollSnap?.align ?? 'center'
 
+  // 直接子要素 1 つを 1 スライドとして数える。key は子要素の key を引き継ぐ
+  // （toArray が付与する接頭辞付き key。無ければ index）。
+  const slides = Children.toArray(children)
+  const slideKeys = slides.map((slide, i) =>
+    isValidElement(slide) && slide.key != null ? slide.key : i,
+  )
+
   const scrollerRef = useRef<HTMLDivElement>(null)
   const [store] = useState(createCarouselStore)
 
   const { scrollByStep, onItemResize, resetScroll } = useCarouselScroller(
     scrollerRef,
     store,
-    props.items.length,
+    slides.length,
     { align, offset, scrollStep, onScroll, onResize, onScrollStateChange },
   )
 
@@ -225,14 +231,14 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
           tabIndex={0}
           data-focus-visible={scrollerFocusVisible || undefined}
         >
-          {props.items.map((item, i) => (
+          {slides.map((slide, i) => (
             <CarouselSlide
-              key={item.id}
+              key={slideKeys[i]}
               index={i}
               store={store}
               onResize={onItemResize}
             >
-              {item.children}
+              {slide}
             </CarouselSlide>
           ))}
         </div>
@@ -260,9 +266,9 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
         data-visible={showIndicator}
         aria-hidden={!showIndicator}
       >
-        {props.items.map((item, i) => (
+        {slides.map((_, i) => (
           <CarouselIndicatorItem
-            key={item.id}
+            key={slideKeys[i]}
             index={i}
             isActive={i === activeIndex}
             onSelect={scrollToItem}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -98,7 +98,6 @@ export {
 export {
   default as Carousel,
   type CarouselProps,
-  type CarouselItem,
   type CarouselHandlerRef,
   type ScrollAlign,
   type ScrollSnap,


### PR DESCRIPTION
## やったこと

- `Carousel` の `items: { id: string; children: ReactNode }[]` prop を廃止し、react-sandbox と同じく `children` を直接受け取る API に変更した
  - 直接子要素 1 つを 1 スライドとして扱う（`Children.toArray` で列挙、key は子要素の key を引き継ぐ）
  - sandbox からの移行が「import 差し替えのみ」に近づく（自前の flex ラッパーを外すだけ）
- スライド間隔（`gap: 24px` / S は `0`）の所有をコンポーネントから外した
  - Carousel の責務は「スクロールと indicator / arrow によるページ送り」のみとし、寸法・間隔は sandbox 同様に利用者が children 側で注入する（例: 各スライドに `marginInlineEnd`）
- `CarouselItem` 型の公開 export を削除した
- story / ユニットテストを children API へ移行し、children レンダリングのテストを追加した
- MIGRATION.md を新しい責務分担（children そのまま・間隔は margin で注入）に合わせて更新した

## 動作確認環境

- vitest 208 件パス / typecheck / eslint / stylelint / prettier すべて通過
- Storybook（Chrome）で確認: M サイズは story 側 margin による 24px 間隔、S サイズは 1 枚全幅ページング維持、snap 挙動に変化なし

## チェックリスト

- [x] 追加したコンポーネントが index.ts から再 export されている（`Carousel` の export は維持、廃止した `CarouselItem` 型のみ削除）
- [x] README やドキュメントに影響があることを確認した（MIGRATION.md を更新）