### PR TITLE
fix: add dropdown and sandbox notes

### DIFF
--- a/.storybook/src/v6.0.0.mdx
+++ b/.storybook/src/v6.0.0.mdx
@@ -6,6 +6,8 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 v6 では、`@charcoal-ui/react` のコンポーネントを Design Token 2.0 に対応させました。あわせて、react-sandbox からのコンポーネント移行、React Aria の依存関係の再編、アイコンの SSR 対応などを行っています。
 
+> **非推奨:** `@charcoal-ui/react-sandbox` は v6 から非推奨です。次のメジャーバージョンでパッケージの削除を検討しています。新規に利用せず、既存の実装は `@charcoal-ui/react` へ順次移行してください。
+
 ---
 
 # v5 からの移行チェックリスト
@@ -15,7 +17,8 @@ v6 では、`@charcoal-ui/react` のコンポーネントを Design Token 2.0 �
    a. Design Token 2.0の見た目を使用したい範囲に `.ch-token-v2` クラスが有効になるように指定します。
 3. `TagItem` をボタンとして使っている場合は、`component="button"` を明示します。
 4. `UnstableTextEllipsis` / `UnstablePagination` を stable な export 名へ置き換えます。
-5. peer dependency の解決エラーが出る場合は、`react-aria` と `react-stately` をアプリケーションへ追加します。
+5. `@charcoal-ui/react-sandbox` を利用している場合は、`@charcoal-ui/react` へ順次移行します。
+6. peer dependency の解決エラーが出る場合は、`react-aria` と `react-stately` をアプリケーションへ追加します。
 
 ```diff
 -import { UnstableTextEllipsis, UnstablePagination } from '@charcoal-ui/react'
@@ -198,6 +201,10 @@ Design Token 2.0 では、複数の Design Token 1.0 のトークンを 1 つの
 ---
 
 # コンポーネント
+
+## DropdownSelector
+
+iPadOS Safari で Apple Pencil などのペン入力を使用した場合に、DropdownSelector を開けない、選択肢を選べない、または選択肢の外側をタップしても閉じられない問題を修正しました。マウス、タッチ、キーボードでの操作方法に変更はありません。
 
 ## TextEllipsis / Pagination の stable 化（破壊的変更）
 


### PR DESCRIPTION
## やったこと

- DropdownSelectorのApple Pencil対応と、react-sandboxについての内容を v6.0.0.mdxに追加

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
