### PR TITLE
fix(icon-files): moduleフィールドの先頭スペースを削除

### DIFF
--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",
-  "module": " ./src/index.js",
+  "module": "./src/index.js",
   "exports": {
     ".": {
       "types": "./src/index.d.ts",


### PR DESCRIPTION
## 概要

- `@charcoal-ui/icon-files` の `module` フィールドから先頭スペースを削除
- 全 package.json の公開パス値を確認し、同種の空白がないことを確認

Closes #1027

## 確認

- ESM / CJS の自己参照による `@charcoal-ui/icon-files` の解決
- `prettier --check packages/icon-files/package.json`
- `git diff --check`