### PR TITLE
fix: ナビゲーションの 72px 帯クリックが背後のスライドへ素通りする問題を修正

### DIFF
--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -140,14 +140,34 @@
   pointer-events: auto;
 }
 
+/* ヒットエリアをグリッド端列（= mask のフェード帯と同じ 72px）全体へ広げる。
+     擬似要素上のクリックは元の button に届くため、帯のどこを押してもページ送りになる。
+     position: absolute の基準は positioned な .charcoal-carousel__navigation（inset: 0）。 */
+
+.charcoal-carousel__navigation__item::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 72px;
+}
+
 .charcoal-carousel__navigation__item[data-direction='prev'] {
   grid-column: 1;
   justify-self: center;
 }
 
+.charcoal-carousel__navigation__item[data-direction='prev']::after {
+  left: 0;
+}
+
 .charcoal-carousel__navigation__item[data-direction='next'] {
   grid-column: 3;
   justify-self: center;
+}
+
+.charcoal-carousel__navigation__item[data-direction='next']::after {
+  right: 0;
 }
 
 /* スクロール端では非表示。IconButton の disabled スタイル(opacity:0.32)より

--- a/packages/react/src/components/Carousel/index.browser.test.tsx
+++ b/packages/react/src/components/Carousel/index.browser.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * ナビゲーションボタンのヒットエリア検証（実ブラウザ）
+ *
+ * hasGradient の 72px フェード帯はページ送り操作の領域に見えるが、
+ * クリック可能域が中央の 32px 円形ボタンだけだと、帯の残り部分の
+ * クリックが背後のスライド（リンク等）に素通りしてしまう。
+ * 帯全体がナビゲーションボタンのヒットエリアであることを
+ * document.elementFromPoint のヒットテストで検証する。
+ * （pointer-events / 擬似要素のヒットテストは jsdom では再現できない）
+ */
+import { userEvent } from '@vitest/browser/context'
+import { render } from '@testing-library/react'
+import Carousel from '.'
+
+const EDGE_ZONE_WIDTH = 72
+
+const slides = Array.from({ length: 10 }, (_, i) => (
+  <div key={`slide-${i}`} style={{ width: 200, height: 160 }}>
+    Slide {i}
+  </div>
+))
+
+function renderCarousel() {
+  const { container } = render(
+    <div style={{ width: 400 }}>
+      <Carousel size="M" hasGradient>
+        {slides}
+      </Carousel>
+    </div>,
+  )
+  const viewport = container.querySelector(
+    '.charcoal-carousel__viewport',
+  ) as HTMLElement
+  return { container, viewport, rect: viewport.getBoundingClientRect() }
+}
+
+function hitNavigationItem(x: number, y: number) {
+  return document
+    .elementFromPoint(x, y)
+    ?.closest('.charcoal-carousel__navigation__item')
+}
+
+describe('navigation button hit area', () => {
+  it('右端 72px 帯のクリックはスライドではなく next ボタンに届く', () => {
+    const { rect } = renderCarousel()
+    const centerY = rect.top + rect.height / 2
+
+    // ボタン円（32px、帯の中央）の外側かつ帯の内側の点
+    const nearEdge = hitNavigationItem(rect.right - 8, centerY)
+    expect(nearEdge?.getAttribute('data-direction')).toBe('next')
+
+    // ボタンの上下方向の外側（帯の上端付近）
+    const aboveButton = hitNavigationItem(
+      rect.right - EDGE_ZONE_WIDTH / 2,
+      rect.top + 8,
+    )
+    expect(aboveButton?.getAttribute('data-direction')).toBe('next')
+  })
+
+  it('スクロール不能な側（初期位置の prev）の帯はスライドへ素通りする', () => {
+    const { rect } = renderCarousel()
+    const centerY = rect.top + rect.height / 2
+
+    const hit = document.elementFromPoint(rect.left + 8, centerY)
+    expect(hit?.closest('.charcoal-carousel__navigation__item')).toBeNull()
+    expect(hit?.closest('.charcoal-carousel__scroller')).not.toBeNull()
+  })
+
+  it('帯のボタン外の点をクリックすると next へページ送りされる', async () => {
+    const { container, viewport, rect } = renderCarousel()
+    const scroller = container.querySelector(
+      '.charcoal-carousel__scroller',
+    ) as HTMLElement
+    expect(scroller.scrollLeft).toBe(0)
+
+    // trusted click とその後の scroll イベントは React の act() 管理外で
+    // 発火するため、この区間だけ act 警告を無効化する。
+    const g = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    g.IS_REACT_ACT_ENVIRONMENT = false
+    try {
+      // viewport 左上基準・帯の内側かつボタン円の外側の座標を実クリックする
+      await userEvent.click(viewport, {
+        position: { x: rect.width - 8, y: 8 },
+      })
+
+      await vi.waitFor(() => {
+        expect(scroller.scrollLeft).toBeGreaterThan(0)
+      })
+    } finally {
+      g.IS_REACT_ACT_ENVIRONMENT = true
+    }
+  })
+
+  it('帯の外側（中央領域）のクリックはスライドに届く', () => {
+    const { rect } = renderCarousel()
+    const centerY = rect.top + rect.height / 2
+
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, centerY)
+    expect(hit?.closest('.charcoal-carousel__navigation__item')).toBeNull()
+    expect(hit?.closest('.charcoal-carousel__scroller')).not.toBeNull()
+  })
+})

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -143,14 +143,33 @@
 .charcoal-carousel__navigation__item {
   pointer-events: auto;
 
+  /* ヒットエリアをグリッド端列（= mask のフェード帯と同じ 72px）全体へ広げる。
+     擬似要素上のクリックは元の button に届くため、帯のどこを押してもページ送りになる。
+     position: absolute の基準は positioned な .charcoal-carousel__navigation（inset: 0）。 */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 72px;
+  }
+
   &[data-direction='prev'] {
     grid-column: 1;
     justify-self: center;
+
+    &::after {
+      left: 0;
+    }
   }
 
   &[data-direction='next'] {
     grid-column: 3;
     justify-self: center;
+
+    &::after {
+      right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
## やったこと

- Carousel のナビゲーションボタン（prev / next）のヒットエリアを、mask のフェード帯と同じ 72px のグリッド端列全体へ拡張しました
  - 従来はクリック可能域が中央の 32px 円形 IconButton のみで、`.charcoal-carousel__navigation` が `pointer-events: none` のため、帯の残り部分のクリック/タップが背後のスライド（リンク等）へ素通りしていました
- 実装は CSS のみ（DOM / JS 変更なし）。ボタンの `::after` を `position: absolute` にすると基準が positioned な `.charcoal-carousel__navigation`（`inset: 0`）になるため、`top: 0; bottom: 0; width: 72px` で帯全体を覆えます。擬似要素上のクリックはヒットテスト上元の button に届きます
  - スクロール不能側（`data-hidden='true'`）は従来どおり `pointer-events: none` でスライドへ素通りします
  - タッチデバイス（`hover: none` / `pointer: coarse`）ではナビ自体が非表示のため挙動は変わりません
- 実ブラウザテスト `index.browser.test.tsx`（vitest browser mode + Playwright chromium）を新規追加しました
  - `document.elementFromPoint` によるヒットテスト（帯の内側・外側・スクロール不能側）
  - 座標指定の trusted click で実際に `scrollLeft` が進む end-to-end 検証
  - pointer-events / 擬似要素のヒットテストは jsdom では再現できないため browser mode を使っています

## 動作確認環境

- vitest browser mode（Playwright chromium, headless）: 4 件パス
- 非ブラウザテスト 1398 件 / CSS スナップショット・css-output 等価性テスト更新済み
- prettier / eslint / stylelint パス

## チェックリスト

- [x] README やドキュメントに影響があることを確認した（挙動修正のみでドキュメント影響なし）
