### PR TITLE
TextAreaコンポーネントで長いテキスト入力による折り返しでもAutoHeight挙動をさせる

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9992,38 +9992,47 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeight 1`] = `
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          Label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              Label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 4;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="false"
+              id="test-id"
+              rows="4"
+              style=""
+            />
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 4;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="false"
-          id="test-id"
-          rows="4"
-        />
       </div>
     </div>
   </div>
@@ -10036,52 +10045,61 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightAndDefaul
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 3;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="3"
+              style=""
+            >
+              デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+            </textarea>
+            <span
+              class="charcoal-text-area-counter"
+            >
+              87
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 8;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="8"
-        >
-          デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-        </textarea>
-        <span
-          class="charcoal-text-area-counter"
-        >
-          87
-        </span>
       </div>
     </div>
   </div>
@@ -10094,38 +10112,149 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightAndRows 1
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 3;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="false"
+              id="test-id"
+              rows="3"
+              style=""
+            />
+          </div>
         </div>
       </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/TextArea > react/TextArea > AutoHeightWithSoftWrap 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
+    >
       <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 3;"
+        style="width: 100%; max-width: 640px;"
       >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="false"
-          id="test-id"
-          rows="3"
-        />
+        <div
+          style="display: grid; grid-template-columns: 160px 320px; gap: 16px;"
+        >
+          <div
+            aria-disabled="false"
+            class="charcoal-text-area-root"
+          >
+            <div
+              class="charcoal-field-label-root"
+              style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+            >
+              <label
+                class="charcoal-field-label"
+                for="test-id"
+                id="test-id"
+              >
+                狭い幅
+              </label>
+              <div
+                class="charcoal-field-label-sub-label"
+              >
+                <span />
+              </div>
+            </div>
+            <div
+              aria-invalid="false"
+              class="charcoal-text-area-container"
+              style="--charcoal-text-area-rows: 1;"
+            >
+              <textarea
+                aria-labelledby="test-id"
+                class="charcoal-text-area-textarea"
+                data-no-bottom-padding="false"
+                id="test-id"
+                rows="1"
+                style=""
+              >
+                改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。
+              </textarea>
+            </div>
+          </div>
+          <div
+            aria-disabled="false"
+            class="charcoal-text-area-root"
+          >
+            <div
+              class="charcoal-field-label-root"
+              style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+            >
+              <label
+                class="charcoal-field-label"
+                for="test-id"
+                id="test-id"
+              >
+                maxRows と showCount
+              </label>
+              <div
+                class="charcoal-field-label-sub-label"
+              >
+                <span />
+              </div>
+            </div>
+            <div
+              aria-invalid="false"
+              class="charcoal-text-area-container"
+              style="--charcoal-text-area-rows: 1;"
+            >
+              <textarea
+                aria-labelledby="test-id"
+                class="charcoal-text-area-textarea"
+                data-no-bottom-padding="true"
+                id="test-id"
+                rows="1"
+                style=""
+              >
+                改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。
+              </textarea>
+              <span
+                class="charcoal-text-area-counter"
+              >
+                135
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -10382,47 +10511,56 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowWorkingChangi
   <div
     data-dark="false"
   >
-    <button>
-      insert value
-    </button>
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
+        <button>
+          insert value
+        </button>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 1;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="1"
+              style=""
+            />
+            <span
+              class="charcoal-text-area-counter"
+            >
+              0
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 1;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="1"
-        />
-        <span
-          class="charcoal-text-area-counter"
-        >
-          0
-        </span>
       </div>
     </div>
   </div>
@@ -10434,47 +10572,56 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowWorkingChangi
   <div
     data-dark="false"
   >
-    <button>
-      insert value
-    </button>
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
+        <button>
+          insert value
+        </button>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 1;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="1"
+              style=""
+            />
+            <span
+              class="charcoal-text-area-counter"
+            >
+              0
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 1;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="1"
-        />
-        <span
-          class="charcoal-text-area-counter"
-        >
-          0
-        </span>
       </div>
     </div>
   </div>
@@ -10487,43 +10634,52 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRows 1`] = `
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 4;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="4"
+              style=""
+            />
+            <span
+              class="charcoal-text-area-counter"
+            >
+              0
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 4;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="4"
-        />
-        <span
-          class="charcoal-text-area-counter"
-        >
-          0
-        </span>
       </div>
     </div>
   </div>
