### PR TITLE
feat: Carousel にスライド間隔を指定する gap prop を追加

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -455,6 +455,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -469,7 +470,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -478,7 +479,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -487,7 +488,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -496,7 +497,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -505,7 +506,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -514,7 +515,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > AllControls 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>
@@ -615,6 +616,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -627,7 +629,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -636,7 +638,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -645,7 +647,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -654,7 +656,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -663,7 +665,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -672,7 +674,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -681,7 +683,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -690,7 +692,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -699,7 +701,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -708,7 +710,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -717,7 +719,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -726,7 +728,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -735,7 +737,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -744,7 +746,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -753,7 +755,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -762,7 +764,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -771,7 +773,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -780,7 +782,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -789,7 +791,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -798,7 +800,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -971,6 +973,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -985,7 +988,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -994,7 +997,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1003,7 +1006,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1012,7 +1015,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1021,7 +1024,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1030,7 +1033,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollCenter
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>
@@ -1131,6 +1134,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -1143,7 +1147,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -1152,7 +1156,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -1161,7 +1165,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -1170,7 +1174,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -1179,7 +1183,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -1188,7 +1192,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -1197,7 +1201,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -1206,7 +1210,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -1215,7 +1219,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -1224,7 +1228,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -1233,7 +1237,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -1242,7 +1246,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -1251,7 +1255,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -1260,7 +1264,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -1269,7 +1273,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -1278,7 +1282,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -1287,7 +1291,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -1296,7 +1300,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -1305,7 +1309,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -1314,7 +1318,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > DefaultScrollRight 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -1487,6 +1491,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -1501,7 +1506,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1510,7 +1515,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1519,7 +1524,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1528,7 +1533,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1537,7 +1542,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1546,7 +1551,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > FullWidth 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>
@@ -1647,6 +1652,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -1659,7 +1665,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               1
             </div>
@@ -1668,7 +1674,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               2
             </div>
@@ -1677,7 +1683,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               3
             </div>
@@ -1686,7 +1692,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               4
             </div>
@@ -1695,7 +1701,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               5
             </div>
@@ -1704,7 +1710,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               6
             </div>
@@ -1713,7 +1719,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               7
             </div>
@@ -1722,7 +1728,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               8
             </div>
@@ -1731,7 +1737,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               9
             </div>
@@ -1740,7 +1746,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > GradientOnDarkConte
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 220px; height: 140px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
+              style="width: 220px; height: 140px; display: flex; align-items: center; justify-content: center; background: rgb(42, 59, 143); color: rgb(255, 255, 255); border-radius: 4px; font: sans-serif 28px bold 28px;"
             >
               10
             </div>
