### PR TITLE
fix(react): カルーセルのグラデーションを mask 方式に変更 `@property` 利用

### DIFF
--- a/packages/react/src/components/Carousel/MIGRATION.md
+++ b/packages/react/src/components/Carousel/MIGRATION.md
@@ -63,8 +63,8 @@ sandbox では自前で `flex` ラッパーや `gap` を組んでいたが、新
 | `children`                                        | `items: { id: string; children: ReactNode }[]` | 上記参照                                                                                                  |
 | `scrollAmountCoef`（既定 `0.75`）                 | `scrollStep`（既定 `0.75`）                    | `number`（表示幅比）に加え `(ctx) => px` の関数も渡せる                                                   |
 | `defaultScroll: { align, offset }`                | `defaultScroll: { align, offset }`             | `align` は `'left' \| 'center' \| 'right'`。ほぼ同等                                                      |
-| `hasGradient`                                     | `hasGradient`（既定 `false`）                  | 実装が mask → 背景色オーバーレイに変更                                                                    |
-| `fadeInGradient`                                  | （廃止）                                       | 常にオーバーレイ式フェード                                                                                |
+| `hasGradient`                                     | `hasGradient`（既定 `false`）                  | ✅ そのまま対応（mask による透過フェード）                                                                |
+| `fadeInGradient`                                  | （廃止）                                       | スクロール可能な側のみ常にフェード                                                                        |
 | `buttonOffset` / `buttonPadding` / `bottomOffset` | （廃止）                                       | ボタン配置は CSS グリッド（左右 72px ゾーン）に固定                                                       |
 | `centerItems`                                     | （廃止）                                       | レイアウトは `flex` + `gap` 固定                                                                          |
 | `onScroll(left)`                                  | `onScroll(left)`                               | ✅ そのまま対応（scroll で発火）                                                                          |
@@ -92,8 +92,6 @@ sandbox では自前で `flex` ラッパーや `gap` を組んでいたが、新
   非対応環境では JS フォールバック）。
 - **キーボード操作**: スクローラーが `tabIndex={0}` でフォーカス可能になり、`←` / `→` で 1 ステップスクロール。
   フォーカスリングは charcoal 標準（`box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32)`）。
-- **グラデーション**: `mask` による透過から、背景色（`#fff`）オーバーレイ方式に変更。
-  ダークモードは現状未対応（背景色固定）。
 
 ## スクロール量を細かく制御したい場合
 

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -12,6 +12,13 @@
   position: relative;
 }
 
+/* フォーカスリングは scroller ではなく viewport に描く。scroller に置くと
+     hasGradient の mask（mask-clip: border-box）で外側の box-shadow ごと消えるため。 */
+
+.charcoal-carousel__viewport[data-focus-visible] {
+  box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
+}
+
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
@@ -26,10 +33,6 @@
 
 .charcoal-carousel__scroller::-webkit-scrollbar {
   display: none;
-}
-
-.charcoal-carousel__scroller[data-focus-visible] {
-  box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
 }
 
 .charcoal-carousel[data-size='S'] .charcoal-carousel__scroller {
@@ -52,38 +55,51 @@
   scroll-snap-type: x mandatory;
 }
 
-/* グラデーション: はみ出してスクロール可能な側のみ、端のアイテムを背景色（白）へ
-   フェードさせる。mask による透過ではなく、72px の「背景色→透明」オーバーレイを
-   ビューポートに重ねて白で覆う。スクロール可能な側だけ data-can-prev/next で出し分ける。 */
+/* mask の端色を transition できるよう <color> として型登録する
+   （@property 未対応ブラウザではフェードなしの即時切替になる）。 */
 
-.charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__viewport::before, .charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__viewport::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 72px;
-  pointer-events: none;
-  opacity: 0;
-  transition: 0.2s opacity;
-  z-index: 1;
+@property --charcoal-carousel-mask-start {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #000;
 }
 
