### PR TITLE
fix(react): 互換インターフェースのreact aria表記を修正

### DIFF
--- a/packages/react/src/_lib/compat.ts
+++ b/packages/react/src/_lib/compat.ts
@@ -1,13 +1,14 @@
 import * as React from 'react'
 
 /**
- * react-ariaの`useTextField()`は、<textarea>をサポートするにも関わらず、
+ * react-aria@3.48.0の`useTextField()`は、<textarea>をサポートするにも関わらず、
  * `React.KeyboardEvent<HTMLInputElement>`しか想定していないイベントハンドラがいくつかある
- * ↓ が直るまで、以下のイベントハンドラの型は信用しない（本当は`Element`ではなく`HTMLTextAreaElement`とかにしたい）
+ * react-aria@3.49.0で修正済みだが、peerDependenciesで3.48.0もサポートしているため、
+ * 以下のイベントハンドラの型は信用しない（本当は`Element`ではなく`HTMLTextAreaElement`とかにしたい）
  *
  * @see https://github.com/adobe/react-spectrum/issues/4662
  */
-export interface ReactAreaUseTextFieldCompat<E = Element> {
+export interface ReactAriaUseTextFieldCompat<E = Element> {
   readonly onCopy?: React.ClipboardEventHandler<E>
   readonly onPaste?: React.ClipboardEventHandler<E>
   readonly onCut?: React.ClipboardEventHandler<E>


### PR DESCRIPTION
## 概要

- `ReactAreaUseTextFieldCompat` を `ReactAriaUseTextFieldCompat` に修正
- react-aria@3.48.0 での問題と、3.49.0 での修正済みであることをコメントに明記

## 確認

- `pnpm exec prettier --check packages/react/src/_lib/compat.ts`
- `pnpm --filter @charcoal-ui/react typecheck`（既存の `@charcoal-ui/icons` 未ビルドにより失敗）