### PR TITLE
fix(icons-cli): remove incompatible p-queue usage

### DIFF
--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -33,7 +33,6 @@
     "figma-js": "^1.14.0",
     "fs-extra": "^10.0.0",
     "jsdom": "^24.1.0",
-    "p-queue": "^6.6.2",
     "path-to-regexp": "^6.2.0",
     "polished": "^4.1.4",
     "svgo": "^1.3.2",

--- a/packages/icons-cli/src/concurrently.test.ts
+++ b/packages/icons-cli/src/concurrently.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { concurrently } from './concurrently.ts'
+
+describe('concurrently', () => {
+  it('runs at most three tasks concurrently', async () => {
+    let activeTasks = 0
+    let maxActiveTasks = 0
+    let releaseTasks: () => void = () => undefined
+    const tasksCanFinish = new Promise<void>((resolve) => {
+      releaseTasks = resolve
+    })
+
+    const tasks = Array.from({ length: 6 }, () => async () => {
+      activeTasks += 1
+      maxActiveTasks = Math.max(maxActiveTasks, activeTasks)
+      await tasksCanFinish
+      activeTasks -= 1
+    })
+
+    const completion = concurrently(tasks)
+    expect(activeTasks).toBe(3)
+
+    releaseTasks()
+    await completion
+
+    expect(maxActiveTasks).toBe(3)
+    expect(activeTasks).toBe(0)
+  })
+
+  it('accepts an empty task list', async () => {
+    await expect(concurrently([])).resolves.toBeUndefined()
+  })
+})

--- a/packages/icons-cli/src/concurrently.ts
+++ b/packages/icons-cli/src/concurrently.ts
@@ -1,11 +1,15 @@
-import PQueue from 'p-queue'
+export async function concurrently(tasks: (() => Promise<unknown>)[]) {
+  let nextTaskIndex = 0
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function concurrently(tasks: (() => Promise<any>)[]) {
-  const queue = new PQueue({ concurrency: 3 })
-  for (const task of tasks) {
-    void queue.add(task)
+  async function worker() {
+    while (nextTaskIndex < tasks.length) {
+      const task = tasks[nextTaskIndex]
+      nextTaskIndex += 1
+      await task()
+    }
   }
-  queue.start()
-  return queue.onIdle()
+
+  await Promise.all(
+    Array.from({ length: Math.min(3, tasks.length) }, () => worker()),
+  )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,9 +325,6 @@ importers:
       jsdom:
         specifier: ^24.1.0
         version: 24.1.3
-      p-queue:
-        specifier: ^6.6.2
-        version: 6.6.2
       path-to-regexp:
         specifier: ^6.2.0
         version: 6.3.0


### PR DESCRIPTION
## やったこと

- icons-cliで利用している並列処理で、PQueueをはずしてPromise.allに変えた

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
