### PR TITLE
fix(react): 未使用のランタイム依存を削除

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     "test:browser": "vitest run --config vitest.browser.config.ts"
   },
   "devDependencies": {
+    "@charcoal-ui/theme": "workspace:*",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/user-event": "catalog:",
@@ -47,11 +48,7 @@
     "react-stately": "catalog:"
   },
   "dependencies": {
-    "@charcoal-ui/foundation": "workspace:*",
     "@charcoal-ui/icons": "workspace:*",
-    "@charcoal-ui/theme": "workspace:*",
-    "@charcoal-ui/utils": "workspace:*",
-    "polished": "^4.1.4",
     "react-compiler-runtime": "catalog:",
     "warning": "^4.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,21 +362,9 @@ importers:
 
   packages/react:
     dependencies:
-      '@charcoal-ui/foundation':
-        specifier: workspace:*
-        version: link:../foundation
       '@charcoal-ui/icons':
         specifier: workspace:*
         version: link:../icons
-      '@charcoal-ui/theme':
-        specifier: workspace:*
-        version: link:../theme
-      '@charcoal-ui/utils':
-        specifier: workspace:*
-        version: link:../utils
-      polished:
-        specifier: ^4.1.4
-        version: 4.3.1
       react-compiler-runtime:
         specifier: 'catalog:'
         version: 1.0.0(react@18.3.1)
@@ -384,6 +372,9 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
     devDependencies:
+      '@charcoal-ui/theme':
+        specifier: workspace:*
+        version: link:../theme
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1


### PR DESCRIPTION
close #1015

## 概要
- 未使用のランタイム依存（polished、@charcoal-ui/foundation、@charcoal-ui/utils）を削除
- @charcoal-ui/theme を開発依存へ移動
- @charcoal-ui/icons を含む、React パッケージが実行時に必要とする依存は維持

## 確認
- React パッケージの型検査とビルド
- ユニットテスト（45ファイル・1,462テスト）
- ブラウザテスト（3ファイル・43テスト）
- クリーンな upstream/main worktree と React パッケージ tarball のファイル一覧を比較

## 互換性
minor 扱いの変更です。@charcoal-ui/react 経由で hoist された依存を、宣言せずに直接 import している利用者は、必要な依存を自身で宣言する必要があります。