### PR TITLE
fix(styled): stop inferring createTheme's theme from the styled argument

### DIFF
--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -1,5 +1,5 @@
-import { CSSObject, ThemedStyledInterface } from 'styled-components'
-import { CharcoalAbstractTheme } from '@charcoal-ui/theme'
+import type { CSSObject, DefaultTheme } from 'styled-components'
+import type { CharcoalAbstractTheme, CharcoalTheme } from '@charcoal-ui/theme'
 import { ArrayOrSingle, isPresent, noThemeProvider, wrapArray } from './util'
 import { Internal, toCSSObjects } from './internals'
 import createO from './builders/o'
@@ -35,20 +35,29 @@ const nonBlank = <T>(value: T): value is T extends Blank ? never : T =>
  *
  * `theme(o => [...])` の `theme` ユーティリティを構築する
  *
- * @param _styled - DEPRECATED: styled-components の `styled` そのものを渡すとそれを元に型推論ができる。が、型引数を渡す方が型推論が高速になりやすい
+ * @param _styled - DEPRECATED: 実行時には元々使われていない引数。以前は
+ *   styled-components の `styled` を渡すと `T` を型推論できたが、この推論は
+ *   `ThemedStyledInterface` (全 HTML タグ × ThemedStyledFunction) の変性計算と
+ *   インスタンス化を誘発し、呼び出し側リポジトリの型検査を極端に遅くするため
+ *   現在は型レベルでも無視される。`T` は既定で `DefaultTheme`
+ *   (module augmentation 済みの場合) に解決される
  *
  * @example
  *
  * import styled from 'styled-components'
- * const theme = createTheme(styled)
+ * const theme = createTheme(styled) // T = DefaultTheme (引数は無視される)
  *
  * @example
  *
  * const theme = createTheme<DefaultTheme>()
  */
-export function createTheme<T extends CharcoalAbstractTheme>(
-  _styled?: ThemedStyledInterface<T>,
-) {
+export function createTheme<
+  // DefaultTheme が CharcoalAbstractTheme を満たすように augment されていればそれを、
+  // されていなければ charcoal 標準の CharcoalTheme を既定にする
+  T extends CharcoalAbstractTheme = DefaultTheme extends CharcoalAbstractTheme
+    ? DefaultTheme
+    : CharcoalTheme,
+>(_styled?: unknown) {
   type Builder = ReturnType<typeof createO<T>>
 
   // ランタイムの `theme(o => [...])` のインターフェースを構築する


### PR DESCRIPTION
## やったこと

`createTheme(styled)` の `_styled` 引数からの型推論をやめ、`T` を
`DefaultTheme` (augment 済みの場合) / `CharcoalTheme` (未 augment) のデフォルトに変更します。
runtime は元々この引数を無視しており、挙動変更はありません。

## 背景 / 動機

`_styled?: ThemedStyledInterface<T>` から `T` を推論させると、コンパイラは消費側リポジトリで
`ThemedStyledInterface` (全 HTML タグ × `ThemedStyledFunction`) の**変性計算とインスタンス化**を
強制されます。JSDoc が既に「型引数を渡す方が型推論が高速になりやすい」と注意している既知問題ですが、
規模の大きいリポジトリでは注意書きでは済まないコストになります。

- `_styled` は受け取るが型レベルでも無視する (`unknown`)
- デフォルトを条件型にしているのは、ライブラリ内では `DefaultTheme` が素の空 interface で
  `extends CharcoalAbstractTheme` 制約を満たせないため。消費側で augment されていれば
  `DefaultTheme`、なければ `CharcoalTheme` に解決される
- JSDoc の `@param` 説明と example を現状に合わせて更新

## 互換性

- **runtime: 変更なし** (実装は `_styled` を一度も参照していない)
- **型レベル: 実用上は互換**
  - `createTheme(styled)` / `createTheme<DefaultTheme>()` / `createTheme()` はすべて
    従来どおりコンパイルされる。module の `styled` は常に
    `ThemedStyledInterface<DefaultTheme>` なので、推論結果も従来と同じ `DefaultTheme`
  - 影響があるのは「`ThemedStyledComponentsModule` で独自テーマの `styled` を作り、
    それを渡して推論させていた」消費者のみ (明示型引数の追記が必要)。
    deprecated API のため次版の changelog に注記すれば十分と考えています

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