@@ -10536,43 +10692,52 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowsAndRows 1`] 
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 3;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="3"
+              style=""
+            />
+            <span
+              class="charcoal-text-area-counter"
+            >
+              0
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 3;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="3"
-        />
-        <span
-          class="charcoal-text-area-counter"
-        >
-          0
-        </span>
       </div>
     </div>
   </div>
@@ -10585,52 +10750,61 @@ exports[`Storybook Tests > react/TextArea > react/TextArea > MaxRowsOverInitialR
     data-dark="false"
   >
     <div
-      aria-disabled="false"
-      class="charcoal-text-area-root"
+      style="display: grid; min-height: calc(100vh - 32px); place-items: center;"
     >
       <div
-        class="charcoal-field-label-root"
-        style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        style="width: 100%; max-width: 640px;"
       >
-        <label
-          class="charcoal-field-label"
-          for="test-id"
-          id="test-id"
-        >
-          label
-        </label>
         <div
-          class="charcoal-field-label-sub-label"
+          aria-disabled="false"
+          class="charcoal-text-area-root"
         >
-          <span />
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              for="test-id"
+              id="test-id"
+            >
+              label
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-invalid="false"
+            class="charcoal-text-area-container"
+            style="--charcoal-text-area-rows: 3;"
+          >
+            <textarea
+              aria-labelledby="test-id"
+              class="charcoal-text-area-textarea"
+              data-no-bottom-padding="true"
+              id="test-id"
+              rows="3"
+              style=""
+            >
+              デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+デフォルトの入力内容
+            </textarea>
+            <span
+              class="charcoal-text-area-counter"
+            >
+              87
+            </span>
+          </div>
         </div>
-      </div>
-      <div
-        aria-invalid="false"
-        class="charcoal-text-area-container"
-        style="--charcoal-text-area-rows: 6;"
-      >
-        <textarea
-          aria-labelledby="test-id"
-          class="charcoal-text-area-textarea"
-          data-no-bottom-padding="true"
-          id="test-id"
-          rows="6"
-        >
-          デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-デフォルトの入力内容
-        </textarea>
-        <span
-          class="charcoal-text-area-counter"
-        >
-          87
-        </span>
       </div>
     </div>
   </div>

--- a/packages/react/src/components/TextArea/TextArea.browser.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.browser.test.tsx
@@ -207,14 +207,16 @@ describe('TextArea autoHeight', () => {
     const containers = Array.from(
       container.querySelectorAll('.charcoal-text-area-container'),
     ) as HTMLDivElement[]
-    const disabledTextArea = containers[2].querySelector('textarea')
+    const disabledTextArea = containers[2].querySelector(
+      'textarea',
+    ) as HTMLTextAreaElement
     const disabledHeight = containers[2].getBoundingClientRect().height
 
     await vi.waitFor(() => {
       expect(getRows(containers[0])).toBeGreaterThan(1)
       expect(getRows(containers[1])).toBe(getRows(containers[0]))
     })
-    fireEvent.change(disabledTextArea!, { target: { value: longText } })
+    fireEvent.change(disabledTextArea, { target: { value: longText } })
     expect(containers[2].getBoundingClientRect().height).toBe(disabledHeight)
   })
 })

