### PR TITLE
fix: make default icon button background transparent

### DIFF
--- a/packages/react/src/components/IconButton/__snapshots__/index.css.snap
+++ b/packages/react/src/components/IconButton/__snapshots__/index.css.snap
@@ -54,7 +54,7 @@
 
 .charcoal-icon-button[data-variant='Default'] {
   color: var(--charcoal-color-icon-tertiary-default);
-  background-color: var(--charcoal-color-container-default-a);
+  background-color: transparent;
 }
 
 .charcoal-icon-button[data-variant='Default'][data-active='true']:not(:disabled):not([aria-disabled]), .charcoal-icon-button[data-variant='Default'][data-active='true'][aria-disabled='false'] {

--- a/packages/react/src/components/IconButton/index.css
+++ b/packages/react/src/components/IconButton/index.css
@@ -56,7 +56,7 @@
 
   &[data-variant='Default'] {
     color: var(--charcoal-color-icon-tertiary-default);
-    background-color: var(--charcoal-color-container-default-a);
+    background-color: transparent;
 
     &[data-active='true']:not(:disabled):not([aria-disabled]),
     &[data-active='true'][aria-disabled='false'] {


### PR DESCRIPTION
## やったこと

- IconButtonコンポーネントで、透明であるべき時に `transparent` キーワードを使うようにしました
  - light / dark 切り替えで背景色のトランジションが発生してしまい、不自然な見た目になっていたため

## 動作確認環境
Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