@@ -1863,6 +1869,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -1877,7 +1884,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1886,7 +1893,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1895,7 +1902,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1904,7 +1911,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1913,7 +1920,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -1922,7 +1929,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > IndicatorOnSizeM 1`
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>
@@ -2023,6 +2030,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > NavigationButtonsOn
       data-scroll-snap-type="mandatory"
       data-size="S"
       role="region"
+      style="--charcoal-carousel-gap: 0px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -2183,6 +2191,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
       data-scroll-snap-type="mandatory"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -2195,7 +2204,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -2204,7 +2213,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -2213,7 +2222,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -2222,7 +2231,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -2231,7 +2240,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -2240,7 +2249,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -2249,7 +2258,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -2258,7 +2267,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -2267,7 +2276,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -2276,7 +2285,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -2285,7 +2294,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -2294,7 +2303,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -2303,7 +2312,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -2312,7 +2321,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -2321,7 +2330,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -2330,7 +2339,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -2339,7 +2348,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -2348,7 +2357,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -2357,7 +2366,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -2366,7 +2375,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollSnapPerItem 1
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -2539,6 +2548,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -2551,7 +2561,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               1
             </div>
@@ -2560,7 +2570,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               2
             </div>
@@ -2569,7 +2579,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               3
             </div>
@@ -2578,7 +2588,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               4
             </div>
@@ -2587,7 +2597,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               5
             </div>
@@ -2596,7 +2606,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               6
             </div>
@@ -2605,7 +2615,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               7
             </div>
@@ -2614,7 +2624,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               8
             </div>
@@ -2623,7 +2633,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               9
             </div>
@@ -2632,7 +2642,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               10
             </div>
@@ -2641,7 +2651,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               11
             </div>
@@ -2650,7 +2660,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               12
             </div>
@@ -2659,7 +2669,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               13
             </div>
@@ -2668,7 +2678,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               14
             </div>
@@ -2677,7 +2687,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               15
             </div>
@@ -2686,7 +2696,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               16
             </div>
@@ -2695,7 +2705,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               17
             </div>
@@ -2704,7 +2714,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               18
             </div>
@@ -2713,7 +2723,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(207, 227, 255); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               19
             </div>
@@ -2722,7 +2732,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > ScrollStepFunction 
             class="charcoal-carousel__item"
           >
             <div
-              style="width: 200px; height: 120px; margin-inline-end: 24px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
+              style="width: 200px; height: 120px; display: flex; align-items: center; justify-content: center; background: rgb(255, 227, 207); border-radius: 8px; font: sans-serif 32px bold 32px; color: rgb(51, 51, 51);"
             >
               20
             </div>
@@ -2895,6 +2905,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -2909,7 +2920,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -2918,7 +2929,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -2927,7 +2938,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -2936,7 +2947,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -2945,7 +2956,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -2954,7 +2965,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeM 1`] = `
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>
@@ -3055,6 +3066,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > SizeS 1`] = `
       data-scroll-snap-type="mandatory"
       data-size="S"
       role="region"
+      style="--charcoal-carousel-gap: 0px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -3215,6 +3227,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
       data-scroll-snap-type="none"
       data-size="M"
       role="region"
+      style="--charcoal-carousel-gap: 24px;"
     >
       <div
         class="charcoal-carousel__viewport"
@@ -3229,7 +3242,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -3238,7 +3251,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -3247,7 +3260,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -3256,7 +3269,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -3265,7 +3278,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
           <div
@@ -3274,7 +3287,7 @@ exports[`Storybook Tests > react/Carousel > react/Carousel > WithGradient 1`] = 
             <img
               alt="サンプル画像"
               src="/carousel-sample.png"
-              style="object-fit: cover; display: block; width: 280px; height: 210px; margin-inline-end: 24px;"
+              style="object-fit: cover; display: block; width: 280px; height: 210px;"
             />
           </div>
         </div>

--- a/packages/react/src/components/Carousel/MIGRATION.md
+++ b/packages/react/src/components/Carousel/MIGRATION.md
@@ -7,12 +7,12 @@
 
 - **import 差し替えがほぼ唯一の必須変更**。`children` はそのまま渡せる（ただし自前の
   `flex` ラッパーは外して **1 スライド 1 直接子要素**にし、ラッパーの `gap` は
-  各スライドの `margin` に置き換える）。
+  Carousel の `gap` prop に置き換える）。
 - `onScroll` / `onResize` / `onScrollStateChange` / `ref`（`resetScroll()`）/ `defaultScroll` /
   `hasGradient` は **sandbox と同じシグネチャ**で利用できる（drop-in 互換）。
 - `scrollAmountCoef` は `scrollStep`（関数も可）に名称変更。`fadeInGradient` / `buttonOffset` 系 /
   `centerItems` は廃止。
-- `size` / `indicator` / `scrollSnap` / `fullWidth` は新規（任意・後方互換）。
+- `size` / `indicator` / `scrollSnap` / `fullWidth` / `gap` は新規（任意・後方互換）。
 
 ## 概要
 
@@ -35,10 +35,9 @@
 
 ## 子要素: `children`（そのまま渡せる）
 
-sandbox と同じく子ノードを直接渡し、スライドの寸法・間隔も sandbox 同様に利用者が持つ
-（コンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ）。
+sandbox と同じく子ノードを直接渡し、スライドの寸法は sandbox 同様に利用者が持つ。
 ただし**直接子要素 1 つを 1 スライド**として数えるので、`flex` ラッパーは外し、
-`gap` の代わりに各スライドの `margin` などで間隔を注入する。
+ラッパーで指定していた `gap` は Carousel の `gap` prop で指定する。
 
 ```diff
 - <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollAmountCoef={0.75}>
