### PR TITLE
fix: Carousel のナビゲーションボタンがクリック後にカーソルを外しても非表示にならない問題を修正

### DIFF
--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -130,9 +130,11 @@
   display: none;
 }
 
-/* hover で表示。キーボード操作でも到達できるよう focus-within でも表示する。 */
+/* hover で表示。キーボード操作でも到達できるよう、キーボード由来のフォーカスが
+   カルーセル内にある間も表示する（:focus-within だとクリックで残ったフォーカスでも
+   表示され続けるため、react-aria が付与する data 属性で判定する）。 */
 
-.charcoal-carousel:hover .charcoal-carousel__navigation, .charcoal-carousel:focus-within .charcoal-carousel__navigation {
+.charcoal-carousel:hover .charcoal-carousel__navigation, .charcoal-carousel[data-focus-visible-within] .charcoal-carousel__navigation {
   opacity: 1;
 }
 

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -134,9 +134,11 @@
   }
 }
 
-/* hover で表示。キーボード操作でも到達できるよう focus-within でも表示する。 */
+/* hover で表示。キーボード操作でも到達できるよう、キーボード由来のフォーカスが
+   カルーセル内にある間も表示する（:focus-within だとクリックで残ったフォーカスでも
+   表示され続けるため、react-aria が付与する data 属性で判定する）。 */
 .charcoal-carousel:hover .charcoal-carousel__navigation,
-.charcoal-carousel:focus-within .charcoal-carousel__navigation {
+.charcoal-carousel[data-focus-visible-within] .charcoal-carousel__navigation {
   opacity: 1;
 }
 

--- a/packages/react/src/components/Carousel/index.test.tsx
+++ b/packages/react/src/components/Carousel/index.test.tsx
@@ -634,6 +634,58 @@ describe('Carousel', () => {
     })
   })
 
+  describe('navigation button visibility (focus modality)', () => {
+    // jsdom はジオメトリが全て 0 で Next ボタンが disabled（=フォーカス不可）の
+    // ままになるため、スクロール余地をモックして有効化してからフォーカスする。
+    function renderWithFocusableNext() {
+      render(<Carousel size="M">{slides}</Carousel>)
+      const scroller = getScroller()
+      mockScrollerGeometry(scroller, { scrollLeft: 0 })
+      scroller.scrollBy = vi.fn()
+      act(() => {
+        fireEvent.scroll(scroller)
+      })
+      const next = screen.getByRole('button', { name: 'Next' })
+      expect(next).not.toBeDisabled()
+      return next
+    }
+
+    // react-aria は document 上の keydown / pointerdown でフォーカスの由来
+    // （keyboard / pointer）を判定するため、focus() の前にイベントを発火して
+    // モダリティを切り替える。
+    it('does not mark focus-visible when a button is focused by pointer', () => {
+      const next = renderWithFocusableNext()
+      fireEvent.pointerDown(next)
+      fireEvent.mouseDown(next)
+      act(() => next.focus())
+      fireEvent.click(next)
+      expect(document.activeElement).toBe(next)
+      expect(screen.getByRole('region')).not.toHaveAttribute(
+        'data-focus-visible-within',
+      )
+    })
+
+    it('marks focus-visible when a button is focused by keyboard', () => {
+      const next = renderWithFocusableNext()
+      fireEvent.keyDown(document.body, { key: 'Tab' })
+      act(() => next.focus())
+      expect(screen.getByRole('region')).toHaveAttribute(
+        'data-focus-visible-within',
+        'true',
+      )
+    })
+
+    it('clears focus-visible when focus leaves the carousel', () => {
+      const next = renderWithFocusableNext()
+      fireEvent.keyDown(document.body, { key: 'Tab' })
+      act(() => next.focus())
+      act(() => next.blur())
+      expect(screen.getByRole('region')).not.toHaveAttribute(
+        'data-focus-visible-within',
+      )
+    })
+  })
+
   describe('SSR (server rendering)', () => {
     // jsdom では window が定義されているため renderToString 時に
     // 「useLayoutEffect does nothing on the server」警告が出る（実 SSR=window 無しでは

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -208,8 +208,14 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
     isFocusVisible: scrollerFocusVisible,
   } = useFocusRing()
 
+  // ナビゲーションボタン表示用。クリックで残留したフォーカス（pointer 由来）では
+  // 表示し続けないよう、キーボード由来のフォーカスのみを検知する。
+  const { focusProps: rootFocusProps, isFocusVisible: rootFocusVisible } =
+    useFocusRing({ within: true })
+
   return (
     <div
+      {...rootFocusProps}
       className={className}
       data-size={size}
       data-has-gradient={hasGradient}
@@ -219,6 +225,7 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
       data-scroll-snap-align={snapAlign}
       data-can-prev={canPrev}
       data-can-next={canNext}
+      data-focus-visible-within={rootFocusVisible || undefined}
       role="region"
       aria-roledescription="carousel"
       aria-label="Carousel"


### PR DESCRIPTION
## やったこと

- ナビゲーションボタンの表示条件を `.charcoal-carousel:focus-within` から、react-aria の `useFocusRing({ within: true })` が付与する `data-focus-visible-within` 属性での判定に変更しました
- フォーカスモダリティ（pointer / keyboard）のユニットテストを 3 件追加しました
- CSS スナップショットを更新しました

### 問題の原因

`:focus-within` はフォーカスの由来を区別しないため、マウスクリックでボタン（や `tabIndex=0` の scroller）に残留したフォーカスでも表示条件が生き続け、カーソルを外してもボタンが表示されたままになっていました。IconButton（react-aria `usePress`）は Safari でも明示的に `.focus()` を呼ぶため、全ブラウザで発生します。

なお 1 クリックでスクロール端に到達するとボタンが `disabled` になりフォーカスが強制解除されるため、スクロール余地が残っている場合のみ再現する条件付きのバグでした。

### 修正後の挙動

| ケース | フォーカスの由来 | カーソルを外した後 |
|---|---|---|
| ボタンをクリック | pointer | 非表示になる（修正） |
| カルーセル本体をクリック | pointer | 非表示になる（修正） |
| Tab でカルーセルに進入 | keyboard | 表示を維持（a11y のため従来どおり） |

native の `:focus-visible` ではなく react-aria を使ったのは、`usePress` がプログラム的に呼ぶ `.focus()` に対する判定がブラウザ間で不安定なのに対し、react-aria は入力モダリティを document レベルで一貫して追跡するためです。viewport のフォーカスリング（`data-focus-visible`)と同じ既存パターンです。

## 動作確認環境

- Storybook (`react/Carousel` SizeM) + Playwright / Chromium で以下を実測
  - ボタンクリック → カーソル離脱で opacity `1 → 0`（修正前は `1` のまま）
  - スライド部分クリック → カーソル離脱で非表示
  - Tab 移動: scroller → ボタン間は表示維持、カルーセル外へ抜けると非表示
- `vitest run`（非 browser）全 1401 件パス、型エラーなし、ESLint / Prettier クリーン

## チェックリスト

不要なチェック項目は消して構いません

- [x] README やドキュメントに影響がないことを確認した