### PR TITLE
fix: resolve storybook tailwind css warnings

### DIFF
--- a/.storybook/tailwind.config.mjs
+++ b/.storybook/tailwind.config.mjs
@@ -5,9 +5,10 @@ import { createTailwindConfig } from '@charcoal-ui/tailwind-config'
  * @type {import('tailwindcss').Config}
  */
 export default {
-  darkMode: false,
   content: [
-    '**/*.tsx',
+    './.storybook/**/*.tsx',
+    './packages/**/*.tsx',
+    '!./packages/**/node_modules/**',
     /* pluginで生成されるクラス名をチェックしたい */
     'packages/tailwind-config/src/__snapshots__/iconsV2.test.ts.snap',
   ],


### PR DESCRIPTION
## やったこと

- 非推奨の `darkMode: false` を削除
  - `darkMode: false` は現在 `media` と同じ動作になっており、不要な警告が発生していたため
- Tailwind CSSのスキャン対象を `.storybook` と `packages` に限定
- 各packageの `node_modules` をスキャン対象から除外
  - `**/*.tsx` がリポジトリ内の `node_modules` まで走査していたため、Storybookの起動や再ビルドに余計な負荷がかかる可能性があったため

## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
