### PR TITLE
feat: snackbar コンポーネントを追加

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -12605,7 +12605,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > B
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; bottom: 12px;"
+    style="z-index: 10; --charcoal-snackbar-offset: 12px;"
     tabindex="-1"
   >
     <div
@@ -12651,7 +12651,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
     data-position="top"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; top: 16px;"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12697,7 +12697,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; bottom: 16px;"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12750,7 +12750,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > L
     data-position="top"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; top: 16px;"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12796,7 +12796,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; bottom: 16px;"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -12588,52 +12588,6 @@ exports[`Storybook Tests > react/internals/Popover > react/internals/Popover > B
 </div>
 `;
 
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Bottom 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 12px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="false"
-      data-with-button="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          下部に表示します
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Default 1`] = `
 <div>
   <div
@@ -12648,7 +12602,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
   <div
     aria-label="1 notification."
     class="charcoal-snackbar-region"
-    data-position="top"
+    data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
     style="z-index: 10; --charcoal-snackbar-offset: 16px;"
@@ -12747,6 +12701,52 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > L
   <div
     aria-label="1 notification."
     class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Top 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
     data-position="top"
     data-react-aria-top-layer="true"
     role="region"
@@ -12771,7 +12771,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > L
           class="charcoal-snackbar-label"
           id="test-id"
         >
-          保存した内容はすべての端末に同期され、あとから設定画面で変更できます
+          上部に表示します
         </div>
       </div>
     </div>
@@ -12826,6 +12826,54 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
       >
         取り消す
       </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithLineBreak 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存に失敗しました
+          <br />
+          通信環境を確認してください
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9409,251 +9409,6 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
 </div>
 `;
 
-exports[`Storybook Tests > react/Snackbar > react/Snackbar > Bottom 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; bottom: 12px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="false"
-      data-with-button="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          下部に表示します
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/Snackbar > react/Snackbar > Default 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; top: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="false"
-      data-with-button="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          保存しました
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/Snackbar > react/Snackbar > Dim 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; bottom: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="true"
-      data-with-button="true"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          Dim の Snackbar
-        </div>
-      </div>
-      <button
-        aria-keyshortcuts="F6"
-        class="charcoal-button charcoal-snackbar-button"
-        data-size="S"
-        data-variant="Overlay"
-      >
-        閉じる
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/Snackbar > react/Snackbar > LongMessage 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; top: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="false"
-      data-with-button="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          保存した内容はすべての端末に同期され、あとから設定画面で変更できます
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithButton 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 10; bottom: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-snackbar"
-      data-dim="false"
-      data-with-button="true"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-snackbar-content"
-        role="status"
-      >
-        <div
-          class="charcoal-snackbar-label"
-          id="test-id"
-        >
-          保存しました
-        </div>
-      </div>
-      <button
-        aria-keyshortcuts="F6"
-        class="charcoal-button charcoal-snackbar-button"
-        data-size="S"
-      >
-        取り消す
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storybook Tests > react/Switch > react/Switch > Checked 1`] = `
 <div>
   <div
@@ -12829,6 +12584,249 @@ exports[`Storybook Tests > react/internals/Popover > react/internals/Popover > B
     >
       button
     </button>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Bottom 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 12px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          下部に表示します
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Default 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; top: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Dim 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="true"
+      data-with-button="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          Dim の Snackbar
+        </div>
+      </div>
+      <button
+        class="charcoal-button"
+        data-size="S"
+        data-variant="Navigation"
+      >
+        閉じる
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > LongMessage 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; top: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存した内容はすべての端末に同期され、あとから設定画面で変更できます
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithButton 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+      <button
+        class="charcoal-button"
+        data-size="S"
+      >
+        取り消す
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -12605,7 +12605,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12651,7 +12651,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12704,7 +12704,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > L
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12750,7 +12750,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > T
     data-position="top"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12796,7 +12796,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div
@@ -12848,7 +12848,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
     data-position="bottom"
     data-react-aria-top-layer="true"
     role="region"
-    style="z-index: 10; --charcoal-snackbar-offset: 16px;"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
     tabindex="-1"
   >
     <div

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9409,6 +9409,251 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
 </div>
 `;
 
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Bottom 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 12px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          下部に表示します
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Default 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; top: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Dim 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="true"
+      data-with-button="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          Dim の Snackbar
+        </div>
+      </div>
+      <button
+        aria-keyshortcuts="F6"
+        class="charcoal-button charcoal-snackbar-button"
+        data-size="S"
+        data-variant="Overlay"
+      >
+        閉じる
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > LongMessage 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; top: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存した内容はすべての端末に同期され、あとから設定画面で変更できます
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithButton 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 10; bottom: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-snackbar"
+      data-dim="false"
+      data-with-button="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-snackbar-content"
+        role="status"
+      >
+        <div
+          class="charcoal-snackbar-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+      <button
+        aria-keyshortcuts="F6"
+        class="charcoal-button charcoal-snackbar-button"
+        data-size="S"
+      >
+        取り消す
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/Switch > react/Switch > Checked 1`] = `
 <div>
   <div

--- a/misc/test/vitest.snapshot-serializer.ts
+++ b/misc/test/vitest.snapshot-serializer.ts
@@ -16,12 +16,18 @@ function isTestingLibraryContainer(value: unknown): value is HTMLElement {
   )
 }
 
+function isOverlayPortalNode(child: Element) {
+  return (
+    child.classList.contains('charcoal-modal-background') ||
+    child.classList.contains('charcoal-snackbar-region') ||
+    child.querySelector('.charcoal-snackbar-region') !== null
+  )
+}
+
 function hasModalPortal(source: HTMLElement) {
   return Array.from(document.body.children).some((child) => {
     return (
-      child !== source &&
-      !source.contains(child) &&
-      child.classList.contains('charcoal-modal-background')
+      child !== source && !source.contains(child) && isOverlayPortalNode(child)
     )
   })
 }
@@ -45,9 +51,7 @@ function normalizeReactAriaIds(root: HTMLElement) {
 function appendPortalContent(source: HTMLElement, target: HTMLElement) {
   const portalNodes = Array.from(document.body.children).filter((child) => {
     return (
-      child !== source &&
-      !source.contains(child) &&
-      child.classList.contains('charcoal-modal-background')
+      child !== source && !source.contains(child) && isOverlayPortalNode(child)
     )
   })
 
@@ -60,11 +64,16 @@ function appendPortalContent(source: HTMLElement, target: HTMLElement) {
 
   target.removeAttribute('aria-hidden')
 
-  for (const child of Array.from(overlayContainer.children)) {
-    if (child.classList.contains('charcoal-modal-background')) {
-      break
+  const hasModal = portalNodes.some((node) =>
+    node.classList.contains('charcoal-modal-background'),
+  )
+  if (hasModal) {
+    for (const child of Array.from(overlayContainer.children)) {
+      if (child.classList.contains('charcoal-modal-background')) {
+        break
+      }
+      child.setAttribute('aria-hidden', 'true')
     }
-    child.setAttribute('aria-hidden', 'true')
   }
 
   for (const portalNode of portalNodes) {

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -56,22 +56,15 @@
 .charcoal-snackbar-content {
   display: flex;
   align-items: center;
-  flex: 0 1 auto;
   min-width: 0;
 }
 
 .charcoal-snackbar-label {
-  flex: 0 1 auto;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   font-size: var(--charcoal-text-font-size-caption-m);
   font-weight: var(--charcoal-text-font-weight-bold);
   line-height: var(--charcoal-text-line-height-caption-m);
-}
-
-.charcoal-snackbar-button {
-  flex: none;
-  line-height: var(--charcoal-text-line-height-5);
 }
 
 @keyframes charcoal-snackbar-enter {

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -50,7 +50,7 @@
 .charcoal-snackbar[data-dim='true'] {
   background-color: var(--charcoal-color-container-hud-default);
   color: var(--charcoal-color-text-on-hud-default);
-  border-color: var(--charcoal-color-container-hud-default);
+  border-color: var(--charcoal-color-border-secondary);
 }
 
 .charcoal-snackbar-content {

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -56,7 +56,7 @@
 .charcoal-snackbar[data-dim='true'] {
   background-color: var(--charcoal-color-container-hud-default);
   color: var(--charcoal-color-text-on-hud-default);
-  border-color: var(--charcoal-color-container-hud-default);
+  border-color: var(--charcoal-color-border-hud);
 }
 
 .charcoal-snackbar-content {
@@ -67,7 +67,11 @@
 
 .charcoal-snackbar-label {
   min-width: 0;
+  overflow: hidden;
   overflow-wrap: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   font-size: var(--charcoal-text-font-size-caption-m);
   font-weight: var(--charcoal-text-font-weight-bold);
   line-height: var(--charcoal-text-line-height-caption-m);

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -1,0 +1,107 @@
+.charcoal-snackbar-region {
+  position: fixed;
+  left: 0;
+  right: 0;
+  display: grid;
+  justify-content: center;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.charcoal-snackbar-region[data-position='top'] {
+  --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
+  padding-top: var(--charcoal-space-25);
+}
+
+.charcoal-snackbar-region[data-position='bottom'] {
+  --charcoal-snackbar-enter-offset: var(--charcoal-space-30);
+  padding-bottom: var(--charcoal-space-25);
+}
+
+.charcoal-snackbar {
+  box-sizing: border-box;
+  border-radius: var(--charcoal-radius-oval);
+  width: fit-content;
+  max-width: calc(100vw - var(--charcoal-space-46));
+  min-height: 44px;
+  padding: var(--charcoal-space-25) var(--charcoal-space-40);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--charcoal-space-20);
+  pointer-events: auto;
+  background-color: var(--charcoal-color-background-default);
+  color: var(--charcoal-color-text-default-text1);
+  border: var(--charcoal-border-width-m) solid
+    var(--charcoal-color-border-secondary);
+  animation: charcoal-snackbar-enter 0.3s ease-out both;
+}
+
+.charcoal-snackbar[data-exiting='true'] {
+  animation: charcoal-snackbar-exit 0.3s ease-out both;
+}
+
+.charcoal-snackbar[data-with-button='true'] {
+  min-height: 56px;
+  padding: var(--charcoal-space-25) var(--charcoal-space-30)
+      var(--charcoal-space-25) var(--charcoal-space-40);
+}
+
+.charcoal-snackbar[data-dim='true'] {
+  background-color: var(--charcoal-color-container-hud-default);
+  color: var(--charcoal-color-text-on-hud-default);
+  border-color: var(--charcoal-color-container-hud-default);
+}
+
+.charcoal-snackbar-content {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.charcoal-snackbar-label {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: var(--charcoal-text-font-size-caption-m);
+  font-weight: var(--charcoal-text-font-weight-bold);
+  line-height: var(--charcoal-text-line-height-caption-m);
+}
+
+.charcoal-snackbar-button {
+  flex: none;
+  line-height: var(--charcoal-text-line-height-5);
+}
+
+@keyframes charcoal-snackbar-enter {
+
+from {
+  opacity: 0;
+  transform: translateY(var(--charcoal-snackbar-enter-offset));
+}
+
+to {
+  opacity: 1;
+  transform: translateY(0);
+}
+}
+
+@keyframes charcoal-snackbar-exit {
+
+from {
+  opacity: 1;
+}
+
+to {
+  opacity: 0;
+}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+.charcoal-snackbar, .charcoal-snackbar[data-exiting='true'] {
+  animation: none;
+}
+}
+

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -30,8 +30,8 @@
   justify-content: center;
   gap: var(--charcoal-space-20);
   pointer-events: auto;
-  background-color: var(--charcoal-color-background-default);
-  color: var(--charcoal-color-text-default-text1);
+  background-color: var(--charcoal-color-container-default);
+  color: var(--charcoal-color-text-default);
   border: var(--charcoal-border-width-m) solid
     var(--charcoal-color-border-secondary);
   animation: charcoal-snackbar-enter 0.3s ease-out both;
@@ -50,7 +50,7 @@
 .charcoal-snackbar[data-dim='true'] {
   background-color: var(--charcoal-color-container-hud-default);
   color: var(--charcoal-color-text-on-hud-default);
-  border-color: var(--charcoal-color-border-secondary);
+  border-color: var(--charcoal-color-container-hud-default);
 }
 
 .charcoal-snackbar-content {

--- a/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Snackbar/__snapshots__/index.css.snap
@@ -1,4 +1,5 @@
 .charcoal-snackbar-region {
+  --charcoal-snackbar-offset: 16px;
   position: fixed;
   left: 0;
   right: 0;
@@ -10,12 +11,17 @@
 
 .charcoal-snackbar-region[data-position='top'] {
   --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
-  padding-top: var(--charcoal-space-25);
+  top: calc(
+      env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px)
+    );
 }
 
 .charcoal-snackbar-region[data-position='bottom'] {
   --charcoal-snackbar-enter-offset: var(--charcoal-space-30);
-  padding-bottom: var(--charcoal-space-25);
+  bottom: calc(
+      env(safe-area-inset-bottom, 0px) +
+        max(var(--charcoal-snackbar-offset), 16px)
+    );
 }
 
 .charcoal-snackbar {

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -1,4 +1,6 @@
 .charcoal-snackbar-region {
+  --charcoal-snackbar-offset: 16px;
+
   position: fixed;
   left: 0;
   right: 0;
@@ -10,13 +12,18 @@
   &[data-position='top'] {
     --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
 
-    padding-top: var(--charcoal-space-25);
+    top: calc(
+      env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px)
+    );
   }
 
   &[data-position='bottom'] {
     --charcoal-snackbar-enter-offset: var(--charcoal-space-30);
 
-    padding-bottom: var(--charcoal-space-25);
+    bottom: calc(
+      env(safe-area-inset-bottom, 0px) +
+        max(var(--charcoal-snackbar-offset), 16px)
+    );
   }
 }
 

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -51,7 +51,7 @@
   &[data-dim='true'] {
     background-color: var(--charcoal-color-container-hud-default);
     color: var(--charcoal-color-text-on-hud-default);
-    border-color: var(--charcoal-color-container-hud-default);
+    border-color: var(--charcoal-color-border-secondary);
   }
 }
 

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -32,8 +32,8 @@
   justify-content: center;
   gap: var(--charcoal-space-20);
   pointer-events: auto;
-  background-color: var(--charcoal-color-background-default);
-  color: var(--charcoal-color-text-default-text1);
+  background-color: var(--charcoal-color-container-default);
+  color: var(--charcoal-color-text-default);
   border: var(--charcoal-border-width-m) solid
     var(--charcoal-color-border-secondary);
   animation: charcoal-snackbar-enter 0.3s ease-out both;
@@ -51,7 +51,7 @@
   &[data-dim='true'] {
     background-color: var(--charcoal-color-container-hud-default);
     color: var(--charcoal-color-text-on-hud-default);
-    border-color: var(--charcoal-color-border-secondary);
+    border-color: var(--charcoal-color-container-hud-default);
   }
 }
 

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -1,0 +1,106 @@
+.charcoal-snackbar-region {
+  position: fixed;
+  left: 0;
+  right: 0;
+  display: grid;
+  justify-content: center;
+  pointer-events: none;
+  box-sizing: border-box;
+
+  &[data-position='top'] {
+    --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
+
+    padding-top: var(--charcoal-space-25);
+  }
+
+  &[data-position='bottom'] {
+    --charcoal-snackbar-enter-offset: var(--charcoal-space-30);
+
+    padding-bottom: var(--charcoal-space-25);
+  }
+}
+
+.charcoal-snackbar {
+  box-sizing: border-box;
+  border-radius: var(--charcoal-radius-oval);
+  width: fit-content;
+  max-width: calc(100vw - var(--charcoal-space-46));
+  min-height: 44px;
+  padding: var(--charcoal-space-25) var(--charcoal-space-40);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--charcoal-space-20);
+  pointer-events: auto;
+  background-color: var(--charcoal-color-background-default);
+  color: var(--charcoal-color-text-default-text1);
+  border: var(--charcoal-border-width-m) solid
+    var(--charcoal-color-border-secondary);
+  animation: charcoal-snackbar-enter 0.3s ease-out both;
+
+  &[data-exiting='true'] {
+    animation: charcoal-snackbar-exit 0.3s ease-out both;
+  }
+
+  &[data-with-button='true'] {
+    min-height: 56px;
+    padding: var(--charcoal-space-25) var(--charcoal-space-30)
+      var(--charcoal-space-25) var(--charcoal-space-40);
+  }
+
+  &[data-dim='true'] {
+    background-color: var(--charcoal-color-container-hud-default);
+    color: var(--charcoal-color-text-on-hud-default);
+    border-color: var(--charcoal-color-container-hud-default);
+  }
+}
+
+.charcoal-snackbar-content {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.charcoal-snackbar-label {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: var(--charcoal-text-font-size-caption-m);
+  font-weight: var(--charcoal-text-font-weight-bold);
+  line-height: var(--charcoal-text-line-height-caption-m);
+}
+
+.charcoal-snackbar-button {
+  flex: none;
+  line-height: var(--charcoal-text-line-height-5);
+}
+
+@keyframes charcoal-snackbar-enter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--charcoal-snackbar-enter-offset));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes charcoal-snackbar-exit {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .charcoal-snackbar,
+  .charcoal-snackbar[data-exiting='true'] {
+    animation: none;
+  }
+}

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -58,22 +58,15 @@
 .charcoal-snackbar-content {
   display: flex;
   align-items: center;
-  flex: 0 1 auto;
   min-width: 0;
 }
 
 .charcoal-snackbar-label {
-  flex: 0 1 auto;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
   font-size: var(--charcoal-text-font-size-caption-m);
   font-weight: var(--charcoal-text-font-weight-bold);
   line-height: var(--charcoal-text-line-height-caption-m);
-}
-
-.charcoal-snackbar-button {
-  flex: none;
-  line-height: var(--charcoal-text-line-height-5);
 }
 
 @keyframes charcoal-snackbar-enter {

--- a/packages/react/src/components/Snackbar/index.css
+++ b/packages/react/src/components/Snackbar/index.css
@@ -58,7 +58,7 @@
   &[data-dim='true'] {
     background-color: var(--charcoal-color-container-hud-default);
     color: var(--charcoal-color-text-on-hud-default);
-    border-color: var(--charcoal-color-container-hud-default);
+    border-color: var(--charcoal-color-border-hud);
   }
 }
 
@@ -70,7 +70,11 @@
 
 .charcoal-snackbar-label {
   min-width: 0;
+  overflow: hidden;
   overflow-wrap: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   font-size: var(--charcoal-text-font-size-caption-m);
   font-weight: var(--charcoal-text-font-weight-bold);
   line-height: var(--charcoal-text-line-height-caption-m);

--- a/packages/react/src/components/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Snackbar/index.story.tsx
@@ -1,44 +1,60 @@
 import { useEffect } from 'react'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import Button from '../Button'
-import Snackbar, {
-  useSnackbar,
-  type SnackbarProps,
-  type SnackbarShowOptions,
+import unstable_Snackbar, {
+  useSnackbar as unstable_useSnackbar,
+  type SnackbarProps as unstable_SnackbarProps,
 } from '.'
 
 const defaultOpen = !!process.env.TEST
 
+type SnackbarStoryArgs = unstable_SnackbarProps & {
+  message: string
+  buttonChildren?: string
+}
+
 export default {
-  title: 'react/Snackbar',
-  component: Snackbar,
+  title: 'react/unstable_Snackbar',
+  component: unstable_Snackbar,
   parameters: {
     layout: 'centered',
     tokenVersion: 'v2',
+  },
+  args: {
+    message: '保存しました',
   },
   argTypes: {
     position: {
       options: ['top', 'bottom'],
       control: { type: 'inline-radio' },
     },
+    message: {
+      control: 'text',
+    },
+    buttonChildren: {
+      name: 'button.children',
+      control: 'text',
+    },
   },
-} as Meta<typeof Snackbar>
+  render: (args) => <SnackbarDemo {...args} />,
+} as Meta<SnackbarStoryArgs>
 
 function SnackbarDemo({
   message,
-  showOptions,
+  buttonChildren,
   ...props
-}: SnackbarProps & {
-  message: string
-  showOptions?: SnackbarShowOptions
-}) {
-  const [snackbar, showSnackbar] = useSnackbar(props)
+}: SnackbarStoryArgs) {
+  const [snackbar, showSnackbar] = unstable_useSnackbar(props)
+  const showOptions =
+    buttonChildren === undefined || buttonChildren === ''
+      ? undefined
+      : { button: { children: buttonChildren } }
 
   useEffect(() => {
     if (defaultOpen) {
       showSnackbar(message, { duration: 60_000, ...showOptions })
     }
-  }, [message, showOptions, showSnackbar])
+  }, [buttonChildren, message, showSnackbar])
 
   return (
     <>
@@ -54,16 +70,15 @@ function SnackbarDemo({
   )
 }
 
-export const Default: StoryObj<typeof Snackbar> = {
-  render: (args) => <SnackbarDemo {...args} message="保存しました" />,
+export const Default: StoryObj<SnackbarStoryArgs> = {
   parameters: {
     docs: {
       source: {
         language: 'tsx',
-        code: `import { Button, useSnackbar } from '@charcoal-ui/react'
+        code: `import { Button, unstable_useSnackbar } from '@charcoal-ui/react'
 
 export function Example() {
-  const [snackbar, showSnackbar] = useSnackbar()
+  const [snackbar, showSnackbar] = unstable_useSnackbar()
 
   return (
     <>
@@ -79,33 +94,26 @@ export function Example() {
   },
 }
 
-export const LongMessage: StoryObj<typeof Snackbar> = {
-  render: (args) => (
-    <SnackbarDemo
-      {...args}
-      message="保存した内容はすべての端末に同期され、あとから設定画面で変更できます"
-    />
-  ),
+export const LongMessage: StoryObj<SnackbarStoryArgs> = {
+  args: {
+    message:
+      '保存した内容はすべての端末に同期され、あとから設定画面で変更できます',
+  },
 }
 
-export const WithButton: StoryObj<typeof Snackbar> = {
-  render: (args) => (
-    <SnackbarDemo
-      {...args}
-      message="保存しました"
-      showOptions={{
-        button: { children: '取り消す' },
-      }}
-    />
-  ),
+export const WithButton: StoryObj<SnackbarStoryArgs> = {
+  args: {
+    message: '保存しました',
+    buttonChildren: '取り消す',
+  },
   parameters: {
     docs: {
       source: {
         language: 'tsx',
-        code: `import { Button, useSnackbar } from '@charcoal-ui/react'
+        code: `import { Button, unstable_useSnackbar } from '@charcoal-ui/react'
 
 export function Example() {
-  const [snackbar, showSnackbar] = useSnackbar()
+  const [snackbar, showSnackbar] = unstable_useSnackbar()
 
   return (
     <>
@@ -129,25 +137,18 @@ export function Example() {
   },
 }
 
-export const Bottom: StoryObj<typeof Snackbar> = {
+export const Bottom: StoryObj<SnackbarStoryArgs> = {
   args: {
     position: 'bottom',
     offset: 12,
+    message: '下部に表示します',
   },
-  render: (args) => <SnackbarDemo {...args} message="下部に表示します" />,
 }
 
-export const Dim: StoryObj<typeof Snackbar> = {
+export const Dim: StoryObj<SnackbarStoryArgs> = {
   args: {
     dim: true,
+    message: 'Dim の Snackbar',
+    buttonChildren: '閉じる',
   },
-  render: (args) => (
-    <SnackbarDemo
-      {...args}
-      message="Dim の Snackbar"
-      showOptions={{
-        button: { children: '閉じる' },
-      }}
-    />
-  ),
 }

--- a/packages/react/src/components/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Snackbar/index.story.tsx
@@ -51,9 +51,15 @@ function SnackbarDemo({
       : { button: { children: buttonChildren } }
 
   useEffect(() => {
-    if (defaultOpen) {
-      showSnackbar(message, { duration: 60_000, ...showOptions })
+    if (!defaultOpen) {
+      return
     }
+    showSnackbar(
+      message,
+      buttonChildren === undefined || buttonChildren === ''
+        ? { duration: 60_000 }
+        : { duration: 60_000, button: { children: buttonChildren } },
+    )
   }, [buttonChildren, message, showSnackbar])
 
   return (

--- a/packages/react/src/components/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Snackbar/index.story.tsx
@@ -11,6 +11,7 @@ const defaultOpen = !!process.env.TEST
 type SnackbarStoryArgs = unstable_SnackbarProps & {
   message: ReactNode
   buttonChildren?: string
+  duration?: number
 }
 
 export default {
@@ -19,9 +20,17 @@ export default {
   parameters: {
     layout: 'centered',
     tokenVersion: 'v2',
+    docs: {
+      description: {
+        component: `同時に表示できるスナックバーは1つのみです。表示中に別のスナックバーが発生した場合はキューに積み、前のスナックバーが消えてから表示します。
+
+別々の \`useSnackbar\` を呼び出した場合は互いに独立するため、同時表示数は1件に制限されません。`,
+      },
+    },
   },
   args: {
     message: '保存しました',
+    duration: 5000,
   },
   argTypes: {
     position: {
@@ -30,6 +39,10 @@ export default {
     },
     message: {
       control: 'text',
+    },
+    duration: {
+      control: { type: 'number', min: 0, step: 500 },
+      description: '表示時間（ミリ秒）',
     },
     buttonChildren: {
       name: 'button.children',
@@ -42,25 +55,25 @@ export default {
 function SnackbarDemo({
   message,
   buttonChildren,
+  duration,
   ...props
 }: SnackbarStoryArgs) {
   const [snackbar, showSnackbar] = unstable_useSnackbar(props)
-  const showOptions =
-    buttonChildren === undefined || buttonChildren === ''
-      ? undefined
-      : { button: { children: buttonChildren } }
+  const hasButton = buttonChildren !== undefined && buttonChildren !== ''
+  const showOptions = {
+    duration,
+    ...(hasButton ? { button: { children: buttonChildren } } : {}),
+  }
 
   useEffect(() => {
     if (!defaultOpen) {
       return
     }
-    showSnackbar(
-      message,
-      buttonChildren === undefined || buttonChildren === ''
-        ? { duration: 60_000 }
-        : { duration: 60_000, button: { children: buttonChildren } },
-    )
-  }, [buttonChildren, message, showSnackbar])
+    showSnackbar(message, {
+      duration: 60_000,
+      ...(hasButton ? { button: { children: buttonChildren } } : {}),
+    })
+  }, [buttonChildren, hasButton, message, showSnackbar])
 
   return (
     <>

--- a/packages/react/src/components/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Snackbar/index.story.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import Button from '../Button'
 import unstable_Snackbar, {
@@ -9,7 +9,7 @@ import unstable_Snackbar, {
 const defaultOpen = !!process.env.TEST
 
 type SnackbarStoryArgs = unstable_SnackbarProps & {
-  message: string
+  message: ReactNode
   buttonChildren?: string
 }
 
@@ -103,7 +103,19 @@ export function Example() {
 export const LongMessage: StoryObj<SnackbarStoryArgs> = {
   args: {
     message:
-      '保存した内容はすべての端末に同期され、あとから設定画面で変更できます',
+      '保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます',
+  },
+}
+
+export const WithLineBreak: StoryObj<SnackbarStoryArgs> = {
+  args: {
+    message: (
+      <>
+        保存に失敗しました
+        <br />
+        通信環境を確認してください
+      </>
+    ),
   },
 }
 
@@ -143,11 +155,10 @@ export function Example() {
   },
 }
 
-export const Bottom: StoryObj<SnackbarStoryArgs> = {
+export const Top: StoryObj<SnackbarStoryArgs> = {
   args: {
-    position: 'bottom',
-    offset: 12,
-    message: '下部に表示します',
+    position: 'top',
+    message: '上部に表示します',
   },
 }
 

--- a/packages/react/src/components/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Snackbar/index.story.tsx
@@ -1,0 +1,153 @@
+import { useEffect } from 'react'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import Button from '../Button'
+import Snackbar, {
+  useSnackbar,
+  type SnackbarProps,
+  type SnackbarShowOptions,
+} from '.'
+
+const defaultOpen = !!process.env.TEST
+
+export default {
+  title: 'react/Snackbar',
+  component: Snackbar,
+  parameters: {
+    layout: 'centered',
+    tokenVersion: 'v2',
+  },
+  argTypes: {
+    position: {
+      options: ['top', 'bottom'],
+      control: { type: 'inline-radio' },
+    },
+  },
+} as Meta<typeof Snackbar>
+
+function SnackbarDemo({
+  message,
+  showOptions,
+  ...props
+}: SnackbarProps & {
+  message: string
+  showOptions?: SnackbarShowOptions
+}) {
+  const [snackbar, showSnackbar] = useSnackbar(props)
+
+  useEffect(() => {
+    if (defaultOpen) {
+      showSnackbar(message, { duration: 60_000, ...showOptions })
+    }
+  }, [message, showOptions, showSnackbar])
+
+  return (
+    <>
+      {snackbar}
+      <Button
+        onClick={() => {
+          showSnackbar(message, showOptions)
+        }}
+      >
+        show
+      </Button>
+    </>
+  )
+}
+
+export const Default: StoryObj<typeof Snackbar> = {
+  render: (args) => <SnackbarDemo {...args} message="保存しました" />,
+  parameters: {
+    docs: {
+      source: {
+        language: 'tsx',
+        code: `import { Button, useSnackbar } from '@charcoal-ui/react'
+
+export function Example() {
+  const [snackbar, showSnackbar] = useSnackbar()
+
+  return (
+    <>
+      {snackbar}
+      <Button onClick={() => showSnackbar('保存しました')}>
+        保存
+      </Button>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}
+
+export const LongMessage: StoryObj<typeof Snackbar> = {
+  render: (args) => (
+    <SnackbarDemo
+      {...args}
+      message="保存した内容はすべての端末に同期され、あとから設定画面で変更できます"
+    />
+  ),
+}
+
+export const WithButton: StoryObj<typeof Snackbar> = {
+  render: (args) => (
+    <SnackbarDemo
+      {...args}
+      message="保存しました"
+      showOptions={{
+        button: { children: '取り消す' },
+      }}
+    />
+  ),
+  parameters: {
+    docs: {
+      source: {
+        language: 'tsx',
+        code: `import { Button, useSnackbar } from '@charcoal-ui/react'
+
+export function Example() {
+  const [snackbar, showSnackbar] = useSnackbar()
+
+  return (
+    <>
+      {snackbar}
+      <Button
+        onClick={() =>
+          showSnackbar('保存しました', {
+            button: {
+              children: '取り消す',
+            },
+          })
+        }
+      >
+        保存
+      </Button>
+    </>
+  )
+}`,
+      },
+    },
+  },
+}
+
+export const Bottom: StoryObj<typeof Snackbar> = {
+  args: {
+    position: 'bottom',
+    offset: 12,
+  },
+  render: (args) => <SnackbarDemo {...args} message="下部に表示します" />,
+}
+
+export const Dim: StoryObj<typeof Snackbar> = {
+  args: {
+    dim: true,
+  },
+  render: (args) => (
+    <SnackbarDemo
+      {...args}
+      message="Dim の Snackbar"
+      showOptions={{
+        button: { children: '閉じる' },
+      }}
+    />
+  ),
+}

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -177,7 +177,7 @@ describe('Snackbar', () => {
     portalContainer.remove()
   })
 
-  it('moves focus to the action button with F6', () => {
+  it('moves focus to the toast region with F6', () => {
     const { show } = renderSnackbar()
 
     act(() => {
@@ -186,12 +186,9 @@ describe('Snackbar', () => {
       })
     })
 
-    const button = screen.getByRole('button', { name: '取り消す' })
-    expect(button).toHaveAttribute('aria-keyshortcuts', 'F6')
-
     fireEvent.keyDown(document, { key: 'F6' })
 
-    expect(button).toHaveFocus()
+    expect(screen.getByRole('region')).toHaveFocus()
   })
 
   it('restores focus after a focused snackbar closes', () => {
@@ -207,10 +204,9 @@ describe('Snackbar', () => {
     })
 
     fireEvent.keyDown(document, { key: 'F6' })
-    const closeButton = screen.getByRole('button', { name: '閉じる' })
-    expect(closeButton).toHaveFocus()
+    expect(screen.getByRole('region')).toHaveFocus()
 
-    fireEvent.click(closeButton)
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
     finishExitAnimation('保存しました')
 
     expect(trigger).toHaveFocus()

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -257,6 +257,21 @@ describe('Snackbar', () => {
     expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
   })
 
+  it('uses Navigation button variant when dimmed', () => {
+    const { show } = renderSnackbar({ dim: true })
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '閉じる' },
+      })
+    })
+
+    expect(screen.getByRole('button', { name: '閉じる' })).toHaveAttribute(
+      'data-variant',
+      'Navigation',
+    )
+  })
+
   it('honors an explicit button variant when dimmed', () => {
     const { show } = renderSnackbar({ dim: true })
 

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -187,12 +187,12 @@ describe('Snackbar', () => {
   it('supports a custom z-index and portal container', () => {
     const portalContainer = document.createElement('div')
     document.body.append(portalContainer)
-    const { show } = renderSnackbar({ zIndex: 20, portalContainer })
+    const { show } = renderSnackbar({ zIndex: 30, portalContainer })
 
     show('保存しました')
 
     expect(portalContainer).toContainElement(screen.getByRole('region'))
-    expect(screen.getByRole('region')).toHaveStyle({ zIndex: 20 })
+    expect(screen.getByRole('region')).toHaveStyle({ zIndex: 30 })
 
     portalContainer.remove()
   })

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -7,7 +7,12 @@ function renderSnackbar(props: ComponentProps<typeof Snackbar> = {}) {
   const ref = createRef<SnackbarHandler>()
   const result = render(<Snackbar ref={ref} {...props} />)
   const show: SnackbarHandler['show'] = (message, options) => {
-    ref.current?.show(message, options)
+    act(() => {
+      ref.current?.show(message, options)
+    })
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
   }
   return { ...result, show }
 }
@@ -38,9 +43,7 @@ describe('Snackbar', () => {
 
     expect(screen.queryByRole('region')).not.toBeInTheDocument()
 
-    act(() => {
-      show('保存しました')
-    })
+    show('保存しました')
 
     expect(screen.getByText('保存しました')).toBeInTheDocument()
 
@@ -61,9 +64,7 @@ describe('Snackbar', () => {
   it.each([0, -1])('clamps duration to zero: %s', (duration) => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('保存しました', { duration })
-    })
+    show('保存しました', { duration })
     expect(screen.getByText('保存しました')).toBeInTheDocument()
 
     act(() => {
@@ -85,9 +86,7 @@ describe('Snackbar', () => {
   ])('falls back to the default duration: %s', (duration) => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('保存しました', { duration })
-    })
+    show('保存しました', { duration })
     act(() => {
       vi.advanceTimersByTime(4999)
     })
@@ -104,12 +103,8 @@ describe('Snackbar', () => {
   it('queues the next snackbar until the previous one closes', async () => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('first')
-    })
-    act(() => {
-      show('second')
-    })
+    show('first')
+    show('second')
 
     expect(screen.getByText('first')).toBeInTheDocument()
     expect(screen.queryByText('second')).not.toBeInTheDocument()
@@ -125,12 +120,10 @@ describe('Snackbar', () => {
     expect(screen.getByText('second')).toBeInTheDocument()
   })
 
-  it('keeps the snackbar open while hovered and resumes the timer on leave', () => {
+  it('keeps the snackbar open while hovered after the timer ends, then closes on leave', () => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('保存しました')
-    })
+    show('保存しました')
     const snackbar = screen
       .getByText('保存しました')
       .closest('.charcoal-snackbar')
@@ -143,18 +136,13 @@ describe('Snackbar', () => {
     expect(snackbar).not.toHaveAttribute('data-exiting', 'true')
 
     fireEvent.pointerLeave(snackbar)
-    act(() => {
-      vi.advanceTimersByTime(5000)
-    })
     expect(snackbar).toHaveAttribute('data-exiting', 'true')
   })
 
   it('keeps the snackbar open while focused', () => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('保存しました')
-    })
+    show('保存しました')
     const snackbar = screen
       .getByText('保存しました')
       .closest('.charcoal-snackbar')
@@ -178,10 +166,8 @@ describe('Snackbar', () => {
   it('places a snackbar with a button at the bottom', () => {
     const { show } = renderSnackbar({ position: 'top' })
 
-    act(() => {
-      show('保存しました', {
-        button: { children: '取り消す' },
-      })
+    show('保存しました', {
+      button: { children: '取り消す' },
     })
 
     expect(screen.getByRole('region')).toHaveAttribute(
@@ -190,14 +176,20 @@ describe('Snackbar', () => {
     )
   })
 
+  it('places a snackbar without a button at the top when requested', () => {
+    const { show } = renderSnackbar({ position: 'top' })
+
+    show('保存しました')
+
+    expect(screen.getByRole('region')).toHaveAttribute('data-position', 'top')
+  })
+
   it('supports a custom z-index and portal container', () => {
     const portalContainer = document.createElement('div')
     document.body.append(portalContainer)
     const { show } = renderSnackbar({ zIndex: 20, portalContainer })
 
-    act(() => {
-      show('保存しました')
-    })
+    show('保存しました')
 
     expect(portalContainer).toContainElement(screen.getByRole('region'))
     expect(screen.getByRole('region')).toHaveStyle({ zIndex: 20 })
@@ -208,10 +200,8 @@ describe('Snackbar', () => {
   it('moves focus to the toast region with F6', () => {
     const { show } = renderSnackbar()
 
-    act(() => {
-      show('保存しました', {
-        button: { children: '取り消す' },
-      })
+    show('保存しました', {
+      button: { children: '取り消す' },
     })
 
     fireEvent.keyDown(document, { key: 'F6' })
@@ -225,10 +215,8 @@ describe('Snackbar', () => {
     document.body.append(trigger)
     trigger.focus()
 
-    act(() => {
-      show('保存しました', {
-        button: { children: '閉じる' },
-      })
+    show('保存しました', {
+      button: { children: '閉じる' },
     })
 
     fireEvent.keyDown(document, { key: 'F6' })
@@ -247,10 +235,8 @@ describe('Snackbar', () => {
     document.body.append(trigger)
     trigger.focus()
 
-    act(() => {
-      show('保存しました', {
-        button: { children: '閉じる' },
-      })
+    show('保存しました', {
+      button: { children: '閉じる' },
     })
 
     const snackbar = screen
@@ -267,93 +253,6 @@ describe('Snackbar', () => {
     expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
     expect(trigger).toHaveFocus()
     trigger.remove()
-  })
-
-  it('renders the button with a custom component', () => {
-    function Link({ to, ...props }: ComponentProps<'a'> & { to: string }) {
-      return <a {...props} href={to} />
-    }
-
-    const { show } = renderSnackbar()
-
-    act(() => {
-      show('保存しました', {
-        button: {
-          component: Link,
-          to: '/details',
-          children: '詳細を見る',
-        },
-      })
-    })
-
-    expect(screen.getByRole('link', { name: '詳細を見る' })).toHaveAttribute(
-      'href',
-      '/details',
-    )
-  })
-
-  it('closes on button click', () => {
-    const { show } = renderSnackbar()
-
-    act(() => {
-      show('保存しました', {
-        button: { children: '閉じる' },
-      })
-    })
-
-    fireEvent.click(screen.getByText('閉じる'))
-    expect(screen.getByText('保存しました')).toBeInTheDocument()
-
-    finishExitAnimation('保存しました')
-
-    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
-  })
-
-  it('uses Navigation button variant when dimmed', () => {
-    const { show } = renderSnackbar({ dim: true })
-
-    act(() => {
-      show('保存しました', {
-        button: { children: '閉じる' },
-      })
-    })
-
-    expect(screen.getByRole('button', { name: '閉じる' })).toHaveAttribute(
-      'data-variant',
-      'Navigation',
-    )
-  })
-
-  it('honors an explicit button variant when dimmed', () => {
-    const { show } = renderSnackbar({ dim: true })
-
-    act(() => {
-      show('保存しました', {
-        button: { children: '削除する', variant: 'Danger' },
-      })
-    })
-
-    expect(screen.getByRole('button', { name: '削除する' })).toHaveAttribute(
-      'data-variant',
-      'Danger',
-    )
-  })
-
-  it('removes the snackbar with a timeout fallback', () => {
-    const { show } = renderSnackbar()
-
-    act(() => {
-      show('保存しました', { duration: 1 })
-    })
-    act(() => {
-      vi.advanceTimersByTime(1)
-    })
-
-    act(() => {
-      vi.advanceTimersByTime(400)
-    })
-
-    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
   })
 })
 

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -131,7 +131,9 @@ describe('Snackbar', () => {
     act(() => {
       show('保存しました')
     })
-    const snackbar = screen.getByText('保存しました').closest('.charcoal-snackbar')
+    const snackbar = screen
+      .getByText('保存しました')
+      .closest('.charcoal-snackbar')
     if (snackbar === null) throw new Error('Snackbar not found')
 
     fireEvent.pointerEnter(snackbar, { pointerType: 'mouse' })
@@ -153,7 +155,9 @@ describe('Snackbar', () => {
     act(() => {
       show('保存しました')
     })
-    const snackbar = screen.getByText('保存しました').closest('.charcoal-snackbar')
+    const snackbar = screen
+      .getByText('保存しました')
+      .closest('.charcoal-snackbar')
     if (snackbar === null) throw new Error('Snackbar not found')
 
     fireEvent.keyDown(document, { key: 'F6' })

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -1,0 +1,328 @@
+import { createRef, type ComponentProps } from 'react'
+import { render, fireEvent, act, cleanup, screen } from '@testing-library/react'
+import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
+import Snackbar, { useSnackbar, type SnackbarHandler } from '.'
+
+function renderSnackbar(props: ComponentProps<typeof Snackbar> = {}) {
+  const ref = createRef<SnackbarHandler>()
+  const result = render(<Snackbar ref={ref} {...props} />)
+  const show: SnackbarHandler['show'] = (message, options) => {
+    ref.current?.show(message, options)
+  }
+  return { ...result, show }
+}
+
+function finishExitAnimation(message: string) {
+  const snackbar = screen.getByText(message).closest('.charcoal-snackbar')
+  if (snackbar === null) throw new Error('Snackbar not found')
+  fireEvent(
+    snackbar,
+    Object.assign(new Event('animationend', { bubbles: true }), {
+      animationName: 'charcoal-snackbar-exit',
+    }),
+  )
+}
+
+describe('Snackbar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('shows a message and hides after 5 seconds', () => {
+    const { show } = renderSnackbar()
+
+    expect(screen.queryByRole('region')).not.toBeInTheDocument()
+
+    act(() => {
+      show('保存しました')
+    })
+
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-exiting', 'true')
+
+    finishExitAnimation('保存しました')
+
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
+  })
+
+  it.each([0, -1])('clamps duration to zero: %s', (duration) => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', { duration })
+    })
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-exiting', 'true')
+
+    finishExitAnimation('保存しました')
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    'invalid' as unknown as number,
+  ])('falls back to the default duration: %s', (duration) => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', { duration })
+    })
+    act(() => {
+      vi.advanceTimersByTime(4999)
+    })
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-exiting', 'true')
+  })
+
+  it('queues the next snackbar until the previous one closes', async () => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('first')
+    })
+    act(() => {
+      show('second')
+    })
+
+    expect(screen.getByText('first')).toBeInTheDocument()
+    expect(screen.queryByText('second')).not.toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    await act(async () => {
+      finishExitAnimation('first')
+    })
+
+    expect(screen.queryByText('first')).not.toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
+  })
+
+  it('keeps the snackbar open when hideSnackbarOnClick is false', () => {
+    const onClick = vi.fn()
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', {
+        button: {
+          children: '取り消す',
+          onClick,
+          hideSnackbarOnClick: false,
+        },
+      })
+    })
+
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-with-button', 'true')
+    fireEvent.click(screen.getByText('取り消す'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+  })
+
+  it('places a snackbar with a button at the bottom', () => {
+    const { show } = renderSnackbar({ position: 'top' })
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '取り消す' },
+      })
+    })
+
+    expect(screen.getByRole('region')).toHaveAttribute(
+      'data-position',
+      'bottom',
+    )
+  })
+
+  it('supports a custom z-index and portal container', () => {
+    const portalContainer = document.createElement('div')
+    document.body.append(portalContainer)
+    const { show } = renderSnackbar({ zIndex: 20, portalContainer })
+
+    act(() => {
+      show('保存しました')
+    })
+
+    expect(portalContainer).toContainElement(screen.getByRole('region'))
+    expect(screen.getByRole('region')).toHaveStyle({ zIndex: 20 })
+
+    portalContainer.remove()
+  })
+
+  it('moves focus to the action button with F6', () => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '取り消す' },
+      })
+    })
+
+    const button = screen.getByRole('button', { name: '取り消す' })
+    expect(button).toHaveAttribute('aria-keyshortcuts', 'F6')
+
+    fireEvent.keyDown(document, { key: 'F6' })
+
+    expect(button).toHaveFocus()
+  })
+
+  it('restores focus after a focused snackbar closes', () => {
+    const { show } = renderSnackbar()
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '閉じる' },
+      })
+    })
+
+    fireEvent.keyDown(document, { key: 'F6' })
+    const closeButton = screen.getByRole('button', { name: '閉じる' })
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.click(closeButton)
+    finishExitAnimation('保存しました')
+
+    expect(trigger).toHaveFocus()
+    trigger.remove()
+  })
+
+  it('renders the button with a custom component', () => {
+    function Link({ to, ...props }: ComponentProps<'a'> & { to: string }) {
+      return <a {...props} href={to} />
+    }
+
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', {
+        button: {
+          component: Link,
+          to: '/details',
+          children: '詳細を見る',
+        },
+      })
+    })
+
+    expect(screen.getByRole('link', { name: '詳細を見る' })).toHaveAttribute(
+      'href',
+      '/details',
+    )
+  })
+
+  it('closes on button click by default', () => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '閉じる' },
+      })
+    })
+
+    fireEvent.click(screen.getByText('閉じる'))
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+
+    finishExitAnimation('保存しました')
+
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
+  })
+
+  it('honors an explicit button variant when dimmed', () => {
+    const { show } = renderSnackbar({ dim: true })
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '削除する', variant: 'Danger' },
+      })
+    })
+
+    expect(screen.getByRole('button', { name: '削除する' })).toHaveAttribute(
+      'data-variant',
+      'Danger',
+    )
+  })
+
+  it('removes the snackbar with a timeout fallback', () => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました', { duration: 1 })
+    })
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(400)
+    })
+
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
+  })
+})
+
+describe('useSnackbar', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('shows a snackbar via the returned void function', () => {
+    let showResult: void | undefined
+
+    function HookApp() {
+      const [snackbar, show] = useSnackbar()
+      return (
+        <>
+          {snackbar}
+          <button
+            type="button"
+            onClick={() => {
+              showResult = show('hook message')
+            }}
+          >
+            open
+          </button>
+        </>
+      )
+    }
+
+    render(<HookApp />)
+    fireEvent.click(screen.getByText('open'))
+    expect(screen.getByText('hook message')).toBeInTheDocument()
+    expect(showResult).toBeUndefined()
+  })
+})

--- a/packages/react/src/components/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Snackbar/index.test.tsx
@@ -125,26 +125,50 @@ describe('Snackbar', () => {
     expect(screen.getByText('second')).toBeInTheDocument()
   })
 
-  it('keeps the snackbar open when hideSnackbarOnClick is false', () => {
-    const onClick = vi.fn()
+  it('keeps the snackbar open while hovered and resumes the timer on leave', () => {
     const { show } = renderSnackbar()
 
     act(() => {
-      show('保存しました', {
-        button: {
-          children: '取り消す',
-          onClick,
-          hideSnackbarOnClick: false,
-        },
-      })
+      show('保存しました')
     })
+    const snackbar = screen.getByText('保存しました').closest('.charcoal-snackbar')
+    if (snackbar === null) throw new Error('Snackbar not found')
 
-    expect(
-      screen.getByText('保存しました').closest('.charcoal-snackbar'),
-    ).toHaveAttribute('data-with-button', 'true')
-    fireEvent.click(screen.getByText('取り消す'))
-    expect(onClick).toHaveBeenCalledTimes(1)
-    expect(screen.getByText('保存しました')).toBeInTheDocument()
+    fireEvent.pointerEnter(snackbar, { pointerType: 'mouse' })
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(snackbar).not.toHaveAttribute('data-exiting', 'true')
+
+    fireEvent.pointerLeave(snackbar)
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(snackbar).toHaveAttribute('data-exiting', 'true')
+  })
+
+  it('keeps the snackbar open while focused', () => {
+    const { show } = renderSnackbar()
+
+    act(() => {
+      show('保存しました')
+    })
+    const snackbar = screen.getByText('保存しました').closest('.charcoal-snackbar')
+    if (snackbar === null) throw new Error('Snackbar not found')
+
+    fireEvent.keyDown(document, { key: 'F6' })
+    expect(screen.getByRole('region')).toHaveFocus()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(snackbar).not.toHaveAttribute('data-exiting', 'true')
+
+    fireEvent.blur(screen.getByRole('region'))
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(snackbar).toHaveAttribute('data-exiting', 'true')
   })
 
   it('places a snackbar with a button at the bottom', () => {
@@ -213,6 +237,34 @@ describe('Snackbar', () => {
     trigger.remove()
   })
 
+  it('closes on button click even while hovered', () => {
+    const { show } = renderSnackbar()
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+
+    act(() => {
+      show('保存しました', {
+        button: { children: '閉じる' },
+      })
+    })
+
+    const snackbar = screen
+      .getByText('保存しました')
+      .closest('.charcoal-snackbar')
+    if (snackbar === null) throw new Error('Snackbar not found')
+
+    fireEvent.pointerEnter(snackbar, { pointerType: 'mouse' })
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+
+    expect(snackbar).toHaveAttribute('data-exiting', 'true')
+
+    finishExitAnimation('保存しました')
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+    trigger.remove()
+  })
+
   it('renders the button with a custom component', () => {
     function Link({ to, ...props }: ComponentProps<'a'> & { to: string }) {
       return <a {...props} href={to} />
@@ -236,7 +288,7 @@ describe('Snackbar', () => {
     )
   })
 
-  it('closes on button click by default', () => {
+  it('closes on button click', () => {
     const { show } = renderSnackbar()
 
     act(() => {

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -1,0 +1,436 @@
+import './index.css'
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react'
+import type { ElementType, RefObject } from 'react'
+import { Overlay } from 'react-aria/Overlay'
+import { useToast, useToastRegion } from 'react-aria/useToast'
+import {
+  useToastState,
+  type QueuedToast,
+  type ToastState,
+} from 'react-stately/useToastState'
+import { useClassNames } from '../../_lib/useClassNames'
+import Button, { type ButtonProps } from '../Button'
+
+const DEFAULT_DURATION_MS = 5000
+const DEFAULT_Z_INDEX = 10
+const EXIT_ANIMATION_DURATION_MS = 300
+
+type SnackbarPosition = 'top' | 'bottom'
+
+type SnackbarButtonOption<T extends ElementType = 'button'> = Omit<
+  ButtonProps<T>,
+  'component' | 'className' | 'size'
+> & {
+  /**
+   * ボタンのルート要素として使用するコンポーネント。ページ遷移を伴う場合は `Link` を指定する
+   * @default 'button'
+   * @example 'Link'
+   */
+  component?: T
+  /**
+   * ボタンを押したときに Snackbar を閉じるか
+   * @default true
+   */
+  hideSnackbarOnClick?: boolean
+} & ('button' extends T ? unknown : { component: T })
+
+export type SnackbarShowOptions<T extends ElementType = 'button'> = {
+  /**
+   * Snackbar を表示する時間（ミリ秒）。負の値は 0、数値でない値は 5000 として扱う
+   * @default 5000
+   */
+  duration?: number
+  /**
+   * Snackbar の右側に表示するボタン
+   */
+  button?: SnackbarButtonOption<T>
+}
+
+export type SnackbarHandler = {
+  /**
+   * メッセージを表示する
+   */
+  show: <T extends ElementType = 'button'>(
+    message: string,
+    options?: SnackbarShowOptions<T>,
+  ) => void
+}
+
+export type SnackbarProps = {
+  /**
+   * Snackbar の表示位置。ボタン付きの場合は `bottom` に固定される
+   * @default 'top'
+   */
+  position?: SnackbarPosition
+  /**
+   * 画面端からの距離（ピクセル）
+   * @default 16
+   */
+  offset?: number
+  /**
+   * 暗い背景色
+   * @default false
+   */
+  dim?: boolean
+  /**
+   * Snackbar の重なり順
+   * @default 10
+   */
+  zIndex?: number
+  /**
+   * Snackbar の描画先となるポータルコンテナ
+   */
+  portalContainer?: HTMLElement
+  className?: string
+}
+
+type SnackbarContent = {
+  message: string
+  button?: SnackbarButtonContent
+}
+
+type SnackbarButtonContent = Omit<SnackbarButtonOption, 'component'> & {
+  component?: ElementType
+}
+
+const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
+  {
+    position = 'top',
+    offset = 16,
+    dim = false,
+    zIndex = DEFAULT_Z_INDEX,
+    portalContainer,
+    className,
+  },
+  ref,
+) {
+  'use memo'
+
+  const regionRef = useRef<HTMLDivElement>(null)
+  const exitCompletionRef = useRef<(() => void) | null>(null)
+  const wrapToastUpdate = useCallback(
+    (update: () => void, action: 'add' | 'remove' | 'clear') => {
+      if (action !== 'remove') {
+        update()
+        return
+      }
+
+      const snackbar =
+        regionRef.current?.querySelector<HTMLElement>('.charcoal-snackbar')
+      if (snackbar === undefined || snackbar === null) {
+        update()
+        exitCompletionRef.current?.()
+        exitCompletionRef.current = null
+        return
+      }
+
+      snackbar.dataset.exiting = 'true'
+      let completed = false
+      const complete = () => {
+        if (completed) return
+        completed = true
+        snackbar.removeEventListener('animationend', handleAnimationEnd)
+        window.clearTimeout(fallbackTimer)
+        update()
+        exitCompletionRef.current?.()
+        exitCompletionRef.current = null
+      }
+      const handleAnimationEnd = (event: AnimationEvent) => {
+        if (
+          event.target === snackbar &&
+          event.animationName === 'charcoal-snackbar-exit'
+        ) {
+          complete()
+        }
+      }
+      const fallbackTimer = window.setTimeout(
+        complete,
+        EXIT_ANIMATION_DURATION_MS + 100,
+      )
+
+      snackbar.addEventListener('animationend', handleAnimationEnd)
+
+      if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+        complete()
+      }
+    },
+    [],
+  )
+  const state = useToastState<SnackbarContent>({
+    maxVisibleToasts: 1,
+    wrapUpdate: wrapToastUpdate,
+  })
+
+  const pendingRef = useRef<Promise<void> | null>(null)
+  const mountedRef = useRef(true)
+  const pendingResolversRef = useRef(new Set<() => void>())
+
+  useEffect(() => {
+    const pendingResolvers = pendingResolversRef.current
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+      for (const resolve of Array.from(pendingResolvers)) {
+        resolve()
+      }
+      pendingResolvers.clear()
+    }
+  }, [])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      show<T extends ElementType = 'button'>(
+        message: string,
+        options: SnackbarShowOptions<T> = {},
+      ) {
+        const { duration: durationOption = DEFAULT_DURATION_MS, button } =
+          options
+        const duration =
+          typeof durationOption === 'number' && Number.isFinite(durationOption)
+            ? Math.max(0, durationOption)
+            : DEFAULT_DURATION_MS
+        const run = () =>
+          new Promise<void>((resolve) => {
+            const settle = () => {
+              pendingResolversRef.current.delete(settle)
+              resolve()
+            }
+            pendingResolversRef.current.add(settle)
+
+            if (!mountedRef.current) {
+              settle()
+              return
+            }
+
+            state.add(
+              {
+                message,
+                button: button as SnackbarButtonContent | undefined,
+              },
+              {
+                // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
+                timeout: duration === 0 ? 1 : duration,
+                onClose: () => {
+                  exitCompletionRef.current = settle
+                },
+              },
+            )
+          })
+        if (pendingRef.current === null) {
+          // 初回の Snackbar はすぐに表示する
+          pendingRef.current = run()
+        } else {
+          // 前回の show の完了後に実行し、Snackbar を順番に表示する
+          pendingRef.current = pendingRef.current.then(run)
+        }
+      },
+    }),
+    [state],
+  )
+
+  return (
+    <SnackbarRegion
+      state={state}
+      position={position}
+      offset={offset}
+      dim={dim}
+      zIndex={zIndex}
+      portalContainer={portalContainer}
+      className={className}
+      regionRef={regionRef}
+    />
+  )
+})
+
+export default Snackbar
+
+export function useSnackbar(props: SnackbarProps = {}) {
+  const { position, offset, dim, zIndex, portalContainer, className } = props
+  const snackbarHandlerRef = useRef<SnackbarHandler>(null)
+  const element = useMemo(
+    () => (
+      <Snackbar
+        ref={snackbarHandlerRef}
+        position={position}
+        offset={offset}
+        dim={dim}
+        zIndex={zIndex}
+        portalContainer={portalContainer}
+        className={className}
+      />
+    ),
+    [position, offset, dim, zIndex, portalContainer, className],
+  )
+  const show = useCallback<SnackbarHandler['show']>((message, options) => {
+    snackbarHandlerRef.current?.show(message, options)
+  }, [])
+  return [element, show] as const
+}
+
+function SnackbarRegion({
+  state,
+  position,
+  offset,
+  dim,
+  zIndex,
+  portalContainer,
+  className,
+  regionRef,
+}: {
+  state: ToastState<SnackbarContent>
+  position: SnackbarPosition
+  offset: number
+  dim: boolean
+  zIndex: number
+  portalContainer?: HTMLElement
+  className?: string
+  regionRef: RefObject<HTMLDivElement>
+}) {
+  const { regionProps } = useToastRegion({}, state, regionRef)
+  const classNames = useClassNames('charcoal-snackbar-region', className)
+
+  if (state.visibleToasts.length === 0) {
+    return null
+  }
+
+  // ボタン付きの Snackbar は常に下部に表示される
+  const hasButton = state.visibleToasts.some(
+    (toast) => toast.content.button !== undefined,
+  )
+  const effectivePosition = hasButton ? 'bottom' : position
+
+  return (
+    <Overlay disableFocusManagement portalContainer={portalContainer}>
+      <div
+        {...regionProps}
+        ref={regionRef}
+        className={classNames}
+        data-position={effectivePosition}
+        onFocus={(event) => {
+          regionProps.onFocus?.(event)
+
+          // F6 で通知領域へ移動したとき、アクションがあれば直接フォーカスする
+          if (event.target === event.currentTarget) {
+            event.currentTarget
+              .querySelector<HTMLElement>('.charcoal-snackbar-button')
+              ?.focus()
+          }
+        }}
+        style={{
+          zIndex,
+          [effectivePosition]: offset,
+        }}
+      >
+        {state.visibleToasts.map((toast) => (
+          <SnackbarItem key={toast.key} toast={toast} state={state} dim={dim} />
+        ))}
+      </div>
+    </Overlay>
+  )
+}
+
+function SnackbarItem({
+  toast,
+  state,
+  dim,
+}: {
+  toast: QueuedToast<SnackbarContent>
+  state: ToastState<SnackbarContent>
+  dim: boolean
+}) {
+  const ref = useRef<HTMLDivElement>(null)
+  const { toastProps, contentProps, titleProps } = useToast(
+    { toast },
+    state,
+    ref,
+  )
+  const { message, button } = toast.content
+
+  return (
+    <div
+      {...toastProps}
+      ref={ref}
+      className="charcoal-snackbar"
+      data-dim={dim}
+      data-with-button={button !== undefined}
+    >
+      <div
+        {...contentProps}
+        role="status"
+        className="charcoal-snackbar-content"
+      >
+        <div {...titleProps} className="charcoal-snackbar-label">
+          {message}
+        </div>
+      </div>
+      {button !== undefined && (
+        <SnackbarAction
+          button={button}
+          dim={dim}
+          onClose={() => state.close(toast.key)}
+        />
+      )}
+    </div>
+  )
+}
+
+function SnackbarAction({
+  button,
+  dim,
+  onClose,
+}: {
+  button: SnackbarButtonContent
+  dim: boolean
+  onClose: () => void
+}) {
+  const {
+    hideSnackbarOnClick = true,
+    onClick,
+    variant,
+    children: buttonChildren,
+    ...buttonProps
+  } = button
+
+  function handleButtonClick(
+    event: Parameters<NonNullable<ButtonProps<'button'>['onClick']>>[0],
+  ) {
+    onClick?.(event)
+    if (hideSnackbarOnClick) {
+      onClose()
+    }
+  }
+
+  return (
+    <PolymorphicButton
+      {...buttonProps}
+      size="S"
+      variant={variant ?? (dim ? 'Overlay' : undefined)}
+      className="charcoal-snackbar-button"
+      aria-keyshortcuts="F6"
+      onClick={handleButtonClick}
+    >
+      {buttonChildren}
+    </PolymorphicButton>
+  )
+}
+
+function PolymorphicButton({
+  component,
+  ...props
+}: Omit<ButtonProps, 'component'> & { component?: ElementType }) {
+  if (component === undefined || component === 'button') {
+    return <Button {...props} />
+  }
+
+  return <Button {...props} component={component} />
+}

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
 } from 'react'
 import type { ElementType, RefObject } from 'react'
@@ -108,43 +107,35 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
 ) {
   'use memo'
 
-  const regionRef = useRef<HTMLDivElement>(null)
-  const queueRef = useRef<QueuedSnackbar[]>([]) // 前の要素が消えるまで呼び出し関数を持っておく
-  const onRemovedRef = useRef<(() => void) | null>(null)
-  
-  // wrapUpdate の参照が変わると useToastState が ToastQueue を作り直すため固定する
-  const wrapToastUpdate = useCallback(
-    (update: () => void, action: 'add' | 'remove' | 'clear') => {
-      if (action !== 'remove') {
-        update()
-        return
-      }
+  const snackbarRef = useRef<HTMLDivElement>(null)
+  const queueRef = useRef<QueuedSnackbar[]>([])
+  const isShowingRef = useRef(false)
 
-      const finish = () => {
-        update()
-        const onRemoved = onRemovedRef.current
-        onRemovedRef.current = null
-        onRemoved?.()
-      }
+  // wrapUpdate の参照が変わると useToastState が ToastQueue を作り直すため useCallback で固定する
+  const wrapToastUpdate = useCallback(function wrapToastUpdate(
+    update: () => void,
+    action: 'add' | 'remove' | 'clear',
+  ) {
+    if (action !== 'remove') {
+      update()
+      return
+    }
 
-      const snackbar =
-        regionRef.current?.querySelector<HTMLElement>('.charcoal-snackbar')
-      if (snackbar === undefined || snackbar === null) {
-        finish()
-        return
-      }
+    function finish() {
+      update()
+      playNext()
+    }
 
-      // allow-discreteが Newly Available で使えないので、要素の削除をアニメーション完了まで待つ
-      snackbar.dataset.exiting = 'true'
-      let completed = false
-      const complete = () => {
-        if (completed) return
-        completed = true
-        snackbar.removeEventListener('animationend', handleAnimationEnd)
-        window.clearTimeout(fallbackTimer)
-        finish()
-      }
-      const handleAnimationEnd = (event: AnimationEvent) => {
+    if (snackbarRef.current === null) {
+      finish()
+      return
+    }
+    const snackbar: HTMLDivElement = snackbarRef.current
+
+    // allow-discreteが Newly Available で使えないので、要素の削除をアニメーション完了まで待つ
+    snackbar.dataset.exiting = 'true'
+    let completed = false
+    function handleAnimationEnd(event: AnimationEvent) {
         if (
           event.target === snackbar &&
           event.animationName === 'charcoal-snackbar-exit'
@@ -152,19 +143,21 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
           complete()
         }
       }
-      const fallbackTimer = window.setTimeout(
+    function complete() {
+      if (completed) return
+      completed = true
+      snackbar.removeEventListener('animationend', handleAnimationEnd)
+      window.clearTimeout(window.setTimeout(
         complete,
         EXIT_ANIMATION_DURATION_MS + 100,
-      )
-
-      snackbar.addEventListener('animationend', handleAnimationEnd)
-
-      if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
-        complete()
-      }
-    },
-    [],
-  )
+      ))
+      finish()
+    }
+    snackbar.addEventListener('animationend', handleAnimationEnd)
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      complete()
+    }
+  }, [])
 
   const state = useToastState<SnackbarContent>({
     maxVisibleToasts: 1,
@@ -174,22 +167,23 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   useEffect(() => {
     return () => {
       queueRef.current = []
-      onRemovedRef.current = null
+      isShowingRef.current = false
     }
   }, [])
 
   function playNext() {
     const next = queueRef.current.shift()
     if (next === undefined) {
+      isShowingRef.current = false
       return
     }
 
     const { duration, ...content } = next
+    isShowingRef.current = true
     state.add(content, {
       // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
       timeout: duration === 0 ? 1 : duration,
     })
-    onRemovedRef.current = playNext
   }
 
   function show<T extends ElementType = 'button'>(
@@ -207,7 +201,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
       button: button as SnackbarButtonContent | undefined,
       duration,
     })
-    if (onRemovedRef.current === null) {
+    if (!isShowingRef.current) {
       playNext()
     }
   }
@@ -223,7 +217,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
       zIndex={zIndex}
       portalContainer={portalContainer}
       className={className}
-      regionRef={regionRef}
+      snackbarRef={snackbarRef}
     />
   )
 })
@@ -231,25 +225,27 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
 export default Snackbar
 
 export function useSnackbar(props: SnackbarProps = {}) {
+  'use memo'
+
   const { position, offset, dim, zIndex, portalContainer, className } = props
   const snackbarHandlerRef = useRef<SnackbarHandler>(null)
-  const element = useMemo(
-    () => (
-      <Snackbar
-        ref={snackbarHandlerRef}
-        position={position}
-        offset={offset}
-        dim={dim}
-        zIndex={zIndex}
-        portalContainer={portalContainer}
-        className={className}
-      />
-    ),
-    [position, offset, dim, zIndex, portalContainer, className],
+  const element = (
+    <Snackbar
+      ref={snackbarHandlerRef}
+      position={position}
+      offset={offset}
+      dim={dim}
+      zIndex={zIndex}
+      portalContainer={portalContainer}
+      className={className}
+    />
   )
-  const show = useCallback<SnackbarHandler['show']>((message, options) => {
+  function show<T extends ElementType = 'button'>(
+    message: string,
+    options?: SnackbarShowOptions<T>,
+  ) {
     snackbarHandlerRef.current?.show(message, options)
-  }, [])
+  }
   return [element, show] as const
 }
 
@@ -261,7 +257,7 @@ function SnackbarRegion({
   zIndex,
   portalContainer,
   className,
-  regionRef,
+  snackbarRef,
 }: {
   state: ToastState<SnackbarContent>
   position: SnackbarPosition
@@ -270,8 +266,9 @@ function SnackbarRegion({
   zIndex: number
   portalContainer?: HTMLElement
   className?: string
-  regionRef: RefObject<HTMLDivElement>
+  snackbarRef: RefObject<HTMLDivElement>
 }) {
+  const regionRef = useRef<HTMLDivElement>(null)
   const { regionProps } = useToastRegion({}, state, regionRef)
   const classNames = useClassNames('charcoal-snackbar-region', className)
 
@@ -292,16 +289,6 @@ function SnackbarRegion({
         ref={regionRef}
         className={classNames}
         data-position={effectivePosition}
-        onFocus={(event) => {
-          regionProps.onFocus?.(event)
-
-          // F6 で通知領域へ移動したとき、アクションがあれば直接フォーカスする
-          if (event.target === event.currentTarget) {
-            event.currentTarget
-              .querySelector<HTMLElement>('.charcoal-button')
-              ?.focus()
-          }
-        }}
         style={{
           zIndex,
           ...(effectivePosition === 'top'
@@ -310,7 +297,13 @@ function SnackbarRegion({
         }}
       >
         {state.visibleToasts.map((toast) => (
-          <SnackbarItem key={toast.key} toast={toast} state={state} dim={dim} />
+          <SnackbarItem
+            key={toast.key}
+            toast={toast}
+            state={state}
+            dim={dim}
+            snackbarRef={snackbarRef}
+          />
         ))}
       </div>
     </Overlay>
@@ -321,23 +314,24 @@ function SnackbarItem({
   toast,
   state,
   dim,
+  snackbarRef,
 }: {
   toast: QueuedToast<SnackbarContent>
   state: ToastState<SnackbarContent>
   dim: boolean
+  snackbarRef: RefObject<HTMLDivElement>
 }) {
-  const ref = useRef<HTMLDivElement>(null)
   const { toastProps, contentProps, titleProps } = useToast(
     { toast },
     state,
-    ref,
+    snackbarRef,
   )
   const { message, button } = toast.content
 
   return (
     <div
       {...toastProps}
-      ref={ref}
+      ref={snackbarRef}
       className="charcoal-snackbar"
       data-dim={dim}
       data-with-button={button !== undefined}
@@ -355,7 +349,9 @@ function SnackbarItem({
         <SnackbarAction
           button={button}
           dim={dim}
-          onClose={() => state.close(toast.key)}
+          onClose={() => {
+            state.close(toast.key)
+          }}
         />
       )}
     </div>
@@ -393,7 +389,6 @@ function SnackbarAction({
       {...buttonProps}
       size="S"
       variant={variant ?? (dim ? 'Navigation' : undefined)}
-      aria-keyshortcuts="F6"
       onClick={handleButtonClick}
     >
       {buttonChildren}

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -111,6 +111,8 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   const regionRef = useRef<HTMLDivElement>(null)
   const queueRef = useRef<QueuedSnackbar[]>([]) // 前の要素が消えるまで呼び出し関数を持っておく
   const onRemovedRef = useRef<(() => void) | null>(null)
+  
+  // wrapUpdate の参照が変わると useToastState が ToastQueue を作り直すため固定する
   const wrapToastUpdate = useCallback(
     (update: () => void, action: 'add' | 'remove' | 'clear') => {
       if (action !== 'remove') {
@@ -176,7 +178,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     }
   }, [])
 
-  const playNext = useCallback(() => {
+  function playNext() {
     const next = queueRef.current.shift()
     if (next === undefined) {
       return
@@ -188,27 +190,27 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
       timeout: duration === 0 ? 1 : duration,
     })
     onRemovedRef.current = playNext
-  }, [state])
+  }
 
-  const show = useCallback<SnackbarHandler['show']>(
-    (message, options = {}) => {
-      const { duration: durationOption = DEFAULT_DURATION_MS, button } = options
-      const duration =
-        typeof durationOption === 'number' && Number.isFinite(durationOption)
-          ? Math.max(0, durationOption)
-          : DEFAULT_DURATION_MS
+  function show<T extends ElementType = 'button'>(
+    message: string,
+    options: SnackbarShowOptions<T> = {},
+  ) {
+    const { duration: durationOption = DEFAULT_DURATION_MS, button } = options
+    const duration =
+      typeof durationOption === 'number' && Number.isFinite(durationOption)
+        ? Math.max(0, durationOption)
+        : DEFAULT_DURATION_MS
 
-      queueRef.current.push({
-        message,
-        button: button as SnackbarButtonContent | undefined,
-        duration,
-      })
-      if (onRemovedRef.current === null) {
-        playNext()
-      }
-    },
-    [playNext],
-  )
+    queueRef.current.push({
+      message,
+      button: button as SnackbarButtonContent | undefined,
+      duration,
+    })
+    if (onRemovedRef.current === null) {
+      playNext()
+    }
+  }
 
   useImperativeHandle(ref, () => ({ show }), [show])
 

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -352,7 +352,6 @@ function SnackbarItem({
       {button !== undefined && (
         <SnackbarAction
           button={button}
-          dim={dim}
           onClose={() => state.close(toast.key)}
         />
       )}
@@ -362,17 +361,14 @@ function SnackbarItem({
 
 function SnackbarAction({
   button,
-  dim,
   onClose,
 }: {
   button: SnackbarButtonContent
-  dim: boolean
   onClose: () => void
 }) {
   const {
     hideSnackbarOnClick = true,
     onClick,
-    variant,
     children: buttonChildren,
     ...buttonProps
   } = button
@@ -390,7 +386,6 @@ function SnackbarAction({
     <PolymorphicButton
       {...buttonProps}
       size="S"
-      variant={variant ?? (dim ? 'Overlay' : undefined)}
       aria-keyshortcuts="F6"
       onClick={handleButtonClick}
     >

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -19,7 +19,7 @@ import { useClassNames } from '../../_lib/useClassNames'
 import Button, { type ButtonProps } from '../Button'
 
 const DEFAULT_DURATION_MS = 5000
-const DEFAULT_Z_INDEX = 10
+const DEFAULT_Z_INDEX = 20
 const ENTER_ANIMATION_DURATION_MS = 300
 const EXIT_ANIMATION_DURATION_MS = 300
 

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -55,9 +55,6 @@ export type SnackbarShowOptions<T extends ElementType = 'button'> = {
 }
 
 export type SnackbarHandler = {
-  /**
-   * メッセージを表示する
-   */
   show: <T extends ElementType = 'button'>(
     message: string,
     options?: SnackbarShowOptions<T>,
@@ -80,14 +77,7 @@ export type SnackbarProps = {
    * @default false
    */
   dim?: boolean
-  /**
-   * Snackbar の重なり順
-   * @default 10
-   */
   zIndex?: number
-  /**
-   * Snackbar の描画先となるポータルコンテナ
-   */
   portalContainer?: HTMLElement
   className?: string
 }
@@ -95,6 +85,10 @@ export type SnackbarProps = {
 type SnackbarContent = {
   message: string
   button?: SnackbarButtonContent
+}
+
+type QueuedSnackbar = SnackbarContent & {
+  duration: number
 }
 
 type SnackbarButtonContent = Omit<SnackbarButtonOption, 'component'> & {
@@ -115,7 +109,8 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   'use memo'
 
   const regionRef = useRef<HTMLDivElement>(null)
-  const exitCompletionRef = useRef<(() => void) | null>(null)
+  const queueRef = useRef<QueuedSnackbar[]>([]) // 前の要素が消えるまで呼び出し関数を持っておく
+  const onRemovedRef = useRef<(() => void) | null>(null)
   const wrapToastUpdate = useCallback(
     (update: () => void, action: 'add' | 'remove' | 'clear') => {
       if (action !== 'remove') {
@@ -123,15 +118,21 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
         return
       }
 
+      const finish = () => {
+        update()
+        const onRemoved = onRemovedRef.current
+        onRemovedRef.current = null
+        onRemoved?.()
+      }
+
       const snackbar =
         regionRef.current?.querySelector<HTMLElement>('.charcoal-snackbar')
       if (snackbar === undefined || snackbar === null) {
-        update()
-        exitCompletionRef.current?.()
-        exitCompletionRef.current = null
+        finish()
         return
       }
 
+      // allow-discreteが Newly Available で使えないので、要素の削除をアニメーション完了まで待つ
       snackbar.dataset.exiting = 'true'
       let completed = false
       const complete = () => {
@@ -139,9 +140,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
         completed = true
         snackbar.removeEventListener('animationend', handleAnimationEnd)
         window.clearTimeout(fallbackTimer)
-        update()
-        exitCompletionRef.current?.()
-        exitCompletionRef.current = null
+        finish()
       }
       const handleAnimationEnd = (event: AnimationEvent) => {
         if (
@@ -164,79 +163,54 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     },
     [],
   )
+
   const state = useToastState<SnackbarContent>({
     maxVisibleToasts: 1,
     wrapUpdate: wrapToastUpdate,
   })
 
-  const pendingRef = useRef<Promise<void> | null>(null)
-  const mountedRef = useRef(true)
-  const pendingResolversRef = useRef(new Set<() => void>())
-
   useEffect(() => {
-    const pendingResolvers = pendingResolversRef.current
-    mountedRef.current = true
-
     return () => {
-      mountedRef.current = false
-      for (const resolve of Array.from(pendingResolvers)) {
-        resolve()
-      }
-      pendingResolvers.clear()
+      queueRef.current = []
+      onRemovedRef.current = null
     }
   }, [])
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      show<T extends ElementType = 'button'>(
-        message: string,
-        options: SnackbarShowOptions<T> = {},
-      ) {
-        const { duration: durationOption = DEFAULT_DURATION_MS, button } =
-          options
-        const duration =
-          typeof durationOption === 'number' && Number.isFinite(durationOption)
-            ? Math.max(0, durationOption)
-            : DEFAULT_DURATION_MS
-        const run = () =>
-          new Promise<void>((resolve) => {
-            const settle = () => {
-              pendingResolversRef.current.delete(settle)
-              resolve()
-            }
-            pendingResolversRef.current.add(settle)
+  const playNext = useCallback(() => {
+    const next = queueRef.current.shift()
+    if (next === undefined) {
+      return
+    }
 
-            if (!mountedRef.current) {
-              settle()
-              return
-            }
+    const { duration, ...content } = next
+    state.add(content, {
+      // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
+      timeout: duration === 0 ? 1 : duration,
+    })
+    onRemovedRef.current = playNext
+  }, [state])
 
-            state.add(
-              {
-                message,
-                button: button as SnackbarButtonContent | undefined,
-              },
-              {
-                // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
-                timeout: duration === 0 ? 1 : duration,
-                onClose: () => {
-                  exitCompletionRef.current = settle
-                },
-              },
-            )
-          })
-        if (pendingRef.current === null) {
-          // 初回の Snackbar はすぐに表示する
-          pendingRef.current = run()
-        } else {
-          // 前回の show の完了後に実行し、Snackbar を順番に表示する
-          pendingRef.current = pendingRef.current.then(run)
-        }
-      },
-    }),
-    [state],
+  const show = useCallback<SnackbarHandler['show']>(
+    (message, options = {}) => {
+      const { duration: durationOption = DEFAULT_DURATION_MS, button } = options
+      const duration =
+        typeof durationOption === 'number' && Number.isFinite(durationOption)
+          ? Math.max(0, durationOption)
+          : DEFAULT_DURATION_MS
+
+      queueRef.current.push({
+        message,
+        button: button as SnackbarButtonContent | undefined,
+        duration,
+      })
+      if (onRemovedRef.current === null) {
+        playNext()
+      }
+    },
+    [playNext],
   )
+
+  useImperativeHandle(ref, () => ({ show }), [show])
 
   return (
     <SnackbarRegion
@@ -322,13 +296,15 @@ function SnackbarRegion({
           // F6 で通知領域へ移動したとき、アクションがあれば直接フォーカスする
           if (event.target === event.currentTarget) {
             event.currentTarget
-              .querySelector<HTMLElement>('.charcoal-snackbar-button')
+              .querySelector<HTMLElement>('.charcoal-button')
               ?.focus()
           }
         }}
         style={{
           zIndex,
-          [effectivePosition]: offset,
+          ...(effectivePosition === 'top'
+            ? { top: offset }
+            : { bottom: offset }),
         }}
       >
         {state.visibleToasts.map((toast) => (
@@ -415,7 +391,6 @@ function SnackbarAction({
       {...buttonProps}
       size="S"
       variant={variant ?? (dim ? 'Overlay' : undefined)}
-      className="charcoal-snackbar-button"
       aria-keyshortcuts="F6"
       onClick={handleButtonClick}
     >

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -352,6 +352,7 @@ function SnackbarItem({
       {button !== undefined && (
         <SnackbarAction
           button={button}
+          dim={dim}
           onClose={() => state.close(toast.key)}
         />
       )}
@@ -361,14 +362,17 @@ function SnackbarItem({
 
 function SnackbarAction({
   button,
+  dim,
   onClose,
 }: {
   button: SnackbarButtonContent
+  dim: boolean
   onClose: () => void
 }) {
   const {
     hideSnackbarOnClick = true,
     onClick,
+    variant,
     children: buttonChildren,
     ...buttonProps
   } = button
@@ -386,6 +390,7 @@ function SnackbarAction({
     <PolymorphicButton
       {...buttonProps}
       size="S"
+      variant={variant ?? (dim ? 'Navigation' : undefined)}
       aria-keyshortcuts="F6"
       onClick={handleButtonClick}
     >

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -7,7 +7,7 @@ import {
   useImperativeHandle,
   useRef,
 } from 'react'
-import type { ElementType, RefObject } from 'react'
+import type { ElementType, MutableRefObject, RefObject } from 'react'
 import { Overlay } from 'react-aria/Overlay'
 import { useToast, useToastRegion } from 'react-aria/useToast'
 import {
@@ -34,11 +34,6 @@ type SnackbarButtonOption<T extends ElementType = 'button'> = Omit<
    * @example 'Link'
    */
   component?: T
-  /**
-   * ボタンを押したときに Snackbar を閉じるか
-   * @default true
-   */
-  hideSnackbarOnClick?: boolean
 } & ('button' extends T ? unknown : { component: T })
 
 export type SnackbarShowOptions<T extends ElementType = 'button'> = {
@@ -135,25 +130,27 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     // allow-discreteが Newly Available で使えないので、要素の削除をアニメーション完了まで待つ
     snackbar.dataset.exiting = 'true'
     let completed = false
+    let fallbackTimer = 0 // complete 内で clearTimeout(setTimeout(...)) すると新規タイマーを即キャンセルしてしまう
     function handleAnimationEnd(event: AnimationEvent) {
-        if (
-          event.target === snackbar &&
-          event.animationName === 'charcoal-snackbar-exit'
-        ) {
-          complete()
-        }
+      if (
+        event.target === snackbar &&
+        event.animationName === 'charcoal-snackbar-exit'
+      ) {
+        complete()
       }
+    }
     function complete() {
       if (completed) return
       completed = true
       snackbar.removeEventListener('animationend', handleAnimationEnd)
-      window.clearTimeout(window.setTimeout(
-        complete,
-        EXIT_ANIMATION_DURATION_MS + 100,
-      ))
+      window.clearTimeout(fallbackTimer)
       finish()
     }
     snackbar.addEventListener('animationend', handleAnimationEnd)
+    fallbackTimer = window.setTimeout(
+      complete,
+      EXIT_ANIMATION_DURATION_MS + 100,
+    )
     if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
       complete()
     }
@@ -269,7 +266,22 @@ function SnackbarRegion({
   snackbarRef: RefObject<HTMLDivElement>
 }) {
   const regionRef = useRef<HTMLDivElement>(null)
-  const { regionProps } = useToastRegion({}, state, regionRef)
+  const hoveredRef = useRef(false)
+  const pausedByRegionRef = useRef(false)
+  const timerState: ToastState<SnackbarContent> = {
+    ...state,
+    pauseAll() {
+      pausedByRegionRef.current = true
+      state.pauseAll()
+    },
+    resumeAll() {
+      pausedByRegionRef.current = false
+      if (!hoveredRef.current) {
+        state.resumeAll()
+      }
+    },
+  }
+  const { regionProps } = useToastRegion({}, timerState, regionRef)
   const classNames = useClassNames('charcoal-snackbar-region', className)
 
   if (state.visibleToasts.length === 0) {
@@ -303,6 +315,8 @@ function SnackbarRegion({
             state={state}
             dim={dim}
             snackbarRef={snackbarRef}
+            hoveredRef={hoveredRef}
+            pausedByRegionRef={pausedByRegionRef}
           />
         ))}
       </div>
@@ -315,11 +329,15 @@ function SnackbarItem({
   state,
   dim,
   snackbarRef,
+  hoveredRef,
+  pausedByRegionRef,
 }: {
   toast: QueuedToast<SnackbarContent>
   state: ToastState<SnackbarContent>
   dim: boolean
   snackbarRef: RefObject<HTMLDivElement>
+  hoveredRef: MutableRefObject<boolean>
+  pausedByRegionRef: MutableRefObject<boolean>
 }) {
   const { toastProps, contentProps, titleProps } = useToast(
     { toast },
@@ -328,6 +346,18 @@ function SnackbarItem({
   )
   const { message, button } = toast.content
 
+  function handleHoverStart() {
+    hoveredRef.current = true
+    state.pauseAll()
+  }
+
+  function handleHoverEnd() {
+    hoveredRef.current = false
+    if (!pausedByRegionRef.current) {
+      state.resumeAll()
+    }
+  }
+
   return (
     <div
       {...toastProps}
@@ -335,6 +365,8 @@ function SnackbarItem({
       className="charcoal-snackbar"
       data-dim={dim}
       data-with-button={button !== undefined}
+      onPointerEnter={handleHoverStart}
+      onPointerLeave={handleHoverEnd}
     >
       <div
         {...contentProps}
@@ -350,6 +382,7 @@ function SnackbarItem({
           button={button}
           dim={dim}
           onClose={() => {
+            hoveredRef.current = false
             state.close(toast.key)
           }}
         />
@@ -368,7 +401,6 @@ function SnackbarAction({
   onClose: () => void
 }) {
   const {
-    hideSnackbarOnClick = true,
     onClick,
     variant,
     children: buttonChildren,
@@ -379,9 +411,7 @@ function SnackbarAction({
     event: Parameters<NonNullable<ButtonProps<'button'>['onClick']>>[0],
   ) {
     onClick?.(event)
-    if (hideSnackbarOnClick) {
-      onClose()
-    }
+    onClose()
   }
 
   return (

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -7,7 +7,7 @@ import {
   useImperativeHandle,
   useRef,
 } from 'react'
-import type { ElementType, RefObject } from 'react'
+import type { ElementType, ReactNode, RefObject } from 'react'
 import { Overlay } from 'react-aria/Overlay'
 import { useToast, useToastRegion } from 'react-aria/useToast'
 import {
@@ -20,6 +20,7 @@ import Button, { type ButtonProps } from '../Button'
 
 const DEFAULT_DURATION_MS = 5000
 const DEFAULT_Z_INDEX = 10
+const ENTER_ANIMATION_DURATION_MS = 300
 const EXIT_ANIMATION_DURATION_MS = 300
 
 type SnackbarPosition = 'top' | 'bottom'
@@ -50,7 +51,7 @@ export type SnackbarShowOptions<T extends ElementType = 'button'> = {
 
 export type SnackbarHandler = {
   show: <T extends ElementType = 'button'>(
-    message: string,
+    message: ReactNode,
     options?: SnackbarShowOptions<T>,
   ) => void
 }
@@ -58,7 +59,7 @@ export type SnackbarHandler = {
 export type SnackbarProps = {
   /**
    * Snackbar の表示位置。ボタン付きの場合は `bottom` に固定される
-   * @default 'top'
+   * @default 'bottom'
    */
   position?: SnackbarPosition
   /**
@@ -77,7 +78,7 @@ export type SnackbarProps = {
 }
 
 type SnackbarContent = {
-  message: string
+  message: ReactNode
   button?: SnackbarButtonContent
 }
 
@@ -91,7 +92,7 @@ type SnackbarButtonContent = Omit<SnackbarButtonOption, 'component'> & {
 
 const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   {
-    position = 'top',
+    position = 'bottom',
     offset = 16,
     dim = false,
     zIndex = DEFAULT_Z_INDEX,
@@ -105,6 +106,10 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   const snackbarRef = useRef<HTMLDivElement>(null)
   const queueRef = useRef<QueuedSnackbar[]>([])
   const isShowingRef = useRef(false)
+  const hoverRef = useRef({
+    active: false,
+    pending: undefined as (() => void) | undefined,
+  })
   // wrapUpdate を固定したまま、後から定義する playNext の最新版を呼ぶ
   const playNextRef = useRef<(() => void) | undefined>(undefined)
 
@@ -121,6 +126,11 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     function finish() {
       update()
       playNextRef.current?.()
+    }
+
+    if (hoverRef.current.active) {
+      hoverRef.current.pending = () => wrapToastUpdate(update, 'remove')
+      return
     }
 
     if (snackbarRef.current === null) {
@@ -179,15 +189,19 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
 
     const { duration, ...content } = next
     isShowingRef.current = true
+    const enterMs = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+      .matches
+      ? 0
+      : ENTER_ANIMATION_DURATION_MS
     state.add(content, {
       // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
-      timeout: duration === 0 ? 1 : duration,
+      timeout: Math.max(1, duration + enterMs),
     })
   }
   playNextRef.current = playNext
 
   function show<T extends ElementType = 'button'>(
-    message: string,
+    message: ReactNode,
     options: SnackbarShowOptions<T> = {},
   ) {
     const { duration: durationOption = DEFAULT_DURATION_MS, button } = options
@@ -218,6 +232,19 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
       portalContainer={portalContainer}
       className={className}
       snackbarRef={snackbarRef}
+      onHoverStart={() => {
+        hoverRef.current.active = true
+      }}
+      onHoverEnd={() => {
+        hoverRef.current.active = false
+        const pending = hoverRef.current.pending
+        hoverRef.current.pending = undefined
+        pending?.()
+      }}
+      onActionClose={() => {
+        hoverRef.current.active = false
+        hoverRef.current.pending = undefined
+      }}
     />
   )
 })
@@ -241,7 +268,7 @@ export function useSnackbar(props: SnackbarProps = {}) {
     />
   )
   function show<T extends ElementType = 'button'>(
-    message: string,
+    message: ReactNode,
     options?: SnackbarShowOptions<T>,
   ) {
     snackbarHandlerRef.current?.show(message, options)
@@ -258,6 +285,9 @@ function SnackbarRegion({
   portalContainer,
   className,
   snackbarRef,
+  onHoverStart,
+  onHoverEnd,
+  onActionClose,
 }: {
   state: ToastState<SnackbarContent>
   position: SnackbarPosition
@@ -267,19 +297,23 @@ function SnackbarRegion({
   portalContainer?: HTMLElement
   className?: string
   snackbarRef: RefObject<HTMLDivElement>
+  onHoverStart: () => void
+  onHoverEnd: () => void
+  onActionClose: () => void
 }) {
   const regionRef = useRef<HTMLDivElement>(null)
-  const hoveredRef = useRef(false)
-  const pausedByRegionRef = useRef(false)
+  const pausedByFocusRef = useRef(false)
   const timerState: ToastState<SnackbarContent> = {
     ...state,
     pauseAll() {
-      pausedByRegionRef.current = true
-      state.pauseAll()
+      if (regionRef.current?.contains(document.activeElement)) {
+        pausedByFocusRef.current = true
+        state.pauseAll()
+      }
     },
     resumeAll() {
-      pausedByRegionRef.current = false
-      if (!hoveredRef.current) {
+      if (pausedByFocusRef.current) {
+        pausedByFocusRef.current = false
         state.resumeAll()
       }
     },
@@ -316,18 +350,10 @@ function SnackbarRegion({
             state={state}
             dim={dim}
             snackbarRef={snackbarRef}
-            onHoverStart={() => {
-              hoveredRef.current = true
-              state.pauseAll()
-            }}
-            onHoverEnd={() => {
-              hoveredRef.current = false
-              if (!pausedByRegionRef.current) {
-                state.resumeAll()
-              }
-            }}
+            onHoverStart={onHoverStart}
+            onHoverEnd={onHoverEnd}
             onActionClose={() => {
-              hoveredRef.current = false
+              onActionClose()
               state.close(toast.key)
             }}
           />

--- a/packages/react/src/components/Snackbar/index.tsx
+++ b/packages/react/src/components/Snackbar/index.tsx
@@ -7,7 +7,7 @@ import {
   useImperativeHandle,
   useRef,
 } from 'react'
-import type { ElementType, MutableRefObject, RefObject } from 'react'
+import type { ElementType, RefObject } from 'react'
 import { Overlay } from 'react-aria/Overlay'
 import { useToast, useToastRegion } from 'react-aria/useToast'
 import {
@@ -105,6 +105,8 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
   const snackbarRef = useRef<HTMLDivElement>(null)
   const queueRef = useRef<QueuedSnackbar[]>([])
   const isShowingRef = useRef(false)
+  // wrapUpdate を固定したまま、後から定義する playNext の最新版を呼ぶ
+  const playNextRef = useRef<(() => void) | undefined>(undefined)
 
   // wrapUpdate の参照が変わると useToastState が ToastQueue を作り直すため useCallback で固定する
   const wrapToastUpdate = useCallback(function wrapToastUpdate(
@@ -118,7 +120,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
 
     function finish() {
       update()
-      playNext()
+      playNextRef.current?.()
     }
 
     if (snackbarRef.current === null) {
@@ -182,6 +184,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
       timeout: duration === 0 ? 1 : duration,
     })
   }
+  playNextRef.current = playNext
 
   function show<T extends ElementType = 'button'>(
     message: string,
@@ -203,7 +206,7 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     }
   }
 
-  useImperativeHandle(ref, () => ({ show }), [show])
+  useImperativeHandle(ref, () => ({ show }))
 
   return (
     <SnackbarRegion
@@ -303,9 +306,7 @@ function SnackbarRegion({
         data-position={effectivePosition}
         style={{
           zIndex,
-          ...(effectivePosition === 'top'
-            ? { top: offset }
-            : { bottom: offset }),
+          '--charcoal-snackbar-offset': `${offset}px`,
         }}
       >
         {state.visibleToasts.map((toast) => (
@@ -315,8 +316,20 @@ function SnackbarRegion({
             state={state}
             dim={dim}
             snackbarRef={snackbarRef}
-            hoveredRef={hoveredRef}
-            pausedByRegionRef={pausedByRegionRef}
+            onHoverStart={() => {
+              hoveredRef.current = true
+              state.pauseAll()
+            }}
+            onHoverEnd={() => {
+              hoveredRef.current = false
+              if (!pausedByRegionRef.current) {
+                state.resumeAll()
+              }
+            }}
+            onActionClose={() => {
+              hoveredRef.current = false
+              state.close(toast.key)
+            }}
           />
         ))}
       </div>
@@ -329,15 +342,17 @@ function SnackbarItem({
   state,
   dim,
   snackbarRef,
-  hoveredRef,
-  pausedByRegionRef,
+  onHoverStart,
+  onHoverEnd,
+  onActionClose,
 }: {
   toast: QueuedToast<SnackbarContent>
   state: ToastState<SnackbarContent>
   dim: boolean
   snackbarRef: RefObject<HTMLDivElement>
-  hoveredRef: MutableRefObject<boolean>
-  pausedByRegionRef: MutableRefObject<boolean>
+  onHoverStart: () => void
+  onHoverEnd: () => void
+  onActionClose: () => void
 }) {
   const { toastProps, contentProps, titleProps } = useToast(
     { toast },
@@ -346,18 +361,6 @@ function SnackbarItem({
   )
   const { message, button } = toast.content
 
-  function handleHoverStart() {
-    hoveredRef.current = true
-    state.pauseAll()
-  }
-
-  function handleHoverEnd() {
-    hoveredRef.current = false
-    if (!pausedByRegionRef.current) {
-      state.resumeAll()
-    }
-  }
-
   return (
     <div
       {...toastProps}
@@ -365,8 +368,8 @@ function SnackbarItem({
       className="charcoal-snackbar"
       data-dim={dim}
       data-with-button={button !== undefined}
-      onPointerEnter={handleHoverStart}
-      onPointerLeave={handleHoverEnd}
+      onPointerEnter={onHoverStart}
+      onPointerLeave={onHoverEnd}
     >
       <div
         {...contentProps}
@@ -378,14 +381,7 @@ function SnackbarItem({
         </div>
       </div>
       {button !== undefined && (
-        <SnackbarAction
-          button={button}
-          dim={dim}
-          onClose={() => {
-            hoveredRef.current = false
-            state.close(toast.key)
-          }}
-        />
+        <SnackbarAction button={button} dim={dim} onClose={onActionClose} />
       )}
     </div>
   )
@@ -400,12 +396,7 @@ function SnackbarAction({
   dim: boolean
   onClose: () => void
 }) {
-  const {
-    onClick,
-    variant,
-    children: buttonChildren,
-    ...buttonProps
-  } = button
+  const { onClick, variant, children: buttonChildren, ...buttonProps } = button
 
   function handleButtonClick(
     event: Parameters<NonNullable<ButtonProps<'button'>['onClick']>>[0],

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -107,10 +107,10 @@ export {
   type ScrollStepContext,
 } from './components/Carousel'
 export {
-  default as Snackbar,
-  useSnackbar,
-  type SnackbarProps,
-  type SnackbarHandler,
-  type SnackbarShowOptions,
+  default as unstable_Snackbar,
+  useSnackbar as unstable_useSnackbar,
+  type SnackbarProps as unstable_SnackbarProps,
+  type SnackbarHandler as unstable_SnackbarHandler,
+  type SnackbarShowOptions as unstable_SnackbarShowOptions,
 } from './components/Snackbar'
 import './components/FocusRing/index.css'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -106,4 +106,11 @@ export {
   type ScrollStep,
   type ScrollStepContext,
 } from './components/Carousel'
+export {
+  default as Snackbar,
+  useSnackbar,
+  type SnackbarProps,
+  type SnackbarHandler,
+  type SnackbarShowOptions,
+} from './components/Snackbar'
 import './components/FocusRing/index.css'


### PR DESCRIPTION
## Summary
- `@charcoal-ui/react` に一時通知用の `Snackbar` と `useSnackbar` を追加しました
- 表示位置・duration・アクションボタン・Dim 表示に対応し、Storybook のポータル snapshot も Snackbar を取り込めるようにしました

## Test plan
- [ ] Storybook の `react/Snackbar` で Default / Bottom / WithButton / Dim / LongMessage を確認する
- [ ] `show` 後に自動で閉じること、ボタン操作で閉じることを確認する
- [ ] `packages/react` の Snackbar テストと Storybook snapshot テストが通ることを確認する