### PR TITLE
fix: テキスト選択が背景にはみ出すと Modal が閉じる問題を修正

### DIFF
--- a/packages/react/src/components/Modal/index.browser.test.tsx
+++ b/packages/react/src/components/Modal/index.browser.test.tsx
@@ -10,7 +10,7 @@
  * 2. jsdom は PointerEvent を実装しておらず、react-aria の
  *    useInteractOutside が本番と同じ pointerdown + click の経路を通らない。
  */
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { OverlayProvider } from 'react-aria'
 import { vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
@@ -74,5 +74,26 @@ describe('Modal (outside interaction)', () => {
     })
 
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // 自前判定を導入した #472 の原因だった「スクロールバー操作で閉じる」の再発防止。
+  // Chrome のスクロールバー操作は pointerdown / mousedown / mouseup を背景要素に
+  // 発火させるが click は合成しない (実 Chrome + イベント計測で確認済みの列)。
+  // headless Chromium は overlay scrollbar 固定で実スクロールバーを出せないため、
+  // このイベント列を再現して click ベースの外側判定でだけ通ることを担保する
+  it('スクロールバー操作相当のイベント列 (click なし) では閉じない', () => {
+    const onClose = vi.fn()
+    const { background } = renderModal(onClose)
+
+    fireEvent.pointerDown(background, { button: 0 })
+    fireEvent.mouseDown(background, { button: 0 })
+    fireEvent.mouseUp(background, { button: 0 })
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    // 対照: 同じ列に click が続けば閉じる。上の未発火が
+    // 「イベントが判定に届いていないだけ」ではないことの保証
+    fireEvent.click(background, { button: 0 })
+    expect(onClose).toHaveBeenCalledOnce()
   })
 })

