### PR TITLE
feat(react): Notificationのオプションを拡張

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9409,6 +9409,302 @@ exports[`Storybook Tests > react/SegmentedControl > react/SegmentedControl > Uni
 </div>
 `;
 
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Default 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="false"
+      data-with-action="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Dim 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="true"
+      data-with-action="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          Dim の Snackbar
+        </div>
+      </div>
+      <div>
+        <div>
+          <button
+            class="charcoal-button"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > LongMessage 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="false"
+      data-with-action="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > Top 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="false"
+      data-with-action="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          上部に表示します
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithAction 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="false"
+      data-with-action="true"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+      <div>
+        <div>
+          <button
+            class="charcoal-button"
+          >
+            取り消す
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithLineBreak 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-snackbar-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-snackbar"
+      data-dim="false"
+      data-with-action="false"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存に失敗しました
+          <br />
+          通信環境を確認してください
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/Switch > react/Switch > Checked 1`] = `
 <div>
   <div
@@ -12168,6 +12464,233 @@ exports[`Storybook Tests > react/TextField > react/TextField > TokenV2 1`] = `
 </div>
 `;
 
+exports[`Storybook Tests > react/Toast > react/Toast > Bottom 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-toast-region"
+    data-position="bottom"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-toast-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-toast"
+      data-type="success"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          下部に表示します
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Toast > react/Toast > Default 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-toast-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-toast-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-toast"
+      data-type="success"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存しました
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Toast > react/Toast > Error 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-toast-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-toast-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-toast"
+      data-type="error"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存に失敗しました
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Toast > react/Toast > LongMessage 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-toast-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-toast-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-toast"
+      data-type="success"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storybook Tests > react/Toast > react/Toast > WithLineBreak 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <button
+      class="charcoal-button"
+    >
+      show
+    </button>
+  </div>
+  <div
+    aria-label="1 notification."
+    class="charcoal-notification-region charcoal-toast-region"
+    data-position="top"
+    data-react-aria-top-layer="true"
+    role="region"
+    style="z-index: 20; --charcoal-toast-offset: 16px;"
+    tabindex="-1"
+  >
+    <div
+      aria-labelledby="test-id"
+      aria-modal="false"
+      class="charcoal-notification charcoal-toast"
+      data-type="success"
+      role="alertdialog"
+      tabindex="0"
+    >
+      <div
+        aria-atomic="true"
+        class="charcoal-notification-content"
+        role="status"
+      >
+        <div
+          class="charcoal-notification-label"
+          id="test-id"
+        >
+          保存に失敗しました
+          <br />
+          通信環境を確認してください
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/internals/CheckboxInput > react/internals/CheckboxInput > Checked 1`] = `
 <div>
   <div
@@ -12584,525 +13107,6 @@ exports[`Storybook Tests > react/internals/Popover > react/internals/Popover > B
     >
       button
     </button>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Default 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="false"
-      data-with-action="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存しました
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Dim 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="true"
-      data-with-action="true"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          Dim の Snackbar
-        </div>
-      </div>
-      <div>
-        <button
-          class="charcoal-button"
-        >
-          閉じる
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > LongMessage 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="false"
-      data-with-action="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > Top 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="false"
-      data-with-action="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          上部に表示します
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithAction 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="false"
-      data-with-action="true"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存しました
-        </div>
-      </div>
-      <div>
-        <button
-          class="charcoal-button"
-        >
-          取り消す
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithLineBreak 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-snackbar-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-snackbar-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-snackbar"
-      data-dim="false"
-      data-with-action="false"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存に失敗しました
-          <br />
-          通信環境を確認してください
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Bottom 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-toast-region"
-    data-position="bottom"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-toast-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-toast"
-      data-type="success"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          下部に表示します
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Default 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-toast-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-toast-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-toast"
-      data-type="success"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存しました
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Error 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-toast-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-toast-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-toast"
-      data-type="error"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存に失敗しました
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > LongMessage 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-toast-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-toast-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-toast"
-      data-type="success"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存した内容はすべての端末に同期され、あとから設定画面で変更できます。長いメッセージは2行を超えると省略されます
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > WithLineBreak 1`] = `
-<div>
-  <div
-    data-dark="false"
-  >
-    <button
-      class="charcoal-button"
-    >
-      show
-    </button>
-  </div>
-  <div
-    aria-label="1 notification."
-    class="charcoal-notification-region charcoal-toast-region"
-    data-position="top"
-    data-react-aria-top-layer="true"
-    role="region"
-    style="z-index: 20; --charcoal-toast-offset: 16px;"
-    tabindex="-1"
-  >
-    <div
-      aria-labelledby="test-id"
-      aria-modal="false"
-      class="charcoal-notification charcoal-toast"
-      data-type="success"
-      role="alertdialog"
-      tabindex="0"
-    >
-      <div
-        aria-atomic="true"
-        class="charcoal-notification-content"
-        role="status"
-      >
-        <div
-          class="charcoal-notification-label"
-          id="test-id"
-        >
-          保存に失敗しました
-          <br />
-          通信環境を確認してください
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -12613,7 +12613,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="false"
-      data-with-button="false"
+      data-with-action="false"
       role="alertdialog"
       tabindex="0"
     >
@@ -12659,7 +12659,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="true"
-      data-with-button="true"
+      data-with-action="true"
       role="alertdialog"
       tabindex="0"
     >
@@ -12675,13 +12675,13 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > D
           Dim の Snackbar
         </div>
       </div>
-      <button
-        class="charcoal-button"
-        data-size="S"
-        data-variant="Navigation"
-      >
-        閉じる
-      </button>
+      <div>
+        <button
+          class="charcoal-button"
+        >
+          閉じる
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -12712,7 +12712,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > L
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="false"
-      data-with-button="false"
+      data-with-action="false"
       role="alertdialog"
       tabindex="0"
     >
@@ -12758,7 +12758,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > T
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="false"
-      data-with-button="false"
+      data-with-action="false"
       role="alertdialog"
       tabindex="0"
     >
@@ -12779,7 +12779,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > T
 </div>
 `;
 
-exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithButton 1`] = `
+exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > WithAction 1`] = `
 <div>
   <div
     data-dark="false"
@@ -12804,7 +12804,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="false"
-      data-with-button="true"
+      data-with-action="true"
       role="alertdialog"
       tabindex="0"
     >
@@ -12820,12 +12820,13 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
           保存しました
         </div>
       </div>
-      <button
-        class="charcoal-button"
-        data-size="S"
-      >
-        取り消す
-      </button>
+      <div>
+        <button
+          class="charcoal-button"
+        >
+          取り消す
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -12856,7 +12857,7 @@ exports[`Storybook Tests > react/unstable_Snackbar > react/unstable_Snackbar > W
       aria-modal="false"
       class="charcoal-notification charcoal-snackbar"
       data-dim="false"
-      data-with-button="false"
+      data-with-action="false"
       role="alertdialog"
       tabindex="0"
     >
@@ -12903,7 +12904,7 @@ exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Bottom 
       aria-labelledby="test-id"
       aria-modal="false"
       class="charcoal-notification charcoal-toast"
-      data-variant="success"
+      data-type="success"
       role="alertdialog"
       tabindex="0"
     >
@@ -12948,7 +12949,7 @@ exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Default
       aria-labelledby="test-id"
       aria-modal="false"
       class="charcoal-notification charcoal-toast"
-      data-variant="success"
+      data-type="success"
       role="alertdialog"
       tabindex="0"
     >
