### PR TITLE
fix: remap transparent default a

### DIFF
--- a/packages/react/src/components/LoadingSpinner/__snapshots__/index.css.snap
+++ b/packages/react/src/components/LoadingSpinner/__snapshots__/index.css.snap
@@ -12,7 +12,7 @@
 }
 
 .charcoal-loading-spinner[data-transparent='true'] {
-  background-color: var(--charcoal-color-container-default-a);
+  background-color: transparent;
 }
 
 @keyframes charcoal-loading-spinner-icon-scale-out {

--- a/packages/react/src/components/LoadingSpinner/index.css
+++ b/packages/react/src/components/LoadingSpinner/index.css
@@ -11,7 +11,7 @@
   background-color: var(--charcoal-color-background-default);
 
   &[data-transparent='true'] {
-    background-color: var(--charcoal-color-container-default-a);
+    background-color: transparent;
   }
 }
 

--- a/packages/react/src/components/Pagination/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Pagination/__snapshots__/index.css.snap
@@ -42,7 +42,7 @@
   /* stylelint-disable-next-line property-no-vendor-prefix */
   -webkit-transform: translateZ(0);
   color: var(--charcoal-color-text-tertiary-default);
-  background-color: var(--charcoal-color-container-default-a);
+  background-color: transparent;
   border-radius: 20px;
   transition: 0.2s background-color,
     0.2s box-shadow;

--- a/packages/react/src/components/Pagination/index.css
+++ b/packages/react/src/components/Pagination/index.css
@@ -43,7 +43,7 @@
   -webkit-transform: translateZ(0);
 
   color: var(--charcoal-color-text-tertiary-default);
-  background-color: var(--charcoal-color-container-default-a);
+  background-color: transparent;
   border-radius: 20px;
   transition:
     0.2s background-color,


### PR DESCRIPTION
## やったこと

- https://github.com/pixiv/charcoal/blame/2f89ba73f06cb028bc8611ae356342c4de05952d/packages/react/src/components/Pagination/index.css
- --charcoal-transparent -> --charcoal-color-container-default-a is wrong

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
