### PR TITLE
fix: tag item should pass full props

### DIFF
--- a/packages/react/src/components/TagItem/index.test.tsx
+++ b/packages/react/src/components/TagItem/index.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { forwardRef } from 'react'
+import TagItem from '.'
+
+describe('TagItem', () => {
+  it('preserves link props on a custom link component', () => {
+    const NextLink = forwardRef<
+      HTMLAnchorElement,
+      React.ComponentPropsWithoutRef<'a'>
+    >(function NextLink({ children, ...props }, ref) {
+      return (
+        <a ref={ref} {...props}>
+          {children}
+        </a>
+      )
+    })
+
+    const onClick = vi.fn()
+
+    render(
+      <TagItem
+        component={NextLink}
+        href="/tags/girl"
+        label="#girl"
+        target="_blank"
+        onClick={onClick}
+      />,
+    )
+
+    const link = screen.getByRole('link')
+
+    expect(link).toHaveAttribute('href', '/tags/girl')
+    expect(link).toHaveAttribute('target', '_blank')
+
+    fireEvent.click(link)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/components/TagItem/index.tsx
+++ b/packages/react/src/components/TagItem/index.tsx
@@ -61,6 +61,7 @@ const TagItem = forwardRef<HTMLAnchorElement, TagItemProps>(
 
     const { linkProps } = useLink(
       {
+        ...props,
         isDisabled: disabled,
         elementType: typeof Component === 'string' ? Component : 'a',
       },


### PR DESCRIPTION
## やったこと

- TagItemが十分propsを渡せていない

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