--- a/packages/react/src/components/TextArea/TextArea.browser.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.browser.test.tsx
@@ -5,9 +5,7 @@ import TextArea, { type TextAreaImperativeHandle } from '.'
 const longText = '折り返しを確認するための長いテキストです。'.repeat(12)
 
 function getRows(container: HTMLElement) {
-  return Number(
-    container.style.getPropertyValue('--charcoal-text-area-rows'),
-  )
+  return Number(container.style.getPropertyValue('--charcoal-text-area-rows'))
 }
 
 describe('TextArea autoHeight', () => {
@@ -73,7 +71,9 @@ describe('TextArea autoHeight', () => {
     ) as HTMLDivElement
 
     fireEvent.click(getByRole('button', { name: 'long' }))
-    await vi.waitFor(() => expect(getRows(controlledContainer)).toBeGreaterThan(1))
+    await vi.waitFor(() =>
+      expect(getRows(controlledContainer)).toBeGreaterThan(1),
+    )
     fireEvent.click(getByRole('button', { name: 'short' }))
     await vi.waitFor(() => expect(getRows(controlledContainer)).toBe(1))
 
@@ -129,11 +129,15 @@ describe('TextArea autoHeight', () => {
     ) as HTMLDivElement
 
     fireEvent.click(getByRole('button', { name: 'long' }))
-    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(1))
+    await vi.waitFor(() =>
+      expect(getRows(textAreaContainer)).toBeGreaterThan(1),
+    )
     fireEvent.click(getByRole('button', { name: 'short' }))
     await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(1))
     fireEvent.click(getByRole('button', { name: 'sync' }))
-    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(1))
+    await vi.waitFor(() =>
+      expect(getRows(textAreaContainer)).toBeGreaterThan(1),
+    )
   })
 
   it('recalculates soft wraps when the container width changes', async () => {
@@ -144,7 +148,12 @@ describe('TextArea autoHeight', () => {
           <button onClick={() => setWidth(120)}>narrow</button>
           <button onClick={() => setWidth(320)}>wide</button>
           <div style={{ width }}>
-            <TextArea autoHeight rows={1} label="label" defaultValue={longText} />
+            <TextArea
+              autoHeight
+              rows={1}
+              label="label"
+              defaultValue={longText}
+            />
           </div>
         </>
       )
@@ -160,7 +169,9 @@ describe('TextArea autoHeight', () => {
       fireEvent.click(getByRole('button', { name: 'narrow' }))
       await new Promise(requestAnimationFrame)
     })
-    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(wideRows))
+    await vi.waitFor(() =>
+      expect(getRows(textAreaContainer)).toBeGreaterThan(wideRows),
+    )
     await act(async () => {
       fireEvent.click(getByRole('button', { name: 'wide' }))
       await new Promise(requestAnimationFrame)
@@ -172,7 +183,12 @@ describe('TextArea autoHeight', () => {
     const { container } = render(
       <>
         <div style={{ width: 160 }}>
-          <TextArea autoHeight rows={1} label="without count" defaultValue={longText} />
+          <TextArea
+            autoHeight
+            rows={1}
+            label="without count"
+            defaultValue={longText}
+          />
         </div>
         <div style={{ width: 160 }}>
           <TextArea

--- a/packages/react/src/components/TextArea/TextArea.browser.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.browser.test.tsx
@@ -1,0 +1,204 @@
+import { fireEvent, render } from '@testing-library/react'
+import { act, useRef, useState } from 'react'
+import TextArea, { type TextAreaImperativeHandle } from '.'
+
+const longText = '折り返しを確認するための長いテキストです。'.repeat(12)
+
+function getRows(container: HTMLElement) {
+  return Number(
+    container.style.getPropertyValue('--charcoal-text-area-rows'),
+  )
+}
+
+describe('TextArea autoHeight', () => {
+  it('grows and shrinks for soft-wrapped and explicit new lines', async () => {
+    const { container } = render(
+      <div style={{ width: 160 }}>
+        <TextArea autoHeight rows={1} label="label" />
+      </div>,
+    )
+    const textArea = container.querySelector('textarea') as HTMLTextAreaElement
+    const textAreaContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+    const initialHeight = textAreaContainer.getBoundingClientRect().height
+
+    fireEvent.change(textArea, { target: { value: longText } })
+    await vi.waitFor(() => {
+      expect(textAreaContainer.getBoundingClientRect().height).toBeGreaterThan(
+        initialHeight,
+      )
+    })
+
+    fireEvent.change(textArea, { target: { value: 'one\ntwo\nthree' } })
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(3))
+
+    fireEvent.change(textArea, { target: { value: 'short' } })
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(1))
+  })
+
+  it('caps soft-wrapped content at maxRows and leaves the textarea scrollable', async () => {
+    const { container } = render(
+      <div style={{ width: 160 }}>
+        <TextArea rows={1} maxRows={3} label="label" />
+      </div>,
+    )
+    const textArea = container.querySelector('textarea') as HTMLTextAreaElement
+    const textAreaContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+
+    fireEvent.change(textArea, { target: { value: longText } })
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(3))
+    expect(textArea.scrollHeight).toBeGreaterThan(textArea.clientHeight)
+  })
+
+  it('synchronizes controlled values and an initial defaultValue', async () => {
+    function ControlledTextArea() {
+      const [value, setValue] = useState('short')
+      return (
+        <>
+          <button onClick={() => setValue(longText)}>long</button>
+          <button onClick={() => setValue('short')}>short</button>
+          <div style={{ width: 160 }}>
+            <TextArea autoHeight rows={1} label="label" value={value} />
+          </div>
+        </>
+      )
+    }
+
+    const { container, getByRole } = render(<ControlledTextArea />)
+    const controlledContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+
+    fireEvent.click(getByRole('button', { name: 'long' }))
+    await vi.waitFor(() => expect(getRows(controlledContainer)).toBeGreaterThan(1))
+    fireEvent.click(getByRole('button', { name: 'short' }))
+    await vi.waitFor(() => expect(getRows(controlledContainer)).toBe(1))
+
+    const { container: defaultValueContainer } = render(
+      <div style={{ width: 160 }}>
+        <TextArea autoHeight rows={1} label="label" defaultValue={longText} />
+      </div>,
+    )
+    const defaultContainer = defaultValueContainer.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+    await vi.waitFor(() => expect(getRows(defaultContainer)).toBeGreaterThan(1))
+  })
+
+  it('synchronizes values set through imperativeRef', async () => {
+    function ImperativeTextArea() {
+      const imperativeRef = useRef<TextAreaImperativeHandle>(null)
+      const textAreaRef = useRef<HTMLTextAreaElement>(null)
+      return (
+        <>
+          <button onClick={() => imperativeRef.current?.setValue(longText)}>
+            long
+          </button>
+          <button onClick={() => imperativeRef.current?.setValue('short')}>
+            short
+          </button>
+          <button
+            onClick={() => {
+              if (textAreaRef.current !== null) {
+                textAreaRef.current.value = longText
+                imperativeRef.current?.sync()
+              }
+            }}
+          >
+            sync
+          </button>
+          <div style={{ width: 160 }}>
+            <TextArea
+              autoHeight
+              rows={1}
+              label="label"
+              imperativeRef={imperativeRef}
+              ref={textAreaRef}
+            />
+          </div>
+        </>
+      )
+    }
+
+    const { container, getByRole } = render(<ImperativeTextArea />)
+    const textAreaContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+
+    fireEvent.click(getByRole('button', { name: 'long' }))
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(1))
+    fireEvent.click(getByRole('button', { name: 'short' }))
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(1))
+    fireEvent.click(getByRole('button', { name: 'sync' }))
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(1))
+  })
+
+  it('recalculates soft wraps when the container width changes', async () => {
+    function ResizableTextArea() {
+      const [width, setWidth] = useState(320)
+      return (
+        <>
+          <button onClick={() => setWidth(120)}>narrow</button>
+          <button onClick={() => setWidth(320)}>wide</button>
+          <div style={{ width }}>
+            <TextArea autoHeight rows={1} label="label" defaultValue={longText} />
+          </div>
+        </>
+      )
+    }
+
+    const { container, getByRole } = render(<ResizableTextArea />)
+    const textAreaContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+    const wideRows = getRows(textAreaContainer)
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'narrow' }))
+      await new Promise(requestAnimationFrame)
+    })
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBeGreaterThan(wideRows))
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: 'wide' }))
+      await new Promise(requestAnimationFrame)
+    })
+    await vi.waitFor(() => expect(getRows(textAreaContainer)).toBe(wideRows))
+  })
+
+  it('keeps text rows independent from showCount and does not resize without autoHeight', async () => {
+    const { container } = render(
+      <>
+        <div style={{ width: 160 }}>
+          <TextArea autoHeight rows={1} label="without count" defaultValue={longText} />
+        </div>
+        <div style={{ width: 160 }}>
+          <TextArea
+            autoHeight
+            rows={1}
+            label="with count"
+            showCount
+            defaultValue={longText}
+          />
+        </div>
+        <div style={{ width: 160 }}>
+          <TextArea rows={1} label="without auto height" />
+        </div>
+      </>,
+    )
+    const containers = Array.from(
+      container.querySelectorAll('.charcoal-text-area-container'),
+    ) as HTMLDivElement[]
+    const disabledTextArea = containers[2].querySelector('textarea')
+    const disabledHeight = containers[2].getBoundingClientRect().height
+
+    await vi.waitFor(() => {
+      expect(getRows(containers[0])).toBeGreaterThan(1)
+      expect(getRows(containers[1])).toBe(getRows(containers[0]))
+    })
+    fireEvent.change(disabledTextArea!, { target: { value: longText } })
+    expect(containers[2].getBoundingClientRect().height).toBe(disabledHeight)
+  })
+})

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -156,6 +156,34 @@ export const AutoHeightAndDefaultValue: StoryObj<typeof TextArea> = {
   },
 }
 
