### PR TITLE
fix: react unbundle treeshake

### DIFF
--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -39,17 +39,46 @@ export default defineConfig({
   clean: false,
   target: 'esnext',
   sourcemap: true,
-  minify: true,
+  // Preserve per-module structure instead of bundling into a single file.
+  // A single bundle prevents consumer bundlers (webpack, etc.) from
+  // tree-shaking unused components (Modal, Popover, etc.) and their
+  // transitive deps like react-aria's overlay machinery — tens of KB
+  // would end up in chunks that only use Button. Per-module output
+  // combined with sideEffects: ["*.css"] ensures only imported
+  // component modules enter the consumer's module graph.
+  unbundle: true,
+  // Skip minification — the consumer's bundler will minify anyway, and
+  // minifying here would destroy /*#__PURE__*/ annotations and module
+  // structure that the consumer's innerGraph analysis needs to drop
+  // unused exports.
+  minify: false,
   deps: {
     neverBundle: ['react-compiler-runtime'],
   },
   css: {
+    // unbundle sets css.splitting by default; disable it so all CSS is
+    // collected into a single index.css instead of per-chunk files.
+    splitting: false,
     fileName: 'index.css',
     transformer: 'postcss',
     postcss: path.join(import.meta.dirname, 'postcss.config.mjs'),
   },
   async onSuccess() {
-    const indexCssPath = path.resolve(import.meta.dirname, './dist/index.css')
+    const distDir = path.resolve(import.meta.dirname, './dist')
+
+    // Strip "use client" and empty-css markers from barrel entry files so
+    // that bundlers (webpack, etc.) treat re-exports as side-effect-free
+    // and can tree-shake unused components.
+    for (const name of ['index.js', 'index.cjs']) {
+      const p = path.join(distDir, name)
+      const src = await fs.readFile(p, 'utf-8')
+      const cleaned = src
+        .replace(/^"use client";\n?/, '')
+        .replace(/\/\*\s*empty css\s*\*\/\n?/g, '')
+      if (cleaned !== src) await fs.writeFile(p, cleaned)
+    }
+
+    const indexCssPath = path.join(distDir, 'index.css')
     const originalCssOutput = await fs.readFile(indexCssPath, 'utf-8')
     if (!originalCssOutput) {
       throw new Error('[at-layer-charcoal]: expect original css output')


### PR DESCRIPTION
## やったこと

- use client, bundle mode, minifyがtreeshakeの妨げになるので調整してみる

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