-.charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__viewport::before {
-  left: 0;
-  background: linear-gradient(to right, #fff, transparent);
+@property --charcoal-carousel-mask-end {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #000;
 }
 
-.charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__viewport::after {
-  right: 0;
-  background: linear-gradient(to left, #fff, transparent);
+/* グラデーション: mask で端のアイテム自体を透明へフェードさせる（下の背景色を
+   問わない）。mask の色はアルファとしてだけ効く（#000=表示 / transparent=透過）。
+   はみ出してスクロール可能な側のみ、data-can-prev/next で端の色を transparent に
+   切り替えて 72px の透過域を有効にする。 */
+
+.charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__scroller {
+  /* var() の第2引数は @property 非対応ブラウザ用。無いと未定義プロパティ参照で
+     mask-image 宣言ごと無効になり、mask 自体が消える。 */
+  mask-image: linear-gradient(
+    to right,
+    var(--charcoal-carousel-mask-start, #000),
+    #000 72px,
+    #000 calc(100% - 72px),
+    var(--charcoal-carousel-mask-end, #000)
+  );
+  /* transition-property としてのカスタムプロパティ名指定（var() 不要）を
+     stylelint が誤検知するため無効化する。 */
+  /* stylelint-disable custom-property-no-missing-var-function */
+  /* 0.2s ease-in は react-sandbox の LeftGradient と同じ値 */
+  transition: 0.2s ease-in --charcoal-carousel-mask-start,
+    0.2s ease-in --charcoal-carousel-mask-end;
+  /* stylelint-enable custom-property-no-missing-var-function */
 }
 
-.charcoal-carousel[data-has-gradient='true'][data-can-prev='true'] .charcoal-carousel__viewport::before {
-  opacity: 1;
+.charcoal-carousel[data-has-gradient='true'][data-can-prev='true'] .charcoal-carousel__scroller {
+  --charcoal-carousel-mask-start: transparent;
 }
 
-.charcoal-carousel[data-has-gradient='true'][data-can-next='true'] .charcoal-carousel__viewport::after {
-  opacity: 1;
+.charcoal-carousel[data-has-gradient='true'][data-can-next='true'] .charcoal-carousel__scroller {
+  --charcoal-carousel-mask-end: transparent;
 }
 
 .charcoal-carousel__item {
@@ -108,7 +124,7 @@
 
 /* ── Navigation Buttons (charcoal IconButton, variant=Overlay size=S) ── */
 
-/* マスクと同じ 72px 1fr 72px グリッド。各ボタンは 72px ゾーンの中央に置く。 */
+/* マスクの透過域と同じ 72px 1fr 72px グリッド。各ボタンは 72px ゾーンの中央に置く。 */
 
 .charcoal-carousel__navigation {
   position: absolute;
@@ -117,8 +133,8 @@
   display: grid;
   grid-template-columns: 72px 1fr 72px;
   align-items: center;
-  /* 白フェード（z-index: 1）より上にボタンを表示する */
-  z-index: 2;
+  /* アイテム内のコンテンツより上にボタンを表示する */
+  z-index: 1;
   /* sandbox 同様、通常は隠してカルーセル hover 時にフェードイン表示する。 */
   opacity: 0;
   transition: 0.4s opacity;

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -10,6 +10,12 @@
 
 .charcoal-carousel__viewport {
   position: relative;
+
+  /* フォーカスリングは scroller ではなく viewport に描く。scroller に置くと
+     hasGradient の mask（mask-clip: border-box）で外側の box-shadow ごと消えるため。 */
+  &[data-focus-visible] {
+    box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
+  }
 }
 
 .charcoal-carousel__scroller {
@@ -25,10 +31,6 @@
 
   &::-webkit-scrollbar {
     display: none;
-  }
-
-  &[data-focus-visible] {
-    box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
   }
 }
 
@@ -53,44 +55,52 @@
   scroll-snap-type: x mandatory;
 }
 
-/* グラデーション: はみ出してスクロール可能な側のみ、端のアイテムを背景色（白）へ
-   フェードさせる。mask による透過ではなく、72px の「背景色→透明」オーバーレイを
-   ビューポートに重ねて白で覆う。スクロール可能な側だけ data-can-prev/next で出し分ける。 */
-.charcoal-carousel[data-has-gradient='true']
-  .charcoal-carousel__viewport::before,
-.charcoal-carousel[data-has-gradient='true']
-  .charcoal-carousel__viewport::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 72px;
-  pointer-events: none;
-  opacity: 0;
-  transition: 0.2s opacity;
-  z-index: 1;
+/* mask の端色を transition できるよう <color> として型登録する
+   （@property 未対応ブラウザではフェードなしの即時切替になる）。 */
+@property --charcoal-carousel-mask-start {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #000;
 }
 
-.charcoal-carousel[data-has-gradient='true']
-  .charcoal-carousel__viewport::before {
-  left: 0;
-  background: linear-gradient(to right, #fff, transparent);
+@property --charcoal-carousel-mask-end {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #000;
 }
 
-.charcoal-carousel[data-has-gradient='true']
-  .charcoal-carousel__viewport::after {
-  right: 0;
-  background: linear-gradient(to left, #fff, transparent);
+/* グラデーション: mask で端のアイテム自体を透明へフェードさせる（下の背景色を
+   問わない）。mask の色はアルファとしてだけ効く（#000=表示 / transparent=透過）。
+   はみ出してスクロール可能な側のみ、data-can-prev/next で端の色を transparent に
+   切り替えて 72px の透過域を有効にする。 */
+.charcoal-carousel[data-has-gradient='true'] .charcoal-carousel__scroller {
+  /* var() の第2引数は @property 非対応ブラウザ用。無いと未定義プロパティ参照で
+     mask-image 宣言ごと無効になり、mask 自体が消える。 */
+  mask-image: linear-gradient(
+    to right,
+    var(--charcoal-carousel-mask-start, #000),
+    #000 72px,
+    #000 calc(100% - 72px),
+    var(--charcoal-carousel-mask-end, #000)
+  );
+  /* transition-property としてのカスタムプロパティ名指定（var() 不要）を
+     stylelint が誤検知するため無効化する。 */
+  /* stylelint-disable custom-property-no-missing-var-function */
+  /* 0.2s ease-in は react-sandbox の LeftGradient と同じ値 */
+  transition:
+    0.2s ease-in --charcoal-carousel-mask-start,
+    0.2s ease-in --charcoal-carousel-mask-end;
+  /* stylelint-enable custom-property-no-missing-var-function */
 }
 
 .charcoal-carousel[data-has-gradient='true'][data-can-prev='true']
-  .charcoal-carousel__viewport::before {
-  opacity: 1;
+  .charcoal-carousel__scroller {
+  --charcoal-carousel-mask-start: transparent;
 }
 
 .charcoal-carousel[data-has-gradient='true'][data-can-next='true']
-  .charcoal-carousel__viewport::after {
-  opacity: 1;
+  .charcoal-carousel__scroller {
+  --charcoal-carousel-mask-end: transparent;
 }
 
 .charcoal-carousel__item {
@@ -114,7 +124,7 @@
 
 /* ── Navigation Buttons (charcoal IconButton, variant=Overlay size=S) ── */
 
-/* マスクと同じ 72px 1fr 72px グリッド。各ボタンは 72px ゾーンの中央に置く。 */
+/* マスクの透過域と同じ 72px 1fr 72px グリッド。各ボタンは 72px ゾーンの中央に置く。 */
 .charcoal-carousel__navigation {
   position: absolute;
   inset: 0;
@@ -122,8 +132,8 @@
   display: grid;
   grid-template-columns: 72px 1fr 72px;
   align-items: center;
-  /* 白フェード（z-index: 1）より上にボタンを表示する */
-  z-index: 2;
+  /* アイテム内のコンテンツより上にボタンを表示する */
+  z-index: 1;
   /* sandbox 同様、通常は隠してカルーセル hover 時にフェードイン表示する。 */
   opacity: 0;
   transition: 0.4s opacity;

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -217,13 +217,16 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
       aria-roledescription="carousel"
       aria-label="Carousel"
     >
-      <div className="charcoal-carousel__viewport">
+      {/* フォーカスリングは viewport に描く（理由は index.css の同セレクタ参照） */}
+      <div
+        className="charcoal-carousel__viewport"
+        data-focus-visible={scrollerFocusVisible || undefined}
+      >
         <div
           {...mergeProps(scrollerFocusProps, keyboardProps)}
           ref={scrollerRef}
           className="charcoal-carousel__scroller"
           tabIndex={0}
-          data-focus-visible={scrollerFocusVisible || undefined}
         >
           {props.items.map((item, i) => (
             <CarouselSlide

--- a/packages/react/src/components/Carousel/useCarouselScroller.ts
+++ b/packages/react/src/components/Carousel/useCarouselScroller.ts
@@ -66,8 +66,12 @@ export function useCarouselScroller(
         left = maxScroll + offset
         break
     }
-    // eslint-disable-next-line react-compiler/react-compiler
-    el.scrollLeft = Math.max(0, Math.min(left, maxScroll))
+    // scrollLeft 代入は CSS の scroll-behavior: smooth の対象になり
+    // 初期位置決めがアニメーションしてしまうため、instant で確定させる。
+    el.scrollTo({
+      left: Math.max(0, Math.min(left, maxScroll)),
+      behavior: 'instant',
+    })
   }, [scrollerRef, align, offset])
 
   // canPrev/canNext: scroll で更新。onScroll もここから発火。itemCount 変化で貼り直し。

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -31,6 +31,24 @@ beforeAll(() => {
     CSS.supports = () => false
   }
 
+  // jsdom は Element.prototype.scrollTo を実装していない。
+  // scrollLeft/scrollTop への反映は残す（テストが setter spy で位置を検証するため）。
+  if (typeof Element.prototype.scrollTo !== 'function') {
+    Element.prototype.scrollTo = vi.fn(function (
+      this: Element,
+      optionsOrX?: ScrollToOptions | number,
+      y?: number,
+    ) {
+      if (typeof optionsOrX === 'object' && optionsOrX !== null) {
+        if (optionsOrX.left !== undefined) this.scrollLeft = optionsOrX.left
+        if (optionsOrX.top !== undefined) this.scrollTop = optionsOrX.top
+      } else {
+        if (optionsOrX !== undefined) this.scrollLeft = optionsOrX
+        if (y !== undefined) this.scrollTop = y
+      }
+    }) as unknown as typeof Element.prototype.scrollTo
+  }
+
   vi.stubGlobal(
     'matchMedia',
     vi.fn().mockImplementation((query: string) => ({


### PR DESCRIPTION
## やったこと

- カルーセルの `hasGradient` を背景色（`#fff`）オーバーレイ方式から `mask-image` による透過フェードに変更
  - 端のアイテム自体を透明にフェードさせるため、下の背景色を仮定しない（ダーク背景上でも白帯が出ない）
- `@property` で mask の端色を `<color>` 登録し、従来と同じ 0.2s のフェード切替を色補間で維持
  - `@property` 非対応ブラウザ（iOS Safari 16.0–16.3 など）向けに `var()` の第 2 引数フォールバックを設定。mask は有効なまま、切替のみ即時になる
- mask（`mask-clip: border-box`）が scroller の外側 `box-shadow` をクリップするため、フォーカスリングの描画を viewport 側に移動
- MIGRATION.md のグラデーションに関する記述を mask 方式に更新

## 動作確認環境

- Chrome + Storybook（`react/Carousel` の WithGradient / GradientOnDarkContent を light / dark 両テーマで実測）
- `pnpm test`（207 件）/ `pnpm lint` / typecheck すべて PASS

## チェックリスト

- [x] README やドキュメントに影響があることを確認した（MIGRATION.md を更新）

## 備考
https://developer.mozilla.org/ja/docs/Web/CSS/Reference/At-rules/@property が `Baseline Widely Available` ならマージする