@@ -48,9 +47,9 @@ sandbox と同じく子ノードを直接渡し、スライドの寸法・間隔
 -     ))}
 -   </div>
 - </Carousel>
-+ <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollStep={0.75}>
++ <Carousel hasGradient defaultScroll={{ align: 'center' }} scrollStep={0.75} gap={8}>
 +   {items.map((i) => (
-+     <Slide key={i} style={{ marginInlineEnd: 8 }} />
++     <Slide key={i} />
 +   ))}
 + </Carousel>
 ```
@@ -67,7 +66,7 @@ sandbox と同じく子ノードを直接渡し、スライドの寸法・間隔
 | `hasGradient`                                     | `hasGradient`（既定 `false`）               | ✅ そのまま対応（mask による透過フェード）                                                                |
 | `fadeInGradient`                                  | （廃止）                                    | スクロール可能な側のみ常にフェード                                                                        |
 | `buttonOffset` / `buttonPadding` / `bottomOffset` | （廃止）                                    | ボタン配置は CSS グリッド（左右 72px ゾーン）に固定                                                       |
-| `centerItems`                                     | （廃止）                                    | スライドの寸法・間隔は children 側で注入する（sandbox 同様）                                              |
+| `centerItems`                                     | （廃止）                                    | スライド寸法は children 側で注入する（sandbox 同様）。間隔は `gap` prop                                   |
 | `onScroll(left)`                                  | `onScroll(left)`                            | ✅ そのまま対応（scroll で発火）                                                                          |
 | `onResize(width)`                                 | `onResize(width)`                           | ✅ scroller 幅の変化で発火                                                                                |
 | `onScrollStateChange(canScroll)`                  | `onScrollStateChange(canScroll)`            | ✅ `canPrev \|\| canNext` の変化で発火                                                                    |
@@ -78,6 +77,7 @@ sandbox と同じく子ノードを直接渡し、スライドの寸法・間隔
 | —                                                 | `fullWidth?: boolean`（既定 `false`）       | `100vw` 表示                                                                                              |
 | —                                                 | `className?: string`                        | ルートに付与                                                                                              |
 | —                                                 | `scrollSnap?: { type?; align? }`            | `type`: `none`/`proximity`/`mandatory`、`align`: `center`/`start`。未指定で M=none / S=mandatory / center |
+| —                                                 | `gap?: number \| string`                    | 新規。スライド間隔。number は px、string は CSS 値をそのまま使う                                          |
 
 ## 挙動の変更（移行時に確認すること）
 

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -26,7 +26,7 @@
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: var(--charcoal-carousel-gap);
+  gap: var(--charcoal-carousel-gap, 0);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -19,12 +19,13 @@
   box-shadow: 0 0 0 4px rgba(0, 150, 250, 0.32);
 }
 
-/* スライド間隔は所有しない（sandbox 同様、利用者が children 側で注入する）。
-   このコンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ。 */
+/* スライド間隔は gap prop（--charcoal-carousel-gap）で注入する。
+   スライド寸法は sandbox 同様、利用者が children 側で持つ。 */
 
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
+  gap: var(--charcoal-carousel-gap, 0px);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -26,7 +26,7 @@
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: var(--charcoal-carousel-gap, 0);
+  gap: var(--charcoal-carousel-gap);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Carousel/__snapshots__/index.css.snap
@@ -1,4 +1,5 @@
 .charcoal-carousel {
+  --charcoal-carousel-gap: 0px;
   position: relative;
   display: block;
 }
@@ -25,7 +26,7 @@
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: var(--charcoal-carousel-gap, 0px);
+  gap: var(--charcoal-carousel-gap);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -18,11 +18,12 @@
   }
 }
 
-/* スライド間隔は所有しない（sandbox 同様、利用者が children 側で注入する）。
-   このコンポーネントの責務はスクロールと indicator / arrow によるページ送りのみ。 */
+/* スライド間隔は gap prop（--charcoal-carousel-gap）で注入する。
+   スライド寸法は sandbox 同様、利用者が children 側で持つ。 */
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
+  gap: var(--charcoal-carousel-gap, 0px);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/index.css
+++ b/packages/react/src/components/Carousel/index.css
@@ -1,4 +1,6 @@
 .charcoal-carousel {
+  --charcoal-carousel-gap: 0px;
+
   position: relative;
   display: block;
 
@@ -23,7 +25,7 @@
 .charcoal-carousel__scroller {
   position: relative;
   display: flex;
-  gap: var(--charcoal-carousel-gap, 0px);
+  gap: var(--charcoal-carousel-gap);
   overflow-x: auto;
   overflow-y: hidden;
   overscroll-behavior-x: contain;

--- a/packages/react/src/components/Carousel/index.story.tsx
+++ b/packages/react/src/components/Carousel/index.story.tsx
@@ -16,25 +16,18 @@ const makeSampleImages = (style: CSSProperties) =>
     />
   ))
 
-// M 用: スライド間隔はコンポーネントが所有しないので、利用者側の margin で注入する。
-// width: 100% と margin の併用はラッパーとの循環サイズ解決で間隔が潰れるため、明示サイズにする。
-const spacedImages = makeSampleImages({
-  width: 280,
-  height: 210,
-  marginInlineEnd: 24,
-})
+// M 用: スライド間隔は gap prop で注入する（既定 args の gap: 24）。
+const spacedImages = makeSampleImages({ width: 280, height: 210 })
 // S 用: 1 枚全幅ページングのため間隔なし
 const fullWidthImages = makeSampleImages({ width: '100%', height: '100%' })
 
 // 横幅が確定したスロット（defaultScroll の初期位置計算と 0.75 ページ送りを確認するため）。
-// スライド間隔はコンポーネントが所有しないので、利用者側の margin で注入する。
 const numberedSlides = Array.from({ length: 20 }, (_, i) => (
   <div
     key={`num-${i + 1}`}
     style={{
       width: 200,
       height: 120,
-      marginInlineEnd: 24,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -60,6 +53,7 @@ export default {
     hasGradient: false,
     fullWidth: false,
     scrollStep: 0.75,
+    gap: 24,
   },
   argTypes: {
     children: { control: false },
@@ -80,6 +74,10 @@ export default {
       // Controls では数値（比率）のみ操作可能。関数形式は ScrollStepFunction story を参照。
       control: { type: 'range', min: 0.1, max: 1.5, step: 0.05 },
     },
+    gap: {
+      // number は px。'1rem' などの CSS 値文字列も渡せる。
+      control: { type: 'number' },
+    },
   },
 } satisfies Meta<typeof Carousel>
 
@@ -88,7 +86,7 @@ export const SizeM: StoryObj<typeof Carousel> = {
 }
 
 export const SizeS: StoryObj<typeof Carousel> = {
-  args: { size: 'S', children: fullWidthImages },
+  args: { size: 'S', children: fullWidthImages, gap: 0 },
 }
 
 export const WithGradient: StoryObj<typeof Carousel> = {
@@ -100,7 +98,12 @@ export const FullWidth: StoryObj<typeof Carousel> = {
 }
 
 export const NavigationButtonsOnSizeS: StoryObj<typeof Carousel> = {
-  args: { size: 'S', navigationButtons: true, children: fullWidthImages },
+  args: {
+    size: 'S',
+    navigationButtons: true,
+    children: fullWidthImages,
+    gap: 0,
+  },
 }
 
 export const IndicatorOnSizeM: StoryObj<typeof Carousel> = {
@@ -140,7 +143,6 @@ const darkTiles = Array.from({ length: 10 }, (_, i) => (
     style={{
       width: 220,
       height: 140,
-      marginInlineEnd: 24,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',

--- a/packages/react/src/components/Carousel/index.test.tsx
+++ b/packages/react/src/components/Carousel/index.test.tsx
@@ -92,6 +92,30 @@ describe('Carousel', () => {
     })
   })
 
+  describe('gap', () => {
+    it('sets --charcoal-carousel-gap in px when gap is a number', () => {
+      const { container } = render(<Carousel gap={24}>{slides}</Carousel>)
+      const root = container.querySelector('.charcoal-carousel') as HTMLElement
+      expect(root.style.getPropertyValue('--charcoal-carousel-gap')).toBe(
+        '24px',
+      )
+    })
+
+    it('passes string gap values through as-is', () => {
+      const { container } = render(<Carousel gap="1rem">{slides}</Carousel>)
+      const root = container.querySelector('.charcoal-carousel') as HTMLElement
+      expect(root.style.getPropertyValue('--charcoal-carousel-gap')).toBe(
+        '1rem',
+      )
+    })
+
+    it('does not set the custom property when gap is not specified', () => {
+      const { container } = render(<Carousel>{slides}</Carousel>)
+      const root = container.querySelector('.charcoal-carousel') as HTMLElement
+      expect(root.style.getPropertyValue('--charcoal-carousel-gap')).toBe('')
+    })
+  })
+
   describe('Size M (default)', () => {
     it('shows navigation buttons', () => {
       render(<Carousel size="M">{slides}</Carousel>)

--- a/packages/react/src/components/Carousel/index.tsx
+++ b/packages/react/src/components/Carousel/index.tsx
@@ -7,9 +7,11 @@ import {
   memo,
   useCallback,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
+  type CSSProperties,
   type ReactNode,
 } from 'react'
 import { mergeProps, useFocusRing, useKeyboard } from 'react-aria'
@@ -67,6 +69,8 @@ export type CarouselProps = Readonly<{
   onResize?: (width: number) => void
   onScrollStateChange?: (canScroll: boolean) => void
   defaultScroll?: { align?: ScrollAlign; offset?: number }
+  // スライド間隔。number は px、string は CSS 値をそのまま使う。未指定は間隔なし。
+  gap?: number | string
   // 1 直接子要素 = 1 スライド（react-sandbox 互換）。
   children: ReactNode
 }>
@@ -147,6 +151,7 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
     onResize,
     onScrollStateChange,
     defaultScroll: { align = 'left', offset = 0 } = {},
+    gap,
     children,
     ...props
   }: CarouselProps,
@@ -213,10 +218,22 @@ const Carousel = forwardRef<CarouselHandlerRef, CarouselProps>(function Render(
   const { focusProps: rootFocusProps, isFocusVisible: rootFocusVisible } =
     useFocusRing({ within: true })
 
+  // gap 宣言自体は index.css 側に置き、ここでは CSS 変数の値だけを注入する。
+  const gapStyle = useMemo(
+    () =>
+      ({
+        ...(gap != null && {
+          '--charcoal-carousel-gap': typeof gap === 'number' ? `${gap}px` : gap,
+        }),
+      }) satisfies CSSProperties,
+    [gap],
+  )
+
   return (
     <div
       {...rootFocusProps}
       className={className}
+      style={gapStyle}
       data-size={size}
       data-has-gradient={hasGradient}
       data-full-width={fullWidth}


### PR DESCRIPTION
## やったこと

- Carousel にスライド間隔を指定する `gap?: number | string` prop を追加
  - `number` は px、`string` は CSS 値をそのまま使用。未指定時は従来どおり間隔なし（後方互換）
  - 値は root 要素へ CSS 変数 `--charcoal-carousel-gap` として注入し、`gap` 宣言自体は index.css 側に置く
- story のスライド間隔注入を margin（`marginInlineEnd`）から gap prop に置き換え
- 移行ガイド（MIGRATION.md）の間隔注入の案内を gap prop に更新
- JS 注入する CSS 変数の初期値 `--charcoal-carousel-gap: 0px` を CSS 側に宣言（css-variables.test.ts の規約対応）

## 動作確認環境

- macOS / Chrome（Storybook）
  - gap=24px 指定時のスライド間隔と末尾余白なしを確認
  - gap 未指定時の full-width paging（SizeS）が従来どおりであることを確認
  - defaultScroll の center / right 初期位置が gap 指定で壊れないことを確認
  - Controls から `40` / `'3rem'` の動的変更が反映されることを確認
- unit 214 件・browser 38 件のテスト、typecheck / eslint / stylelint / prettier すべて通過

## チェックリスト

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [x] README やドキュメントに影響があることを確認した