### PR TITLE
fix: exclude storybook config from docgen

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -28,6 +28,9 @@ const generalConfig: Omit<ViteStorybookConfig, 'framework'> = {
   staticDirs: ['./static'],
   typescript: {
     reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      exclude: ['**/*.stories.tsx', '**/.storybook/**'],
+    },
   },
   managerHead: (head) => `${head}
       <title>Charcoal ドキュメント</title>


### PR DESCRIPTION
## やったこと

- Storybookのdocgen対象から .storybook 配下を除外
  - `.storybook` 配下はTypeScriptプロジェクトの対象外であり、Storybook表示時にdocgenのスキップ警告が発生していた
  - これらはStorybook用の補助コンポーネントでPropsドキュメントの生成も不要なため、docgen対象外とした

## 動作確認環境
ローカル

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