+export const AutoHeightWithSoftWrap: StoryObj<typeof TextArea> = {
+  render: function Render() {
+    const longText =
+      '改行を含まない長い日本語テキストでも、入力欄の横幅に合わせて折り返され、高さが伸縮します。'.repeat(
+        3,
+      )
+
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: '160px 320px', gap: 16 }}>
+        <TextArea
+          autoHeight
+          rows={1}
+          label="狭い幅"
+          defaultValue={longText}
+        />
+        <TextArea
+          autoHeight
+          rows={1}
+          maxRows={4}
+          showCount
+          label="maxRows と showCount"
+          defaultValue={longText}
+        />
+      </div>
+    )
+  },
+}
+
 export const MaxRows: StoryObj<typeof TextArea> = {
   render: function Render() {
     return <TextArea maxRows={6} label="label" showCount />

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -2,7 +2,25 @@ import { action } from 'storybook/actions'
 import Clickable from '../Clickable'
 import TextArea, { type TextAreaImperativeHandle } from '.'
 import { Meta, StoryObj } from '@storybook/react-vite'
-import { useCallback, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useRef, useState } from 'react'
+
+const autoHeightStoryParameters = {
+  layout: 'padded',
+} as const
+
+function AutoHeightStoryLayout({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        minHeight: 'calc(100vh - 32px)',
+        placeItems: 'center',
+      }}
+    >
+      <div style={{ width: '100%', maxWidth: 640 }}>{children}</div>
+    </div>
+  )
+}
 
 export default {
   title: 'react/TextArea',
@@ -130,30 +148,43 @@ export const DefaultValue: StoryObj<typeof TextArea> = {
 
 export const AutoHeight: StoryObj<typeof TextArea> = {
   render: function Render() {
-    return <TextArea autoHeight label="Label" />
+    return (
+      <AutoHeightStoryLayout>
+        <TextArea autoHeight label="Label" />
+      </AutoHeightStoryLayout>
+    )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const AutoHeightAndRows: StoryObj<typeof TextArea> = {
   render: function Render() {
-    return <TextArea rows={3} autoHeight label="label" />
+    return (
+      <AutoHeightStoryLayout>
+        <TextArea rows={3} autoHeight label="label" />
+      </AutoHeightStoryLayout>
+    )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const AutoHeightAndDefaultValue: StoryObj<typeof TextArea> = {
   render: function Render() {
     return (
-      <TextArea
-        rows={3}
-        autoHeight
-        label="label"
-        showCount
-        defaultValue={
-          'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
-        }
-      />
+      <AutoHeightStoryLayout>
+        <TextArea
+          rows={3}
+          autoHeight
+          label="label"
+          showCount
+          defaultValue={
+            'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
+          }
+        />
+      </AutoHeightStoryLayout>
     )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const AutoHeightWithSoftWrap: StoryObj<typeof TextArea> = {
@@ -164,49 +195,74 @@ export const AutoHeightWithSoftWrap: StoryObj<typeof TextArea> = {
       )
 
     return (
-      <div
-        style={{ display: 'grid', gridTemplateColumns: '160px 320px', gap: 16 }}
-      >
-        <TextArea autoHeight rows={1} label="狭い幅" defaultValue={longText} />
-        <TextArea
-          autoHeight
-          rows={1}
-          maxRows={4}
-          showCount
-          label="maxRows と showCount"
-          defaultValue={longText}
-        />
-      </div>
+      <AutoHeightStoryLayout>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '160px 320px',
+            gap: 16,
+          }}
+        >
+          <TextArea
+            autoHeight
+            rows={1}
+            label="狭い幅"
+            defaultValue={longText}
+          />
+          <TextArea
+            autoHeight
+            rows={1}
+            maxRows={4}
+            showCount
+            label="maxRows と showCount"
+            defaultValue={longText}
+          />
+        </div>
+      </AutoHeightStoryLayout>
     )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const MaxRows: StoryObj<typeof TextArea> = {
   render: function Render() {
-    return <TextArea maxRows={6} label="label" showCount />
+    return (
+      <AutoHeightStoryLayout>
+        <TextArea maxRows={6} label="label" showCount />
+      </AutoHeightStoryLayout>
+    )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const MaxRowsAndRows: StoryObj<typeof TextArea> = {
   render: function Render() {
-    return <TextArea rows={3} maxRows={6} label="label" showCount />
+    return (
+      <AutoHeightStoryLayout>
+        <TextArea rows={3} maxRows={6} label="label" showCount />
+      </AutoHeightStoryLayout>
+    )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const MaxRowsOverInitialRow: StoryObj<typeof TextArea> = {
   render: function Render() {
     return (
-      <TextArea
-        rows={3}
-        maxRows={6}
-        label="label"
-        showCount
-        defaultValue={
-          'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
-        }
-      />
+      <AutoHeightStoryLayout>
+        <TextArea
+          rows={3}
+          maxRows={6}
+          label="label"
+          showCount
+          defaultValue={
+            'デフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容\nデフォルトの入力内容'
+          }
+        />
+      </AutoHeightStoryLayout>
     )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
@@ -218,7 +274,7 @@ export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
       )
     }, [])
     return (
-      <>
+      <AutoHeightStoryLayout>
         <button
           onClick={() => {
             handleClick()
@@ -227,9 +283,10 @@ export const MaxRowWorkingChangingValue: StoryObj<typeof TextArea> = {
           insert value
         </button>
         <TextArea rows={1} autoHeight label="label" value={value} showCount />
-      </>
+      </AutoHeightStoryLayout>
     )
   },
+  parameters: autoHeightStoryParameters,
 }
 
 export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
@@ -241,7 +298,7 @@ export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
       )
     }, [])
     return (
-      <>
+      <AutoHeightStoryLayout>
         <button
           onClick={() => {
             handleClick()
@@ -256,7 +313,8 @@ export const MaxRowWorkingChangingValueInRef: StoryObj<typeof TextArea> = {
           autoHeight
           imperativeRef={imperativeRef}
         />
-      </>
+      </AutoHeightStoryLayout>
     )
   },
+  parameters: autoHeightStoryParameters,
 }

--- a/packages/react/src/components/TextArea/TextArea.story.tsx
+++ b/packages/react/src/components/TextArea/TextArea.story.tsx
@@ -164,13 +164,10 @@ export const AutoHeightWithSoftWrap: StoryObj<typeof TextArea> = {
       )
 
     return (
-      <div style={{ display: 'grid', gridTemplateColumns: '160px 320px', gap: 16 }}>
-        <TextArea
-          autoHeight
-          rows={1}
-          label="狭い幅"
-          defaultValue={longText}
-        />
+      <div
+        style={{ display: 'grid', gridTemplateColumns: '160px 320px', gap: 16 }}
+      >
+        <TextArea autoHeight rows={1} label="狭い幅" defaultValue={longText} />
         <TextArea
           autoHeight
           rows={1}

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -2,6 +2,20 @@ import { render, screen } from '@testing-library/react'
 import TextArea from '.'
 
 describe('TextArea component', () => {
+  const computedStyle = {
+    lineHeight: '22px',
+    paddingTop: '8px',
+    paddingBottom: '8px',
+  } as CSSStyleDeclaration
+
+  beforeEach(() => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue(computedStyle)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it.each`
     name                                    | value                        | defaultValue | expectedValue | expectedCount
     ${'uncontrolled defaultValue'}          | ${undefined}                 | ${'abc'}     | ${'abc'}      | ${'3'}
@@ -13,5 +27,34 @@ describe('TextArea component', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue(expectedValue)
     expect(screen.getByText(expectedCount)).toBeInTheDocument()
+  })
+
+  it('uses the measured row count while respecting rows and maxRows', () => {
+    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockReturnValue(
+      104,
+    )
+
+    const { container, rerender } = render(
+      <TextArea autoHeight rows={2} defaultValue="long value" />,
+    )
+    const textAreaContainer = container.querySelector(
+      '.charcoal-text-area-container',
+    ) as HTMLDivElement
+
+    expect(
+      textAreaContainer.style.getPropertyValue('--charcoal-text-area-rows'),
+    ).toBe('4')
+
+    rerender(<TextArea autoHeight rows={5} defaultValue="long value" />)
+    expect(
+      textAreaContainer.style.getPropertyValue('--charcoal-text-area-rows'),
+    ).toBe('5')
+
+    rerender(
+      <TextArea autoHeight rows={5} maxRows={3} defaultValue="long value" />,
+    )
+    expect(
+      textAreaContainer.style.getPropertyValue('--charcoal-text-area-rows'),
+    ).toBe('3')
   })
 })

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -31,9 +31,11 @@ describe('TextArea component', () => {
   })
 
   it('uses the measured row count while respecting rows and maxRows', () => {
-    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockReturnValue(
-      104,
-    )
+    vi.spyOn(
+      HTMLTextAreaElement.prototype,
+      'scrollHeight',
+      'get',
+    ).mockReturnValue(104)
 
     const { container, rerender } = render(
       <TextArea autoHeight rows={2} defaultValue="long value" />,
@@ -61,12 +63,14 @@ describe('TextArea component', () => {
 
   it('restores the textarea inline overflow after measuring its height', () => {
     let overflowYWhileMeasuring: string | undefined
-    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
-      function (this: HTMLTextAreaElement) {
-        overflowYWhileMeasuring = this.style.overflowY
-        return 104
-      },
-    )
+    vi.spyOn(
+      HTMLTextAreaElement.prototype,
+      'scrollHeight',
+      'get',
+    ).mockImplementation(function (this: HTMLTextAreaElement) {
+      overflowYWhileMeasuring = this.style.overflowY
+      return 104
+    })
 
     render(
       <TextArea
@@ -83,6 +87,8 @@ describe('TextArea component', () => {
   it('does not create a ResizeObserver when it is unavailable', () => {
     vi.stubGlobal('ResizeObserver', undefined)
 
-    expect(() => render(<TextArea autoHeight defaultValue="value" />)).not.toThrow()
+    expect(() =>
+      render(<TextArea autoHeight defaultValue="value" />),
+    ).not.toThrow()
   })
 })

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -14,6 +14,7 @@ describe('TextArea component', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it.each`
@@ -56,5 +57,32 @@ describe('TextArea component', () => {
     expect(
       textAreaContainer.style.getPropertyValue('--charcoal-text-area-rows'),
     ).toBe('3')
+  })
+
+  it('restores the textarea inline overflow after measuring its height', () => {
+    let overflowYWhileMeasuring: string | undefined
+    vi.spyOn(HTMLTextAreaElement.prototype, 'scrollHeight', 'get').mockImplementation(
+      function (this: HTMLTextAreaElement) {
+        overflowYWhileMeasuring = this.style.overflowY
+        return 104
+      },
+    )
+
+    render(
+      <TextArea
+        autoHeight
+        defaultValue="long value"
+        style={{ overflowY: 'scroll' }}
+      />,
+    )
+
+    expect(overflowYWhileMeasuring).toBe('hidden')
+    expect(screen.getByRole('textbox')).toHaveStyle({ overflowY: 'scroll' })
+  })
+
+  it('does not create a ResizeObserver when it is unavailable', () => {
+    vi.stubGlobal('ResizeObserver', undefined)
+
+    expect(() => render(<TextArea autoHeight defaultValue="value" />)).not.toThrow()
   })
 })

--- a/packages/react/src/components/TextArea/TextArea.test.tsx
+++ b/packages/react/src/components/TextArea/TextArea.test.tsx
@@ -81,7 +81,8 @@ describe('TextArea component', () => {
     )
 
     expect(overflowYWhileMeasuring).toBe('hidden')
-    expect(screen.getByRole('textbox')).toHaveStyle({ overflowY: 'scroll' })
+    const textArea = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(textArea.style.overflowY).toBe('scroll')
   })
 
   it('does not create a ResizeObserver when it is unavailable', () => {

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -33,7 +33,8 @@ const measureTextAreaRows = (textarea: HTMLTextAreaElement) => {
     const style = getComputedStyle(textarea)
     const lineHeight = Number.parseFloat(style.lineHeight)
     const paddingBlock =
-      Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom)
+      Number.parseFloat(style.paddingTop) +
+      Number.parseFloat(style.paddingBottom)
     const contentHeight = textarea.scrollHeight - paddingBlock
 
     // scrollHeight is rounded to whole pixels while line-height can be a

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -19,12 +19,16 @@ import { useIsomorphicLayoutEffect } from '../../_lib/useIsomorphicLayoutEffect'
 
 const measureTextAreaRows = (textarea: HTMLTextAreaElement) => {
   const previousHeight = textarea.style.height
+  const previousOverflowY = textarea.style.overflowY
 
   try {
     // A fixed height prevents scrollHeight from shrinking with the content.
     // Reset it synchronously so that soft-wrapped lines are measured as laid
     // out by the browser, rather than inferred from the textarea value.
     textarea.style.height = '0px'
+    // Avoid a non-overlay scrollbar reducing the available line width only
+    // while the temporary height is applied.
+    textarea.style.overflowY = 'hidden'
 
     const style = getComputedStyle(textarea)
     const lineHeight = Number.parseFloat(style.lineHeight)
@@ -37,6 +41,7 @@ const measureTextAreaRows = (textarea: HTMLTextAreaElement) => {
     return Math.max(1, Math.round(contentHeight / lineHeight))
   } finally {
     textarea.style.height = previousHeight
+    textarea.style.overflowY = previousOverflowY
   }
 }
 
@@ -218,7 +223,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       if (
         !isEnableAutoHeight ||
         container === null ||
-        !('ResizeObserver' in window)
+        typeof ResizeObserver === 'undefined'
       ) {
         return
       }

--- a/packages/react/src/components/TextArea/index.tsx
+++ b/packages/react/src/components/TextArea/index.tsx
@@ -3,7 +3,6 @@ import './index.css'
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -16,6 +15,30 @@ import { AssistiveText } from '../TextField/AssistiveText'
 import { useClassNames } from '../../_lib/useClassNames'
 import { useVisuallyHidden } from 'react-aria/VisuallyHidden'
 import { useId } from 'react-aria/useId'
+import { useIsomorphicLayoutEffect } from '../../_lib/useIsomorphicLayoutEffect'
+
+const measureTextAreaRows = (textarea: HTMLTextAreaElement) => {
+  const previousHeight = textarea.style.height
+
+  try {
+    // A fixed height prevents scrollHeight from shrinking with the content.
+    // Reset it synchronously so that soft-wrapped lines are measured as laid
+    // out by the browser, rather than inferred from the textarea value.
+    textarea.style.height = '0px'
+
+    const style = getComputedStyle(textarea)
+    const lineHeight = Number.parseFloat(style.lineHeight)
+    const paddingBlock =
+      Number.parseFloat(style.paddingTop) + Number.parseFloat(style.paddingBottom)
+    const contentHeight = textarea.scrollHeight - paddingBlock
+
+    // scrollHeight is rounded to whole pixels while line-height can be a
+    // fractional value (notably due to the iOS Safari scale workaround).
+    return Math.max(1, Math.round(contentHeight / lineHeight))
+  } finally {
+    textarea.style.height = previousHeight
+  }
+}
 
 /**
  * `TextArea` を `imperativeRef` から操作するためのハンドル
@@ -86,12 +109,12 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const [count, setCount] = useState(getCount(countValue))
 
     const textareaRef = useRef<HTMLTextAreaElement>(null)
-    const containerRef = useRef(null)
+    const containerRef = useRef<HTMLDivElement>(null)
     useFocusWithClick(containerRef, textareaRef)
     const { visuallyHiddenProps } = useVisuallyHidden()
 
     const isEnableAutoHeight = useMemo(
-      () => autoHeight || (maxRows && maxRows >= 0),
+      () => autoHeight || (maxRows !== undefined && maxRows >= 1),
       [autoHeight, maxRows],
     )
     const classNames = useClassNames('charcoal-text-area-root', className)
@@ -100,17 +123,18 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     const syncHeight = useCallback(
       (textarea: HTMLTextAreaElement) => {
-        const currentRows =
-          (`${textarea.value}\n`.match(/\n/gu)?.length ?? 0) || 1
+        const currentRows = measureTextAreaRows(textarea)
         const hasValidMaxRows = maxRows !== undefined && maxRows >= 1
         const nextRows = initialRows <= currentRows ? currentRows : initialRows
+        const nextHeightRows = hasValidMaxRows
+          ? Math.min(nextRows, maxRows)
+          : nextRows
 
-        if (!hasValidMaxRows) {
-          setRows(nextRows)
-          return
-        }
-
-        setRows(Math.min(nextRows, maxRows))
+        setRows((currentHeightRows) =>
+          currentHeightRows === nextHeightRows
+            ? currentHeightRows
+            : nextHeightRows,
+        )
       },
       [initialRows, maxRows],
     )
@@ -170,7 +194,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const describedbyId = useId()
     const labelledbyId = useId()
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       // 制御コンポーネントの時の挙動
       if (!isUncontrolled) {
         setCount(getCount(countValue))
@@ -188,6 +212,33 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       textareaRef,
       syncHeight,
     ])
+
+    useIsomorphicLayoutEffect(() => {
+      const container = containerRef.current
+      if (
+        !isEnableAutoHeight ||
+        container === null ||
+        !('ResizeObserver' in window)
+      ) {
+        return
+      }
+
+      let previousWidth = container.getBoundingClientRect().width
+      const observer = new ResizeObserver((entries) => {
+        const width = entries[0]?.contentRect.width
+        if (width === undefined || width === previousWidth) {
+          return
+        }
+
+        previousWidth = width
+        if (textareaRef.current !== null) {
+          syncHeight(textareaRef.current)
+        }
+      })
+
+      observer.observe(container)
+      return () => observer.disconnect()
+    }, [isEnableAutoHeight, syncHeight])
 
     return (
       <div className={classNames} aria-disabled={disabled}>


### PR DESCRIPTION
## やったこと
- `TextArea` の自動高さ調整を、改行だけでなくソフトラップにも対応
- 入力値やコンテナ幅の変更時に高さを再計算するよう修正
- `rows` / `maxRows` を考慮した高さ制御とスクロール動作を改善
- 自動高さ調整のユニットテスト・ブラウザテストを追加
- ソフトラップを確認できる Storybook とスナップショットを更新

### 注意事項
- 親要素の幅が内容依存（shrink-to-fit）の場合、`TextArea` が想定より狭くなる可能性がある
- 幅が狭くなるとソフトラップが増え、`autoHeight` による高さが大きくなる
- Flex/Grid の中央配置、`inline-flex`、`fit-content`、幅未指定の絶対配置などで発生しやすい
- コンポーネント単体では適切な幅を決められないため、呼び出し側で親要素の幅を指定する必要がある
- 折り返しの境界近辺となる文字数で、本来より早く行数の増加が起こるなど、挙動がやや不安定になるので、できるだけTextArea外側で横幅が決まるようにすること。

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
