### PR TITLE
fix: workaround postcss-merge-rules bug

### DIFF
--- a/packages/react/src/__tests__/css-shorthand-safety.test.ts
+++ b/packages/react/src/__tests__/css-shorthand-safety.test.ts
@@ -88,7 +88,7 @@ function findConflicts(root: postcss.Root, file: string): Conflict[] {
 
   root.walkRules((rule) => {
     for (const [shorthand, longhands] of Object.entries(
-      SHORTHAND_TO_LONGHANDS
+      SHORTHAND_TO_LONGHANDS,
     )) {
       let seenShorthand = false
       const conflicting: string[] = []
@@ -135,7 +135,7 @@ describe('CSS shorthand/longhand safety', () => {
       const report = allConflicts
         .map(
           (c) =>
-            `${c.file}: "${c.selector}" has ${c.shorthand} followed by ${c.longhands.join(', ')}`
+            `${c.file}: "${c.selector}" has ${c.shorthand} followed by ${c.longhands.join(', ')}`,
         )
         .join('\n')
       expect.fail(
@@ -143,7 +143,7 @@ describe('CSS shorthand/longhand safety', () => {
           `can extract longhands into merged selectors, leaving the shorthand to ` +
           `silently reset them.\n\n` +
           `Fix: either expand the shorthand into individual properties, or fold ` +
-          `the longhand values into the shorthand.\n\n${report}`
+          `the longhand values into the shorthand.\n\n${report}`,
       )
     }
   })

--- a/packages/react/src/__tests__/css-shorthand-safety.test.ts
+++ b/packages/react/src/__tests__/css-shorthand-safety.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import postcss from 'postcss'
+import postcssNested from 'postcss-nested'
+
+/**
+ * CSS shorthand properties reset ALL their sub-properties. When a rule has
+ * e.g. `font: inherit` followed by `line-height: 22px`, the longhand
+ * correctly overrides the shorthand within that rule. But CSS minifiers
+ * (cssnano's postcss-merge-rules) can extract the shared longhand into a
+ * merged selector, leaving only the shorthand — which then silently resets
+ * the longhand back.
+ *
+ * This test detects shorthand-then-longhand patterns in component CSS so
+ * we catch them before they reach production minification.
+ */
+
+const SHORTHAND_TO_LONGHANDS: Record<string, string[]> = {
+  font: [
+    'font-family',
+    'font-size',
+    'font-style',
+    'font-variant',
+    'font-weight',
+    'font-stretch',
+    'line-height',
+  ],
+  background: [
+    'background-color',
+    'background-image',
+    'background-position',
+    'background-size',
+    'background-repeat',
+    'background-origin',
+    'background-clip',
+    'background-attachment',
+  ],
+  animation: [
+    'animation-name',
+    'animation-duration',
+    'animation-timing-function',
+    'animation-delay',
+    'animation-iteration-count',
+    'animation-direction',
+    'animation-fill-mode',
+    'animation-play-state',
+  ],
+}
+
+const componentsDir = path.resolve(import.meta.dirname, '../components')
+
+async function getComponentCssFiles() {
+  const results: string[] = []
+  async function walk(dir: string) {
+    for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(full)
+      } else if (entry.isFile() && entry.name.endsWith('.css')) {
+        results.push(full)
+      }
+    }
+  }
+  await walk(componentsDir)
+  return results
+}
+
+function selectorPath(rule: postcss.Rule): string {
+  const parts: string[] = []
+  let node: postcss.Container | postcss.Document | undefined = rule
+  while (node && node.type === 'rule') {
+    parts.unshift((node as postcss.Rule).selector.replace(/\s+/g, ' ').trim())
+    node = node.parent as postcss.Container | undefined
+  }
+  return parts.join(' ')
+}
+
+interface Conflict {
+  file: string
+  selector: string
+  shorthand: string
+  longhands: string[]
+}
+
+function findConflicts(root: postcss.Root, file: string): Conflict[] {
+  const conflicts: Conflict[] = []
+
+  root.walkRules((rule) => {
+    for (const [shorthand, longhands] of Object.entries(
+      SHORTHAND_TO_LONGHANDS
+    )) {
+      let seenShorthand = false
+      const conflicting: string[] = []
+
+      rule.walkDecls((decl) => {
+        if (decl.parent !== rule) return
+        if (decl.prop === shorthand) {
+          seenShorthand = true
+          conflicting.length = 0
+        } else if (seenShorthand && longhands.includes(decl.prop)) {
+          conflicting.push(decl.prop)
+        }
+      })
+
+      if (conflicting.length > 0) {
+        conflicts.push({
+          file: path.relative(componentsDir, file),
+          selector: selectorPath(rule),
+          shorthand,
+          longhands: conflicting,
+        })
+      }
+    }
+  })
+
+  return conflicts
+}
+
+const cssFiles = await getComponentCssFiles()
+
+describe('CSS shorthand/longhand safety', () => {
+  it('no shorthand followed by its longhands in the same rule', async () => {
+    const allConflicts: Conflict[] = []
+
+    for (const file of cssFiles) {
+      const source = await fs.readFile(file, 'utf-8')
+      const result = await postcss([postcssNested()]).process(source, {
+        from: file,
+      })
+      allConflicts.push(...findConflicts(result.root, file))
+    }
+
+    if (allConflicts.length > 0) {
+      const report = allConflicts
+        .map(
+          (c) =>
+            `${c.file}: "${c.selector}" has ${c.shorthand} followed by ${c.longhands.join(', ')}`
+        )
+        .join('\n')
+      expect.fail(
+        `Shorthand/longhand conflicts found. CSS minifiers (cssnano merge-rules) ` +
+          `can extract longhands into merged selectors, leaving the shorthand to ` +
+          `silently reset them.\n\n` +
+          `Fix: either expand the shorthand into individual properties, or fold ` +
+          `the longhand values into the shorthand.\n\n${report}`
+      )
+    }
+  })
+})

--- a/packages/react/src/components/Button/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Button/__snapshots__/index.css.snap
@@ -9,7 +9,9 @@
   letter-spacing: inherit;
   word-spacing: inherit;
   text-decoration: none;
-  font: inherit;
+  font-family: inherit;
+  font-style: inherit;
+  font-variant: inherit;
   margin: 0;
   overflow: visible;
   text-transform: none;

--- a/packages/react/src/components/Button/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Button/__snapshots__/index.css.snap
@@ -1,6 +1,5 @@
 .charcoal-button {
   appearance: none;
-  background-color: transparent;
   background-image: none;
   box-sizing: border-box;
   padding: 0 24px;
@@ -28,7 +27,7 @@
   line-height: 22px;
   font-weight: bold;
   color: var(--charcoal-color-text-default);
-  background-color: var(--charcoal-color-container-secondary-default-a);
+  background-color: var(--charcoal-color-container-secondary-default-a, transparent);
   transition: 0.2s color,
     0.2s background-color,
     0.2s box-shadow;

--- a/packages/react/src/components/Button/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Button/__snapshots__/index.css.snap
@@ -27,7 +27,10 @@
   line-height: 22px;
   font-weight: bold;
   color: var(--charcoal-color-text-default);
-  background-color: var(--charcoal-color-container-secondary-default-a, transparent);
+  background-color: var(
+    --charcoal-color-container-secondary-default-a,
+    transparent
+  );
   transition: 0.2s color,
     0.2s background-color,
     0.2s box-shadow;

--- a/packages/react/src/components/Button/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Button/__snapshots__/index.css.snap
@@ -1,6 +1,7 @@
 .charcoal-button {
   appearance: none;
-  background: transparent;
+  background-color: transparent;
+  background-image: none;
   box-sizing: border-box;
   padding: 0 24px;
   border-style: none;

--- a/packages/react/src/components/Button/index.css
+++ b/packages/react/src/components/Button/index.css
@@ -9,7 +9,9 @@
   letter-spacing: inherit;
   word-spacing: inherit;
   text-decoration: none;
-  font: inherit;
+  font-family: inherit;
+  font-style: inherit;
+  font-variant: inherit;
   margin: 0;
   overflow: visible;
   text-transform: none;

--- a/packages/react/src/components/Button/index.css
+++ b/packages/react/src/components/Button/index.css
@@ -1,6 +1,5 @@
 .charcoal-button {
   appearance: none;
-  background-color: transparent;
   background-image: none;
   box-sizing: border-box;
   padding: 0 24px;
@@ -28,7 +27,7 @@
   line-height: 22px;
   font-weight: bold;
   color: var(--charcoal-color-text-default);
-  background-color: var(--charcoal-color-container-secondary-default-a);
+  background-color: var(--charcoal-color-container-secondary-default-a, transparent);
   transition:
     0.2s color,
     0.2s background-color,

--- a/packages/react/src/components/Button/index.css
+++ b/packages/react/src/components/Button/index.css
@@ -1,6 +1,7 @@
 .charcoal-button {
   appearance: none;
-  background: transparent;
+  background-color: transparent;
+  background-image: none;
   box-sizing: border-box;
   padding: 0 24px;
   border-style: none;

--- a/packages/react/src/components/Button/index.css
+++ b/packages/react/src/components/Button/index.css
@@ -27,7 +27,10 @@
   line-height: 22px;
   font-weight: bold;
   color: var(--charcoal-color-text-default);
-  background-color: var(--charcoal-color-container-secondary-default-a, transparent);
+  background-color: var(
+    --charcoal-color-container-secondary-default-a,
+    transparent
+  );
   transition:
     0.2s color,
     0.2s background-color,

--- a/packages/react/src/components/LoadingSpinner/__snapshots__/index.css.snap
+++ b/packages/react/src/components/LoadingSpinner/__snapshots__/index.css.snap
@@ -33,8 +33,7 @@ to {
   height: 1em;
   border-radius: 1em;
   background-color: currentColor;
-  animation: charcoal-loading-spinner-icon-scale-out 1s both ease-out;
-  animation-iteration-count: infinite;
+  animation: charcoal-loading-spinner-icon-scale-out 1s infinite both ease-out;
 }
 
 .charcoal-loading-spinner-icon[data-reset-animation] {

--- a/packages/react/src/components/LoadingSpinner/index.css
+++ b/packages/react/src/components/LoadingSpinner/index.css
@@ -31,8 +31,7 @@
   height: 1em;
   border-radius: 1em;
   background-color: currentColor;
-  animation: charcoal-loading-spinner-icon-scale-out 1s both ease-out;
-  animation-iteration-count: infinite;
+  animation: charcoal-loading-spinner-icon-scale-out 1s infinite both ease-out;
 
   &[data-reset-animation] {
     animation: none;

--- a/packages/react/src/components/Pagination/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Pagination/__snapshots__/index.css.snap
@@ -23,7 +23,9 @@
   border-style: none;
   outline: none;
   text-decoration: none;
-  font: inherit;
+  font-family: inherit;
+  font-style: inherit;
+  font-variant: inherit;
   margin: 0;
   user-select: none;
   display: flex;

--- a/packages/react/src/components/Pagination/index.css
+++ b/packages/react/src/components/Pagination/index.css
@@ -22,7 +22,9 @@
   border-style: none;
   outline: none;
   text-decoration: none;
-  font: inherit;
+  font-family: inherit;
+  font-style: inherit;
+  font-variant: inherit;
   margin: 0;
   user-select: none;
 


### PR DESCRIPTION
## やったこと

- workaround https://github.com/vercel/next.js/issues/96056

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