@@ -12993,7 +12994,7 @@ exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > Error 1
       aria-labelledby="test-id"
       aria-modal="false"
       class="charcoal-notification charcoal-toast"
-      data-variant="error"
+      data-type="error"
       role="alertdialog"
       tabindex="0"
     >
@@ -13038,7 +13039,7 @@ exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > LongMes
       aria-labelledby="test-id"
       aria-modal="false"
       class="charcoal-notification charcoal-toast"
-      data-variant="success"
+      data-type="success"
       role="alertdialog"
       tabindex="0"
     >
@@ -13083,7 +13084,7 @@ exports[`Storybook Tests > react/unstable_Toast > react/unstable_Toast > WithLin
       aria-labelledby="test-id"
       aria-modal="false"
       class="charcoal-notification charcoal-toast"
-      data-variant="success"
+      data-type="success"
       role="alertdialog"
       tabindex="0"
     >

--- a/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
@@ -31,7 +31,7 @@
   animation: charcoal-snackbar-exit 0.3s ease-out both;
 }
 
-.charcoal-snackbar[data-with-button='true'] {
+.charcoal-snackbar[data-with-action='true'] {
   min-height: 56px;
   padding: var(--charcoal-space-25) var(--charcoal-space-30)
       var(--charcoal-space-25) var(--charcoal-space-40);

--- a/packages/react/src/components/Notification/Snackbar/index.css
+++ b/packages/react/src/components/Notification/Snackbar/index.css
@@ -32,7 +32,7 @@
     animation: charcoal-snackbar-exit 0.3s ease-out both;
   }
 
-  &[data-with-button='true'] {
+  &[data-with-action='true'] {
     min-height: 56px;
     padding: var(--charcoal-space-25) var(--charcoal-space-30)
       var(--charcoal-space-25) var(--charcoal-space-40);

--- a/packages/react/src/components/Notification/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.story.tsx
@@ -1,21 +1,20 @@
 import { useEffect, type ReactNode } from 'react'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import Button from '../../Button'
-import unstable_Snackbar, {
-  useSnackbar as unstable_useSnackbar,
-  type SnackbarProps as unstable_SnackbarProps,
-} from '.'
+import { useSnackbar as unstable_useSnackbar } from '.'
 
 const defaultOpen = !!process.env.TEST
 
-type SnackbarStoryArgs = unstable_SnackbarProps & {
+type SnackbarStoryArgs = NonNullable<
+  Parameters<typeof unstable_useSnackbar>[0]
+> & {
   message: ReactNode
   actionChildren?: string
 }
 
 export default {
-  title: 'react/unstable_Snackbar',
-  component: unstable_Snackbar,
+  title: 'react/Snackbar',
+  component: SnackbarDemo,
   parameters: {
     layout: 'centered',
     tokenVersion: 'v2',
@@ -24,43 +23,50 @@ export default {
     },
     docs: {
       description: {
-        component: `同時に表示できるスナックバーは1つのみです。表示中に別のスナックバーが発生した場合は、\`order\` に応じてキューに積むか、表示中のスナックバーを置き換えます。
+        component: `\`unstable_useSnackbar\` を使用すると、表示時間やキューを含む表示制御を利用できます。同時に表示できるスナックバーは1つのみです。表示中に別のスナックバーが発生した場合は、\`order\` に応じてキューに積むか、表示中のスナックバーを置き換えます。
 
-別々の \`useSnackbar\` を呼び出した場合は互いに独立するため、同時表示数は1件に制限されません。`,
+別々の \`unstable_useSnackbar\` を呼び出した場合は互いに独立するため、同時表示数は1件に制限されません。
+
+\`UnstableSnackbar\` は表示専用のコンポーネントです。表示状態や表示時間を制御する機構を持たず、アクションの指定を必須とします。表示の切り替えは利用側で制御してください。`,
       },
     },
   },
   args: {
     message: '保存しました',
+    position: 'bottom',
+    offset: 16,
+    duration: 5000,
     order: 'queue',
+    dim: false,
+    zIndex: 20,
   },
   argTypes: {
     position: {
       options: ['top', 'bottom'],
       control: { type: 'inline-radio' },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: "'bottom'" } },
     },
     offset: {
       control: { type: 'number', min: 0, step: 1 },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '16' } },
     },
     duration: {
       control: { type: 'number', min: 0, step: 500 },
       description: '表示時間（ミリ秒）',
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '5000' } },
     },
     order: {
       options: ['queue', 'replace'],
       control: { type: 'inline-radio' },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: "'queue'" } },
     },
     dim: {
       control: 'boolean',
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: 'false' } },
     },
     zIndex: {
       control: { type: 'number', min: 0, step: 1 },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '20' } },
     },
     className: {
       control: 'text',
@@ -93,17 +99,18 @@ function SnackbarDemo({
 }: SnackbarStoryArgs) {
   const [snackbar, showSnackbar] = unstable_useSnackbar(props)
   const hasAction = actionChildren !== undefined && actionChildren !== ''
-  const showOptions = {
-    ...(hasAction ? { action: <Button>{actionChildren}</Button> } : {}),
-  }
+  const showOptions = hasAction
+    ? { action: <Button>{actionChildren}</Button> }
+    : undefined
 
   useEffect(() => {
     if (!defaultOpen) {
       return
     }
-    showSnackbar(message, {
-      ...(hasAction ? { action: <Button>{actionChildren}</Button> } : {}),
-    })
+    showSnackbar(
+      message,
+      hasAction ? { action: <Button>{actionChildren}</Button> } : undefined,
+    )
   }, [actionChildren, hasAction, message, showSnackbar])
 
   return (

--- a/packages/react/src/components/Notification/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.story.tsx
@@ -10,8 +10,7 @@ const defaultOpen = !!process.env.TEST
 
 type SnackbarStoryArgs = unstable_SnackbarProps & {
   message: ReactNode
-  buttonChildren?: string
-  duration?: number
+  actionChildren?: string
 }
 
 export default {
@@ -20,9 +19,12 @@ export default {
   parameters: {
     layout: 'centered',
     tokenVersion: 'v2',
+    controls: {
+      sort: 'requiredFirst',
+    },
     docs: {
       description: {
-        component: `同時に表示できるスナックバーは1つのみです。表示中に別のスナックバーが発生した場合はキューに積み、前のスナックバーが消えてから表示します。
+        component: `同時に表示できるスナックバーは1つのみです。表示中に別のスナックバーが発生した場合は、\`order\` に応じてキューに積むか、表示中のスナックバーを置き換えます。
 
 別々の \`useSnackbar\` を呼び出した場合は互いに独立するため、同時表示数は1件に制限されません。`,
       },
@@ -30,23 +32,55 @@ export default {
   },
   args: {
     message: '保存しました',
-    duration: 5000,
+    order: 'queue',
   },
   argTypes: {
     position: {
       options: ['top', 'bottom'],
       control: { type: 'inline-radio' },
+      table: { category: 'Hook' },
     },
-    message: {
-      control: 'text',
+    offset: {
+      control: { type: 'number', min: 0, step: 1 },
+      table: { category: 'Hook' },
     },
     duration: {
       control: { type: 'number', min: 0, step: 500 },
       description: '表示時間（ミリ秒）',
+      table: { category: 'Hook' },
     },
-    buttonChildren: {
-      name: 'button.children',
+    order: {
+      options: ['queue', 'replace'],
+      control: { type: 'inline-radio' },
+      table: { category: 'Hook' },
+    },
+    dim: {
+      control: 'boolean',
+      table: { category: 'Hook' },
+    },
+    zIndex: {
+      control: { type: 'number', min: 0, step: 1 },
+      table: { category: 'Hook' },
+    },
+    className: {
       control: 'text',
+      table: { category: 'Hook' },
+    },
+    portalContainer: {
+      control: false,
+      table: { category: 'Hook' },
+    },
+    css: {
+      table: { disable: true },
+    },
+    message: {
+      control: 'text',
+      table: { category: 'Show' },
+    },
+    actionChildren: {
+      name: 'action',
+      control: 'text',
+      table: { category: 'Show' },
     },
   },
   render: (args) => <SnackbarDemo {...args} />,
@@ -54,15 +88,13 @@ export default {
 
 function SnackbarDemo({
   message,
-  buttonChildren,
-  duration,
+  actionChildren,
   ...props
 }: SnackbarStoryArgs) {
   const [snackbar, showSnackbar] = unstable_useSnackbar(props)
-  const hasButton = buttonChildren !== undefined && buttonChildren !== ''
+  const hasAction = actionChildren !== undefined && actionChildren !== ''
   const showOptions = {
-    duration,
-    ...(hasButton ? { button: { children: buttonChildren } } : {}),
+    ...(hasAction ? { action: <Button>{actionChildren}</Button> } : {}),
   }
 
   useEffect(() => {
@@ -70,10 +102,9 @@ function SnackbarDemo({
       return
     }
     showSnackbar(message, {
-      duration: 60_000,
-      ...(hasButton ? { button: { children: buttonChildren } } : {}),
+      ...(hasAction ? { action: <Button>{actionChildren}</Button> } : {}),
     })
-  }, [buttonChildren, hasButton, message, showSnackbar])
+  }, [actionChildren, hasAction, message, showSnackbar])
 
   return (
     <>
@@ -132,10 +163,10 @@ export const WithLineBreak: StoryObj<SnackbarStoryArgs> = {
   },
 }
 
-export const WithButton: StoryObj<SnackbarStoryArgs> = {
+export const WithAction: StoryObj<SnackbarStoryArgs> = {
   args: {
     message: '保存しました',
-    buttonChildren: '取り消す',
+    actionChildren: '取り消す',
   },
   parameters: {
     docs: {
@@ -152,9 +183,7 @@ export function Example() {
       <Button
         onClick={() =>
           showSnackbar('保存しました', {
-            button: {
-              children: '取り消す',
-            },
+            action: <Button>取り消す</Button>,
           })
         }
       >
@@ -179,6 +208,6 @@ export const Dim: StoryObj<SnackbarStoryArgs> = {
   args: {
     dim: true,
     message: 'Dim の Snackbar',
-    buttonChildren: '閉じる',
+    actionChildren: '閉じる',
   },
 }

--- a/packages/react/src/components/Notification/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.test.tsx
@@ -62,9 +62,9 @@ describe('Snackbar', () => {
   })
 
   it.each([0, -1])('clamps duration to zero: %s', (duration) => {
-    const { show } = renderSnackbar()
+    const { show } = renderSnackbar({ duration })
 
-    show('保存しました', { duration })
+    show('保存しました')
     expect(screen.getByText('保存しました')).toBeInTheDocument()
 
     act(() => {
@@ -84,9 +84,9 @@ describe('Snackbar', () => {
     Number.NEGATIVE_INFINITY,
     'invalid' as unknown as number,
   ])('falls back to the default duration: %s', (duration) => {
-    const { show } = renderSnackbar()
+    const { show } = renderSnackbar({ duration })
 
-    show('保存しました', { duration })
+    show('保存しました')
     act(() => {
       vi.advanceTimersByTime(4999)
     })
@@ -118,6 +118,56 @@ describe('Snackbar', () => {
 
     expect(screen.queryByText('first')).not.toBeInTheDocument()
     expect(screen.getByText('second')).toBeInTheDocument()
+  })
+
+  it('replaces the current snackbar immediately when requested', () => {
+    const onClose = vi.fn()
+    const { show } = renderSnackbar({ order: 'replace' })
+
+    show('first', { onClose })
+    show('second')
+
+    expect(screen.queryByText('first')).not.toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
+    expect(onClose).toHaveBeenCalledExactlyOnceWith('replaced')
+  })
+
+  it('reports timeout when the snackbar closes after its duration', () => {
+    const onClose = vi.fn()
+    const { show } = renderSnackbar({ duration: 0 })
+
+    show('保存しました', { onClose })
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(onClose).toHaveBeenCalledExactlyOnceWith('timeout')
+  })
+
+  it('reports action when the action is clicked', () => {
+    const onClose = vi.fn()
+    const { show } = renderSnackbar()
+
+    show('保存しました', {
+      action: <button type="button">取り消す</button>,
+      onClose,
+    })
+    fireEvent.click(screen.getByRole('button', { name: '取り消す' }))
+
+    expect(onClose).toHaveBeenCalledExactlyOnceWith('action')
+  })
+
+  it('reports unmounted only for the currently displayed snackbar', () => {
+    const firstOnClose = vi.fn()
+    const secondOnClose = vi.fn()
+    const { show, unmount } = renderSnackbar()
+
+    show('first', { onClose: firstOnClose })
+    show('second', { onClose: secondOnClose })
+    unmount()
+
+    expect(firstOnClose).toHaveBeenCalledExactlyOnceWith('unmounted')
+    expect(secondOnClose).not.toHaveBeenCalled()
   })
 
   it('keeps the snackbar open while hovered after the timer ends, then closes on leave', () => {
@@ -163,11 +213,11 @@ describe('Snackbar', () => {
     expect(snackbar).toHaveAttribute('data-exiting', 'true')
   })
 
-  it('places a snackbar with a button at the bottom', () => {
+  it('places a snackbar with an action at the bottom', () => {
     const { show } = renderSnackbar({ position: 'top' })
 
     show('保存しました', {
-      button: { children: '取り消す' },
+      action: <button type="button">取り消す</button>,
     })
 
     expect(screen.getByRole('region')).toHaveAttribute(
@@ -176,7 +226,7 @@ describe('Snackbar', () => {
     )
   })
 
-  it('places a snackbar without a button at the top when requested', () => {
+  it('places a snackbar without an action at the top when requested', () => {
     const { show } = renderSnackbar({ position: 'top' })
 
     show('保存しました')
@@ -201,7 +251,7 @@ describe('Snackbar', () => {
     const { show } = renderSnackbar()
 
     show('保存しました', {
-      button: { children: '取り消す' },
+      action: <button type="button">取り消す</button>,
     })
 
     fireEvent.keyDown(document, { key: 'F6' })
@@ -216,7 +266,7 @@ describe('Snackbar', () => {
     trigger.focus()
 
     show('保存しました', {
-      button: { children: '閉じる' },
+      action: <button type="button">閉じる</button>,
     })
 
     fireEvent.keyDown(document, { key: 'F6' })
@@ -229,14 +279,14 @@ describe('Snackbar', () => {
     trigger.remove()
   })
 
-  it('closes on button click even while hovered', () => {
+  it('closes on action click even while hovered', () => {
     const { show } = renderSnackbar()
     const trigger = document.createElement('button')
     document.body.append(trigger)
     trigger.focus()
 
     show('保存しました', {
-      button: { children: '閉じる' },
+      action: <button type="button">閉じる</button>,
     })
 
     const snackbar = screen

--- a/packages/react/src/components/Notification/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.test.tsx
@@ -1,14 +1,26 @@
-import { createRef, type ComponentProps } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { render, fireEvent, act, cleanup, screen } from '@testing-library/react'
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
-import Snackbar, { useSnackbar, type SnackbarHandler } from '.'
+import Snackbar, { useSnackbar, type ShowSnackbarOptions } from '.'
 
-function renderSnackbar(props: ComponentProps<typeof Snackbar> = {}) {
-  const ref = createRef<SnackbarHandler>()
-  const result = render(<Snackbar ref={ref} {...props} />)
-  const show: SnackbarHandler['show'] = (message, options) => {
+function renderSnackbar(props: Parameters<typeof useSnackbar>[0] = {}) {
+  let showSnackbar:
+    ((message: ReactNode, options?: ShowSnackbarOptions) => void) | undefined
+
+  function SnackbarApp() {
+    const [snackbar, show] = useSnackbar(props)
+    useEffect(() => {
+      showSnackbar = show
+    }, [show])
+    return snackbar
+  }
+
+  const result = render(<SnackbarApp />)
+  function show(message: ReactNode, options?: ShowSnackbarOptions) {
+    if (showSnackbar === undefined) throw new Error('showSnackbar not found')
+    const currentShowSnackbar = showSnackbar
     act(() => {
-      ref.current?.show(message, options)
+      currentShowSnackbar(message, options)
     })
     act(() => {
       vi.advanceTimersByTime(300)
@@ -36,6 +48,25 @@ describe('Snackbar', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+  })
+
+  it('renders the message and required action', () => {
+    render(
+      <Snackbar
+        message="保存しました"
+        action={<button type="button">取り消す</button>}
+      />,
+    )
+
+    expect(screen.getByText('保存しました')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '取り消す' })).toBeInTheDocument()
+  })
+
+  it('requires a non-null action at the type level', () => {
+    // @ts-expect-error action must not be undefined
+    const undefinedAction = <Snackbar message="x" action={undefined} />
+
+    expect(undefinedAction).toBeDefined()
   })
 
   it('shows a message and hides after 5 seconds', () => {

--- a/packages/react/src/components/Notification/Snackbar/index.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.tsx
@@ -1,8 +1,8 @@
 import '../layout.css'
 import './index.css'
 
-import { forwardRef, useImperativeHandle, useRef } from 'react'
-import type { ReactNode } from 'react'
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react'
+import { useClassNames } from '../../../_lib/useClassNames'
 import { NotificationItem } from '../NotificationItem'
 import { NotificationRegion } from '../NotificationRegion'
 import { useNotificationQueue } from '../useNotificationQueue'
@@ -12,30 +12,23 @@ export type SnackbarCloseReason =
   'timeout' | 'replaced' | 'action' | 'close' | 'unmounted'
 
 export type ShowSnackbarOptions = {
-  /**
-   * Snackbar の右側に表示するアクション
-   */
   action?: ReactNode
-  /**
-   * Snackbar が閉じるときに呼び出される
-   */
   onClose?: (reason: SnackbarCloseReason) => void
 }
 
-export type SnackbarHandler = {
-  show: (message: ReactNode, options?: ShowSnackbarOptions) => void
+type SnackbarBaseProps = {
+  message: ReactNode
+  action?: ReactNode
+  dim?: boolean
+} & Omit<HTMLAttributes<HTMLDivElement>, 'children'>
+
+export type SnackbarProps = Omit<SnackbarBaseProps, 'action'> & {
+  /** Snackbar の右側に表示するアクション */
+  action: NonNullable<ReactNode>
 }
 
-export type SnackbarProps = Omit<NotificationProps, 'position'> & {
-  /**
-   * Snackbar の表示位置。ボタン付きの場合は `bottom` に固定される
-   * @default 'bottom'
-   */
+export type UseSnackbarProps = Omit<NotificationProps, 'position'> & {
   position?: Position
-  /**
-   * 暗い背景色
-   * @default false
-   */
   dim?: boolean
 }
 
@@ -44,12 +37,24 @@ type SnackbarContent = {
   action?: ReactNode
 }
 
-const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
-  { position = 'bottom', dim = false, duration, order, ...regionProps },
-  ref,
-) {
+const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(
+  function Snackbar(props, ref) {
+    return <SnackbarBase {...props} ref={ref} />
+  },
+)
+
+export default Snackbar
+
+export function useSnackbar(props: UseSnackbarProps = {}) {
   'use memo'
 
+  const {
+    position = 'bottom',
+    dim = false,
+    duration,
+    order,
+    ...regionProps
+  } = props
   const { state, itemRef, enqueue, close, onHoverStart, onHoverEnd } =
     useNotificationQueue<SnackbarContent, SnackbarCloseReason>('snackbar', {
       duration,
@@ -59,24 +64,14 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
     })
 
   function show(message: ReactNode, options: ShowSnackbarOptions = {}) {
-    enqueue(
-      {
-        message,
-        action: options.action,
-      },
-      options.onClose,
-    )
+    enqueue({ message, action: options.action }, options.onClose)
   }
 
-  useImperativeHandle(ref, () => ({ show }))
-
-  // アクション付きの Snackbar は常に下部に表示される
   const hasAction = state.visibleToasts.some(
     (toast) => toast.content.action !== undefined,
   )
   const effectivePosition = hasAction ? 'bottom' : position
-
-  return (
+  const element = (
     <NotificationRegion
       name="snackbar"
       state={state}
@@ -96,36 +91,46 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
           data-with-action={toast.content.action !== undefined}
         >
           {toast.content.action !== undefined && (
-            <SnackbarAction
-              action={toast.content.action}
-              onClick={() => close(toast.key, 'action')}
-            />
+            <div onClick={() => close(toast.key, 'action')}>
+              <SnackbarAction action={toast.content.action} />
+            </div>
           )}
         </NotificationItem>
       ))}
     </NotificationRegion>
   )
-})
 
-export default Snackbar
-
-export function useSnackbar(props: SnackbarProps = {}) {
-  'use memo'
-
-  const snackbarHandlerRef = useRef<SnackbarHandler>(null)
-  const element = <Snackbar ref={snackbarHandlerRef} {...props} />
-  function show(message: ReactNode, options?: ShowSnackbarOptions) {
-    snackbarHandlerRef.current?.show(message, options)
-  }
   return [element, show] as const
 }
 
-function SnackbarAction({
-  action,
-  onClick,
-}: {
-  action: ReactNode
-  onClick: () => void
-}) {
-  return <div onClick={onClick}>{action}</div>
+const SnackbarBase = forwardRef<HTMLDivElement, SnackbarBaseProps>(
+  function SnackbarBase(
+    { message, action, dim = false, className, ...rootProps },
+    ref,
+  ) {
+    const classNames = useClassNames(
+      'charcoal-notification',
+      'charcoal-snackbar',
+      className,
+    )
+
+    return (
+      <div
+        {...rootProps}
+        ref={ref}
+        className={classNames}
+        data-dim={dim}
+        data-with-action={action !== undefined}
+      >
+        <div role="status" className="charcoal-notification-content">
+          <div className="charcoal-notification-label">{message}</div>
+        </div>
+        {action !== undefined && <SnackbarAction action={action} />}
+      </div>
+    )
+  },
+)
+
+function SnackbarAction({ action }: { action: ReactNode }) {
+  return <div>{action}</div>
 }

--- a/packages/react/src/components/Notification/Snackbar/index.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.tsx
@@ -2,42 +2,28 @@ import '../layout.css'
 import './index.css'
 
 import { forwardRef, useImperativeHandle, useRef } from 'react'
-import type { ElementType, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { NotificationItem } from '../NotificationItem'
 import { NotificationRegion } from '../NotificationRegion'
 import { useNotificationQueue } from '../useNotificationQueue'
 import type { NotificationProps, Position } from '../types'
-import Button, { type ButtonProps } from '../../Button'
 
-type SnackbarButtonOption<T extends ElementType = 'button'> = Omit<
-  ButtonProps<T>,
-  'component' | 'className' | 'size'
-> & {
-  /**
-   * ボタンのルート要素として使用するコンポーネント。ページ遷移を伴う場合は `Link` を指定する
-   * @default 'button'
-   * @example 'Link'
-   */
-  component?: T
-} & ('button' extends T ? unknown : { component: T })
+export type SnackbarCloseReason =
+  'timeout' | 'replaced' | 'action' | 'close' | 'unmounted'
 
-export type SnackbarShowOptions<T extends ElementType = 'button'> = {
+export type ShowSnackbarOptions = {
   /**
-   * Snackbar を表示する時間（ミリ秒）。負の値は 0、数値でない値は 5000 として扱う
-   * @default 5000
+   * Snackbar の右側に表示するアクション
    */
-  duration?: number
+  action?: ReactNode
   /**
-   * Snackbar の右側に表示するボタン
+   * Snackbar が閉じるときに呼び出される
    */
-  button?: SnackbarButtonOption<T>
+  onClose?: (reason: SnackbarCloseReason) => void
 }
 
 export type SnackbarHandler = {
-  show: <T extends ElementType = 'button'>(
-    message: ReactNode,
-    options?: SnackbarShowOptions<T>,
-  ) => void
+  show: (message: ReactNode, options?: ShowSnackbarOptions) => void
 }
 
 export type SnackbarProps = Omit<NotificationProps, 'position'> & {
@@ -55,42 +41,40 @@ export type SnackbarProps = Omit<NotificationProps, 'position'> & {
 
 type SnackbarContent = {
   message: ReactNode
-  button?: SnackbarButtonContent
-}
-
-type SnackbarButtonContent = Omit<SnackbarButtonOption, 'component'> & {
-  component?: ElementType
+  action?: ReactNode
 }
 
 const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
-  { position = 'bottom', dim = false, ...regionProps },
+  { position = 'bottom', dim = false, duration, order, ...regionProps },
   ref,
 ) {
   'use memo'
 
-  const { state, itemRef, enqueue, onHoverStart, onHoverEnd, clearHover } =
-    useNotificationQueue<SnackbarContent>('snackbar')
+  const { state, itemRef, enqueue, close, onHoverStart, onHoverEnd } =
+    useNotificationQueue<SnackbarContent, SnackbarCloseReason>('snackbar', {
+      duration,
+      order,
+      timeoutReason: 'timeout',
+      unmountedReason: 'unmounted',
+    })
 
-  function show<T extends ElementType = 'button'>(
-    message: ReactNode,
-    options: SnackbarShowOptions<T> = {},
-  ) {
+  function show(message: ReactNode, options: ShowSnackbarOptions = {}) {
     enqueue(
       {
         message,
-        button: options.button as SnackbarButtonContent | undefined,
+        action: options.action,
       },
-      options.duration,
+      options.onClose,
     )
   }
 
   useImperativeHandle(ref, () => ({ show }))
 
-  // ボタン付きの Snackbar は常に下部に表示される
-  const hasButton = state.visibleToasts.some(
-    (toast) => toast.content.button !== undefined,
+  // アクション付きの Snackbar は常に下部に表示される
+  const hasAction = state.visibleToasts.some(
+    (toast) => toast.content.action !== undefined,
   )
-  const effectivePosition = hasButton ? 'bottom' : position
+  const effectivePosition = hasAction ? 'bottom' : position
 
   return (
     <NotificationRegion
@@ -109,16 +93,12 @@ const Snackbar = forwardRef<SnackbarHandler, SnackbarProps>(function Snackbar(
           onHoverStart={onHoverStart}
           onHoverEnd={onHoverEnd}
           data-dim={dim}
-          data-with-button={toast.content.button !== undefined}
+          data-with-action={toast.content.action !== undefined}
         >
-          {toast.content.button !== undefined && (
+          {toast.content.action !== undefined && (
             <SnackbarAction
-              button={toast.content.button}
-              dim={dim}
-              onClose={() => {
-                clearHover()
-                state.close(toast.key)
-              }}
+              action={toast.content.action}
+              onClick={() => close(toast.key, 'action')}
             />
           )}
         </NotificationItem>
@@ -134,52 +114,18 @@ export function useSnackbar(props: SnackbarProps = {}) {
 
   const snackbarHandlerRef = useRef<SnackbarHandler>(null)
   const element = <Snackbar ref={snackbarHandlerRef} {...props} />
-  function show<T extends ElementType = 'button'>(
-    message: ReactNode,
-    options?: SnackbarShowOptions<T>,
-  ) {
+  function show(message: ReactNode, options?: ShowSnackbarOptions) {
     snackbarHandlerRef.current?.show(message, options)
   }
   return [element, show] as const
 }
 
 function SnackbarAction({
-  button,
-  dim,
-  onClose,
+  action,
+  onClick,
 }: {
-  button: SnackbarButtonContent
-  dim: boolean
-  onClose: () => void
+  action: ReactNode
+  onClick: () => void
 }) {
-  const { onClick, variant, children: buttonChildren, ...buttonProps } = button
-
-  function handleButtonClick(
-    event: Parameters<NonNullable<ButtonProps<'button'>['onClick']>>[0],
-  ) {
-    onClick?.(event)
-    onClose()
-  }
-
-  return (
-    <PolymorphicButton
-      {...buttonProps}
-      size="S"
-      variant={variant ?? (dim ? 'Navigation' : undefined)}
-      onClick={handleButtonClick}
-    >
-      {buttonChildren}
-    </PolymorphicButton>
-  )
-}
-
-function PolymorphicButton({
-  component,
-  ...props
-}: Omit<ButtonProps, 'component'> & { component?: ElementType }) {
-  if (component === undefined || component === 'button') {
-    return <Button {...props} />
-  }
-
-  return <Button {...props} component={component} />
+  return <div onClick={onClick}>{action}</div>
 }

--- a/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
@@ -28,11 +28,11 @@
   animation: charcoal-toast-exit 0.3s ease-out both;
 }
 
-.charcoal-toast[data-variant='success'] {
+.charcoal-toast[data-type='success'] {
   background-color: var(--charcoal-color-container-positive-default);
 }
 
-.charcoal-toast[data-variant='error'] {
+.charcoal-toast[data-type='error'] {
   background-color: var(--charcoal-color-container-negative-default);
 }
 

--- a/packages/react/src/components/Notification/Toast/index.css
+++ b/packages/react/src/components/Notification/Toast/index.css
@@ -29,11 +29,11 @@
     animation: charcoal-toast-exit 0.3s ease-out both;
   }
 
-  &[data-variant='success'] {
+  &[data-type='success'] {
     background-color: var(--charcoal-color-container-positive-default);
   }
 
-  &[data-variant='error'] {
+  &[data-type='error'] {
     background-color: var(--charcoal-color-container-negative-default);
   }
 }

--- a/packages/react/src/components/Notification/Toast/index.story.tsx
+++ b/packages/react/src/components/Notification/Toast/index.story.tsx
@@ -15,7 +15,7 @@ type ToastStoryArgs = unstable_ToastProps & {
 }
 
 export default {
-  title: 'react/unstable_Toast',
+  title: 'react/Toast',
   component: unstable_Toast,
   parameters: {
     layout: 'centered',
@@ -33,33 +33,36 @@ export default {
   },
   args: {
     message: '保存しました',
+    position: 'top',
+    offset: 16,
     duration: 5000,
     order: 'queue',
+    zIndex: 20,
     type: 'success',
   },
   argTypes: {
     position: {
       options: ['top', 'bottom'],
       control: { type: 'inline-radio' },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: "'top'" } },
     },
     offset: {
       control: { type: 'number', min: 0, step: 1 },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '16' } },
     },
     duration: {
       control: { type: 'number', min: 0, step: 500 },
       description: '表示時間（ミリ秒）',
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '5000' } },
     },
     order: {
       options: ['queue', 'replace'],
       control: { type: 'inline-radio' },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: "'queue'" } },
     },
     zIndex: {
       control: { type: 'number', min: 0, step: 1 },
-      table: { category: 'Hook' },
+      table: { category: 'Hook', defaultValue: { summary: '20' } },
     },
     className: {
       control: 'text',

--- a/packages/react/src/components/Notification/Toast/index.story.tsx
+++ b/packages/react/src/components/Notification/Toast/index.story.tsx
@@ -4,15 +4,14 @@ import Button from '../../Button'
 import unstable_Toast, {
   useToast as unstable_useToast,
   type ToastProps as unstable_ToastProps,
-  type ToastShowOptions as unstable_ToastShowOptions,
+  type ShowToastOptions as unstable_ShowToastOptions,
 } from '.'
 
 const defaultOpen = !!process.env.TEST
 
 type ToastStoryArgs = unstable_ToastProps & {
   message: ReactNode
-  duration?: number
-  variant: unstable_ToastShowOptions['variant']
+  type: unstable_ShowToastOptions['type']
 }
 
 export default {
@@ -21,9 +20,12 @@ export default {
   parameters: {
     layout: 'centered',
     tokenVersion: 'v2',
+    controls: {
+      sort: 'requiredFirst',
+    },
     docs: {
       description: {
-        component: `同時に表示できるトーストは1つのみです。表示中に別のトーストが発生した場合はキューに積み、前のトーストが消えてから表示します。
+        component: `同時に表示できるトーストは1つのみです。表示中に別のトーストが発生した場合は、\`order\` に応じてキューに積むか、表示中のトーストを置き換えます。
 
 別々の \`useToast\` を呼び出した場合は互いに独立するため、同時表示数は1件に制限されません。`,
       },
@@ -32,33 +34,61 @@ export default {
   args: {
     message: '保存しました',
     duration: 5000,
-    variant: 'success',
+    order: 'queue',
+    type: 'success',
   },
   argTypes: {
     position: {
       options: ['top', 'bottom'],
       control: { type: 'inline-radio' },
+      table: { category: 'Hook' },
     },
-    variant: {
-      options: ['success', 'error'],
-      control: { type: 'inline-radio' },
-    },
-    message: {
-      control: 'text',
+    offset: {
+      control: { type: 'number', min: 0, step: 1 },
+      table: { category: 'Hook' },
     },
     duration: {
       control: { type: 'number', min: 0, step: 500 },
       description: '表示時間（ミリ秒）',
+      table: { category: 'Hook' },
+    },
+    order: {
+      options: ['queue', 'replace'],
+      control: { type: 'inline-radio' },
+      table: { category: 'Hook' },
+    },
+    zIndex: {
+      control: { type: 'number', min: 0, step: 1 },
+      table: { category: 'Hook' },
+    },
+    className: {
+      control: 'text',
+      table: { category: 'Hook' },
+    },
+    portalContainer: {
+      control: false,
+      table: { category: 'Hook' },
+    },
+    css: {
+      table: { disable: true },
+    },
+    type: {
+      options: ['success', 'error'],
+      control: { type: 'inline-radio' },
+      table: { category: 'Show' },
+    },
+    message: {
+      control: 'text',
+      table: { category: 'Show' },
     },
   },
   render: (args) => <ToastDemo {...args} />,
 } as Meta<ToastStoryArgs>
 
-function ToastDemo({ message, duration, variant, ...props }: ToastStoryArgs) {
+function ToastDemo({ message, type, ...props }: ToastStoryArgs) {
   const [toast, showToast] = unstable_useToast(props)
   const showOptions = {
-    duration,
-    variant,
+    type,
   }
 
   useEffect(() => {
@@ -66,10 +96,9 @@ function ToastDemo({ message, duration, variant, ...props }: ToastStoryArgs) {
       return
     }
     showToast(message, {
-      duration: 60_000,
-      variant,
+      type,
     })
-  }, [message, showToast, variant])
+  }, [message, showToast, type])
 
   return (
     <>
@@ -99,7 +128,7 @@ export function Example() {
     <>
       {toast}
       <Button
-        onClick={() => showToast('保存しました', { variant: 'success' })}
+        onClick={() => showToast('保存しました', { type: 'success' })}
       >
         保存
       </Button>
@@ -113,7 +142,7 @@ export function Example() {
 
 export const Error: StoryObj<ToastStoryArgs> = {
   args: {
-    variant: 'error',
+    type: 'error',
     message: '保存に失敗しました',
   },
 }

--- a/packages/react/src/components/Notification/Toast/index.test.tsx
+++ b/packages/react/src/components/Notification/Toast/index.test.tsx
@@ -43,7 +43,7 @@ describe('Toast', () => {
 
     expect(screen.queryByRole('region')).not.toBeInTheDocument()
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
 
     expect(screen.getByText('保存しました')).toBeInTheDocument()
 
@@ -62,9 +62,9 @@ describe('Toast', () => {
   })
 
   it.each([0, -1])('clamps duration to zero: %s', (duration) => {
-    const { show } = renderToast()
+    const { show } = renderToast({ duration })
 
-    show('保存しました', { variant: 'success', duration })
+    show('保存しました', { type: 'success' })
     expect(screen.getByText('保存しました')).toBeInTheDocument()
 
     act(() => {
@@ -84,9 +84,9 @@ describe('Toast', () => {
     Number.NEGATIVE_INFINITY,
     'invalid' as unknown as number,
   ])('falls back to the default duration: %s', (duration) => {
-    const { show } = renderToast()
+    const { show } = renderToast({ duration })
 
-    show('保存しました', { variant: 'success', duration })
+    show('保存しました', { type: 'success' })
     act(() => {
       vi.advanceTimersByTime(4999)
     })
@@ -103,8 +103,8 @@ describe('Toast', () => {
   it('queues the next toast until the previous one closes', async () => {
     const { show } = renderToast()
 
-    show('first', { variant: 'success' })
-    show('second', { variant: 'error' })
+    show('first', { type: 'success' })
+    show('second', { type: 'error' })
 
     expect(screen.getByText('first')).toBeInTheDocument()
     expect(screen.queryByText('second')).not.toBeInTheDocument()
@@ -120,13 +120,23 @@ describe('Toast', () => {
     expect(screen.getByText('second')).toBeInTheDocument()
     expect(
       screen.getByText('second').closest('.charcoal-toast'),
-    ).toHaveAttribute('data-variant', 'error')
+    ).toHaveAttribute('data-type', 'error')
+  })
+
+  it('replaces the current toast immediately when requested', () => {
+    const { show } = renderToast({ order: 'replace' })
+
+    show('first', { type: 'success' })
+    show('second', { type: 'error' })
+
+    expect(screen.queryByText('first')).not.toBeInTheDocument()
+    expect(screen.getByText('second')).toBeInTheDocument()
   })
 
   it('keeps the toast open while hovered after the timer ends, then closes on leave', () => {
     const { show } = renderToast()
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
     const toast = screen.getByText('保存しました').closest('.charcoal-toast')
     if (toast === null) throw new Error('Toast not found')
 
@@ -143,7 +153,7 @@ describe('Toast', () => {
   it('keeps the toast open while focused', () => {
     const { show } = renderToast()
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
     const toast = screen.getByText('保存しました').closest('.charcoal-toast')
     if (toast === null) throw new Error('Toast not found')
 
@@ -165,7 +175,7 @@ describe('Toast', () => {
   it('places a toast at the top by default', () => {
     const { show } = renderToast()
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
 
     expect(screen.getByRole('region')).toHaveAttribute('data-position', 'top')
   })
@@ -173,7 +183,7 @@ describe('Toast', () => {
   it('places a toast at the bottom when requested', () => {
     const { show } = renderToast({ position: 'bottom' })
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
 
     expect(screen.getByRole('region')).toHaveAttribute(
       'data-position',
@@ -181,25 +191,22 @@ describe('Toast', () => {
     )
   })
 
-  it.each(['success', 'error'] as const)(
-    'applies the %s variant',
-    (variant) => {
-      const { show } = renderToast()
+  it.each(['success', 'error'] as const)('applies the %s type', (type) => {
+    const { show } = renderToast()
 
-      show('保存しました', { variant })
+    show('保存しました', { type })
 
-      expect(
-        screen.getByText('保存しました').closest('.charcoal-toast'),
-      ).toHaveAttribute('data-variant', variant)
-    },
-  )
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-toast'),
+    ).toHaveAttribute('data-type', type)
+  })
 
   it('supports a custom z-index and portal container', () => {
     const portalContainer = document.createElement('div')
     document.body.append(portalContainer)
     const { show } = renderToast({ zIndex: 30, portalContainer })
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
 
     expect(portalContainer).toContainElement(screen.getByRole('region'))
     expect(screen.getByRole('region')).toHaveStyle({ zIndex: 30 })
@@ -210,7 +217,7 @@ describe('Toast', () => {
   it('moves focus to the toast region with F6', () => {
     const { show } = renderToast()
 
-    show('保存しました', { variant: 'success' })
+    show('保存しました', { type: 'success' })
 
     fireEvent.keyDown(document, { key: 'F6' })
 
@@ -239,7 +246,7 @@ describe('useToast', () => {
           <button
             type="button"
             onClick={() => {
-              showResult = show('hook message', { variant: 'success' })
+              showResult = show('hook message', { type: 'success' })
             }}
           >
             open

--- a/packages/react/src/components/Notification/Toast/index.tsx
+++ b/packages/react/src/components/Notification/Toast/index.tsx
@@ -8,19 +8,14 @@ import { NotificationRegion } from '../NotificationRegion'
 import { useNotificationQueue } from '../useNotificationQueue'
 import type { NotificationProps, Position } from '../types'
 
-export type ToastVariant = 'success' | 'error'
+export type ToastType = 'success' | 'error'
 
-export type ToastShowOptions = {
-  variant: ToastVariant
-  /**
-   * Toast を表示する時間（ミリ秒）。負の値は 0、数値でない値は 5000 として扱う
-   * @default 5000
-   */
-  duration?: number
+export type ShowToastOptions = {
+  type: ToastType
 }
 
 export type ToastHandler = {
-  show: (message: ReactNode, options: ToastShowOptions) => void
+  show: (message: ReactNode, options: ShowToastOptions) => void
 }
 
 export type ToastProps = Omit<NotificationProps, 'position'> & {
@@ -33,26 +28,23 @@ export type ToastProps = Omit<NotificationProps, 'position'> & {
 
 type ToastContent = {
   message: ReactNode
-  variant: ToastVariant
+  type: ToastType
 }
 
 const Toast = forwardRef<ToastHandler, ToastProps>(function Toast(
-  { position = 'top', ...regionProps },
+  { position = 'top', duration, order, ...regionProps },
   ref,
 ) {
   'use memo'
 
   const { state, itemRef, enqueue, onHoverStart, onHoverEnd } =
-    useNotificationQueue<ToastContent>('toast')
+    useNotificationQueue<ToastContent>('toast', { duration, order })
 
-  function show(message: ReactNode, options: ToastShowOptions) {
-    enqueue(
-      {
-        message,
-        variant: options.variant,
-      },
-      options.duration,
-    )
+  function show(message: ReactNode, options: ShowToastOptions) {
+    enqueue({
+      message,
+      type: options.type,
+    })
   }
 
   useImperativeHandle(ref, () => ({ show }))
@@ -73,7 +65,7 @@ const Toast = forwardRef<ToastHandler, ToastProps>(function Toast(
           itemRef={itemRef}
           onHoverStart={onHoverStart}
           onHoverEnd={onHoverEnd}
-          data-variant={toast.content.variant}
+          data-type={toast.content.type}
         />
       ))}
     </NotificationRegion>
@@ -87,7 +79,7 @@ export function useToast(props: ToastProps = {}) {
 
   const toastHandlerRef = useRef<ToastHandler>(null)
   const element = <Toast ref={toastHandlerRef} {...props} />
-  function show(message: ReactNode, options: ToastShowOptions) {
+  function show(message: ReactNode, options: ShowToastOptions) {
     toastHandlerRef.current?.show(message, options)
   }
   return [element, show] as const

--- a/packages/react/src/components/Notification/types.ts
+++ b/packages/react/src/components/Notification/types.ts
@@ -1,13 +1,27 @@
 export type NotificationName = 'snackbar' | 'toast'
 export type Position = 'top' | 'bottom'
+export type NotificationOrder = 'queue' | 'replace'
 
-export type NotificationProps = {
+export type UseNotificationOptions = {
   position?: Position
   /**
    * 画面端からの距離（ピクセル）
    * @default 16
    */
   offset?: number
+  /**
+   * 通知を表示する時間（ミリ秒）。負の値は 0、数値でない値は 5000 として扱う
+   * @default 5000
+   */
+  duration?: number
+  /**
+   * 表示中の通知がある場合の次の通知の表示方法
+   * @default 'queue'
+   */
+  order?: NotificationOrder
+}
+
+export type NotificationProps = UseNotificationOptions & {
   zIndex?: number
   portalContainer?: HTMLElement
   className?: string

--- a/packages/react/src/components/Notification/useNotificationQueue.ts
+++ b/packages/react/src/components/Notification/useNotificationQueue.ts
@@ -1,14 +1,44 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { useToastState } from 'react-stately/useToastState'
-import type { NotificationName } from './types'
+import type { NotificationName, NotificationOrder } from './types'
 
 const DEFAULT_DURATION_MS = 5000
 const ANIMATION_DURATION_MS = 300
 
-export function useNotificationQueue<TContent>(name: NotificationName) {
+type QueueItem<TContent, TCloseReason> = {
+  content: TContent
+  onClose?: (reason: TCloseReason) => void
+}
+
+export function useNotificationQueue<
+  TContent,
+  TCloseReason extends string = never,
+>(
+  name: NotificationName,
+  {
+    duration: durationOption,
+    order = 'queue',
+    timeoutReason,
+    unmountedReason,
+  }: {
+    duration?: number
+    order?: NotificationOrder
+    timeoutReason?: TCloseReason
+    unmountedReason?: TCloseReason
+  } = {},
+) {
   const itemRef = useRef<HTMLDivElement>(null)
-  const queueRef = useRef<Array<TContent & { duration: number }>>([])
+  const queueRef = useRef<
+    Array<QueueItem<TContent, TCloseReason> & { duration: number }>
+  >([])
   const isShowingRef = useRef(false)
+  const activeRef = useRef<{
+    key: string
+    onClose?: (reason: TCloseReason) => void
+    reason?: TCloseReason
+    notified: boolean
+  }>()
+  const replaceRef = useRef(false)
   const hoverRef = useRef({
     active: false,
     pending: undefined as (() => void) | undefined,
@@ -27,10 +57,23 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
         return
       }
 
+      function notifyActive() {
+        const active = activeRef.current
+        if (active === undefined || active.notified) return
+        active.notified = true
+        const reason = active.reason ?? timeoutReason
+        if (reason !== undefined) {
+          active.onClose?.(reason)
+        }
+      }
+
       function finish() {
+        activeRef.current = undefined
         update()
         playNextRef.current?.()
       }
+
+      notifyActive()
 
       if (hoverRef.current.active) {
         hoverRef.current.pending = () => wrapUpdate(update, 'remove')
@@ -38,6 +81,12 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
       }
 
       if (itemRef.current === null) {
+        finish()
+        return
+      }
+
+      if (replaceRef.current) {
+        replaceRef.current = false
         finish()
         return
       }
@@ -68,7 +117,7 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
         complete()
       }
     },
-    [name],
+    [name, timeoutReason],
   )
 
   const state = useToastState<TContent>({
@@ -78,10 +127,17 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
 
   useEffect(() => {
     return () => {
+      const active = activeRef.current
+      if (active !== undefined && !active.notified) {
+        if (unmountedReason !== undefined) {
+          active.onClose?.(unmountedReason)
+        }
+      }
+      activeRef.current = undefined
       queueRef.current = []
       isShowingRef.current = false
     }
-  }, [])
+  }, [unmountedReason])
 
   function playNext() {
     const next = queueRef.current.shift()
@@ -90,22 +146,23 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
       return
     }
 
-    const { duration, ...content } = next
+    const { duration, onClose, content } = next
     isShowingRef.current = true
     const enterMs = window.matchMedia?.('(prefers-reduced-motion: reduce)')
       .matches
       ? 0
       : ANIMATION_DURATION_MS
-    state.add(content as TContent, {
+    const key = state.add(content, {
       // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
       timeout: Math.max(1, duration + enterMs),
     })
+    activeRef.current = { key, onClose, notified: false }
   }
   playNextRef.current = playNext
 
   function enqueue(
     content: TContent,
-    durationOption: unknown = DEFAULT_DURATION_MS,
+    onClose?: (reason: TCloseReason) => void,
   ) {
     const duration =
       typeof durationOption === 'number' && Number.isFinite(durationOption)
@@ -113,11 +170,40 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
         : DEFAULT_DURATION_MS
 
     queueRef.current.push({
-      ...content,
+      content,
+      onClose,
       duration,
     })
     if (!isShowingRef.current) {
       playNext()
+    } else if (order === 'replace') {
+      const active = activeRef.current
+      if (active === undefined) return
+
+      active.reason = 'replaced' as TCloseReason
+      replaceRef.current = true
+      hoverRef.current.active = false
+      const pending = hoverRef.current.pending
+      hoverRef.current.pending = undefined
+      if (pending !== undefined) {
+        pending()
+      } else {
+        state.close(active.key)
+      }
+    }
+  }
+
+  function close(key: string, reason: TCloseReason) {
+    const active = activeRef.current
+    if (active?.key !== key) return
+    active.reason = reason
+    hoverRef.current.active = false
+    const pending = hoverRef.current.pending
+    hoverRef.current.pending = undefined
+    if (pending !== undefined) {
+      pending()
+    } else {
+      state.close(key)
     }
   }
 
@@ -141,6 +227,7 @@ export function useNotificationQueue<TContent>(name: NotificationName) {
     state,
     itemRef,
     enqueue,
+    close,
     onHoverStart,
     onHoverEnd,
     clearHover,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -107,10 +107,10 @@ export {
   type ScrollStepContext,
 } from './components/Carousel'
 export {
-  default as unstable_Snackbar,
+  default as UnstableSnackbar,
   useSnackbar as unstable_useSnackbar,
-  type SnackbarProps as unstable_SnackbarProps,
-  type SnackbarHandler as unstable_SnackbarHandler,
+  type SnackbarProps as UnstableSnackbarProps,
+  type UseSnackbarProps as unstable_UseSnackbarProps,
   type SnackbarCloseReason as unstable_SnackbarCloseReason,
   type ShowSnackbarOptions as unstable_ShowSnackbarOptions,
 } from './components/Notification/Snackbar'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -111,13 +111,18 @@ export {
   useSnackbar as unstable_useSnackbar,
   type SnackbarProps as unstable_SnackbarProps,
   type SnackbarHandler as unstable_SnackbarHandler,
-  type SnackbarShowOptions as unstable_SnackbarShowOptions,
+  type SnackbarCloseReason as unstable_SnackbarCloseReason,
+  type ShowSnackbarOptions as unstable_ShowSnackbarOptions,
 } from './components/Notification/Snackbar'
 export {
   default as unstable_Toast,
   useToast as unstable_useToast,
   type ToastProps as unstable_ToastProps,
   type ToastHandler as unstable_ToastHandler,
-  type ToastShowOptions as unstable_ToastShowOptions,
+  type ShowToastOptions as unstable_ShowToastOptions,
 } from './components/Notification/Toast'
+export {
+  type NotificationOrder as unstable_NotificationOrder,
+  type UseNotificationOptions as unstable_UseNotificationOptions,
+} from './components/Notification/types'
 import './components/FocusRing/index.css'

--- a/packages/theme/src/css/v1/remap.css
+++ b/packages/theme/src/css/v1/remap.css
@@ -1,5 +1,7 @@
 :root {
+  --charcoal-radius-oval: 999999px;
   /* 互換レイヤー: focus幅の実値 */
+  --charcoal-border-width-m: 1px;
   --charcoal-border-width-focus-2: 4px;
   --charcoal-border-width-focus-1: 0px;
   /* 互換レイヤー: typography aliasから参照するv1 textプリミティブ */
@@ -39,8 +41,12 @@
   --charcoal-space-104: 104px;
   --charcoal-space-64: 64px;
   /* 互換レイヤー: スペーシングの上書き */
+  --charcoal-space-46: 32px;
   --charcoal-space-40: 40px;
+  --charcoal-space-30: 16px;
+  --charcoal-space-25: 12px;
   --charcoal-space-24: 24px;
+  --charcoal-space-20: 8px;
   --charcoal-space-16: 16px;
   --charcoal-space-8: 8px;
   --charcoal-space-4: 4px;


### PR DESCRIPTION
## 概要
- SnackbarとToastに、表示順を制御する queue / replace を追加
- Snackbarに、閉じる理由を受け取る onClose と action を追加
- NotificationのオプションとStorybookのControlsを整理

## 確認
- pnpm lint
- pnpm test --run