--- a/packages/react/src/components/Modal/index.browser.test.tsx
+++ b/packages/react/src/components/Modal/index.browser.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * 背景クリックでの dismiss 判定テスト
+ *
+ * jsdom では検証できないため実ブラウザで実行する:
+ *
+ * 1. mousedown と mouseup のターゲットが異なるとき、ブラウザは両者の
+ *    最も近い共通祖先で click を合成する。テキスト選択のドラッグが
+ *    ダイアログ内から背景上へはみ出すと click のターゲットは背景になる。
+ *    jsdom はこの合成を行わないため実ブラウザでしか再現できない。
+ * 2. jsdom は PointerEvent を実装しておらず、react-aria の
+ *    useInteractOutside が本番と同じ pointerdown + click の経路を通らない。
+ */
+import { render } from '@testing-library/react'
+import { OverlayProvider } from 'react-aria'
+import { vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import Modal from '.'
+import { ModalHeader } from './ModalPlumbing'
+
+const getBackground = () => {
+  const bg = document.querySelector('.charcoal-modal-background')
+  if (!(bg instanceof HTMLElement)) throw new Error('background not found')
+  return bg
+}
+
+const renderModal = (onClose: () => void) => {
+  const result = render(
+    <OverlayProvider>
+      <Modal title="test modal" isOpen onClose={onClose}>
+        <ModalHeader />
+        <input data-testid="text" defaultValue="selectable text" />
+      </Modal>
+    </OverlayProvider>,
+  )
+  return {
+    input: result.getByTestId('text'),
+    background: getBackground(),
+  }
+}
+
+/** trusted イベントは React の act() 管理外で発火するため区間を区切る */
+async function withoutActEnvironment(run: () => Promise<void>) {
+  const g = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  g.IS_REACT_ACT_ENVIRONMENT = false
+  try {
+    await run()
+  } finally {
+    g.IS_REACT_ACT_ENVIRONMENT = true
+  }
+}
+
+describe('Modal (outside interaction)', () => {
+  it('背景の実クリックで閉じる', async () => {
+    const onClose = vi.fn()
+    const { background } = renderModal(onClose)
+
+    await withoutActEnvironment(async () => {
+      // ダイアログは背景の中央にあるので、左上の余白を実クリックする
+      await userEvent.click(background, { position: { x: 8, y: 8 } })
+    })
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('テキスト選択がダイアログ内から背景上へはみ出しても閉じない', async () => {
+    const onClose = vi.fn()
+    const { input, background } = renderModal(onClose)
+
+    await withoutActEnvironment(async () => {
+      // input のテキスト上で press → 背景の余白で release
+      await userEvent.dragAndDrop(input, background, {
+        targetPosition: { x: 8, y: 8 },
+      })
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/components/Modal/index.test.tsx
+++ b/packages/react/src/components/Modal/index.test.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
-import { render, fireEvent, act, cleanup } from '@testing-library/react'
+import { render, fireEvent, act, cleanup, screen } from '@testing-library/react'
 import { OverlayProvider } from 'react-aria'
 import { vi, describe, it, expect, afterEach } from 'vitest'
 import Modal from '.'
+import DropdownSelector from '../DropdownSelector'
+import DropdownMenuItem from '../DropdownSelector/DropdownMenuItem'
 import { MODAL_TRANSITION_DURATION_MS } from './useTransitionPresence'
 
 const MOBILE_WIDTH = 500
@@ -70,6 +72,53 @@ afterEach(() => {
   cleanup()
   vi.useRealTimers()
   setWindowWidth(DESKTOP_WIDTH)
+})
+
+describe('Modal (outside interaction)', () => {
+  it('背景の上で押して離すと閉じる', () => {
+    const { open } = renderModal()
+    open()
+
+    const bg = getBackground() as Element
+    fireEvent.mouseDown(bg)
+    fireEvent.mouseUp(bg)
+    fireEvent.click(bg)
+    expect(getDialog()).not.toBeInTheDocument()
+  })
+
+  it('ダイアログ内で押し始めて背景の上で離しても閉じない', () => {
+    const { open } = renderModal()
+    open()
+
+    // テキスト選択のドラッグ: mousedown はダイアログ内、mouseup は背景上。
+    // このときブラウザは両者の共通祖先である背景で click を合成する
+    fireEvent.mouseDown(getDialog() as Element)
+    fireEvent.mouseUp(getBackground() as Element)
+    fireEvent.click(getBackground() as Element)
+    expect(getDialog()).toBeInTheDocument()
+  })
+
+  it('Modal 内の DropdownSelector の項目を選択しても Modal は閉じない', () => {
+    // Popover は document.body にポータルされるためダイアログの DOM の外にあるが、
+    // react-aria の overlay スタックにより最前面の popover だけが閉じる
+    render(
+      <OverlayProvider>
+        <Modal title="test modal" isOpen onClose={vi.fn()}>
+          <DropdownSelector label="Label" value="1" onChange={vi.fn()}>
+            <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+            <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+          </DropdownSelector>
+        </Modal>
+      </OverlayProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Label/ }))
+    const item = screen.getByText('Option 2')
+    fireEvent.mouseDown(item)
+    fireEvent.mouseUp(item)
+    fireEvent.click(item)
+    expect(getDialog()).toBeInTheDocument()
+  })
 })
 
 describe('Modal (bottom sheet transition)', () => {

--- a/packages/react/src/components/Modal/index.tsx
+++ b/packages/react/src/components/Modal/index.tsx
@@ -106,15 +106,6 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
   const { isPresent, animationState, handleTransitionEnd } =
     useTransitionPresence(isOpen, transitionEnabled, bgRef, ref)
 
-  const handleClick = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      if (e.currentTarget === e.target) {
-        onClose()
-      }
-    },
-    [onClose],
-  )
-
   if (!isPresent) {
     return null
   }
@@ -128,7 +119,6 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(function ModalInner(
         style={{ zIndex }}
         data-bottom-sheet={bottomSheet}
         data-animation={transitionEnabled ? animationState : undefined}
-        onClick={handleClick}
         onTransitionEnd={handleTransitionEnd}
       >
         <ModalBackgroundContext.Provider value={bgRef.current}>

--- a/packages/react/src/components/Modal/useCustomModalOverlay.tsx
+++ b/packages/react/src/components/Modal/useCustomModalOverlay.tsx
@@ -9,11 +9,6 @@ import {
 } from 'react-aria/useModalOverlay'
 import { useOverlay } from 'react-aria/useOverlay'
 
-/**
- * We want to enable scrolling on the modal background,
- * but `useModalOverlay` (specifically, `useOverlay` within it) detects pointer events on the scrollbar.
- * Therefore, to prevent this issue, we need to override `shouldCloseOnInteractOutside` in `useModalOverlay`.
- */
 export type CharcoalModalOverlayProps = AriaModalOverlayProps & {
   overflowClip?: boolean
 }
@@ -27,7 +22,9 @@ export function useCharcoalModalOverlay(
       ...props,
       isOpen: state.isOpen,
       onClose: state.onClose,
-      shouldCloseOnInteractOutside: () => false,
+      // charcoal では isDismissable は閉じるボタンと ESC の制御であり、
+      // 背景クリックでの dismiss は isDismissable に関係なく常に有効
+      isDismissable: true,
     },
     ref,
   )


### PR DESCRIPTION
## やったこと

Modal 内の TextField でテキスト選択のドラッグを始め、マウスカーソルが overlay(背景)上に出た状態で離すと Modal が dismiss されてしまう問題を修正しました。

### 原因

mousedown と mouseup のターゲットが異なる場合、ブラウザは `click` を両者の最も近い共通祖先で合成します。ダイアログ内で押し始めて背景上で離すと click のターゲットは背景自身になるため、`e.currentTarget === e.target` による自前の dismiss 判定(#472 で導入)をすり抜けて `onClose()` が発火していました。

### 修正方針

自前の `onClick` 判定を削除し、dismiss 判定を react-aria `useOverlay` の interact-outside に委譲しました。

- 自前判定の導入理由だった「スクロールバー操作で Modal が閉じる」問題(d847aeafc 当時の react-aria ^3.20)は、現行 3.48.0 が pointerdown 位置トラッキング + click ベース検知に変わったことで upstream で解消済み
- charcoal の `isDismissable` prop は閉じるボタン表示 + ESC の制御のみで、背景クリック dismiss は従来どおり無条件(`useOverlay` へ内部的に `isDismissable: true` を常に渡す)。既存挙動への breaking change はありません

## 動作確認環境

- vitest (jsdom) 221 件 + vitest browser mode (Chromium 実ブラウザ) 45 件すべて通過
- Storybook + 実 Chrome (macOS) で trusted 入力によるイベント計測つきで確認:
  - TextField からのドラッグが背景上で終わり click が背景で合成されても閉じない
  - 背景の通常クリックでは従来どおり閉じる
  - Modal 内 DropdownSelector の項目選択で Modal が閉じない(react-aria の overlay スタックが機能)
  - `::-webkit-scrollbar` でクラシックスクロールバーを強制した状態(Windows Chrome 相当)でスクロールバーを操作しても、Chrome が click を抑制するため閉じない

## チェックリスト

不要なチェック項目は消して構いません

- [x] 破壊的変更がないことを確認した(背景クリック dismiss の挙動は従来と同一)


## 補足: スクロールバー問題の再発防止テスト

#472 の原因だった「スクロールバー操作で閉じる」については、実 Chrome での計測でスクロールバー操作が `pointerdown` / `mousedown` / `mouseup` を背景要素に発火させつつ `click` を合成しないことを確認した上で、そのイベント列を browser test で再現し「click なしでは閉じない(click が続けば閉じる)」ことを担保しています。react-aria が pointerup ベース判定に退行した場合はこのテストが落ちます。
