### PR TITLE
fix(react): remove unused rdfaPrefix prop

### DIFF
--- a/packages/react/src/components/TextField/index.tsx
+++ b/packages/react/src/components/TextField/index.tsx
@@ -26,7 +26,6 @@ export type TextFieldProps = {
   requiredText?: string
   disabled?: boolean
   subLabel?: React.ReactNode
-  rdfaPrefix?: string
 
   getCount?: (value: string) => number
 } & Omit<React.ComponentPropsWithoutRef<'input'>, 'prefix' | 'onChange'>


### PR DESCRIPTION
## やったこと

- `TextFieldProps` から、どのプロダクトでも使用されていない `rdfaPrefix` を削除
- `rdfaPrefix` は実装上 HTML の `prefix` 属性へ変換されておらず、ランタイムの挙動に変更がないことを確認

## 動作確認環境

- `./node_modules/.bin/tsc --project packages/react/tsconfig.build.json --pretty --noEmit`
- `./node_modules/.bin/vitest run packages/react/src/components/TextField/text-field.test.tsx`（12 tests passed）