### PR TITLE
docs: スタイリングの選び方と導入用 agent skills を追加する

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,34 @@
+{
+  "name": "charcoal",
+  "owner": {
+    "name": "pixiv",
+    "url": "https://github.com/pixiv/charcoal"
+  },
+  "metadata": {
+    "description": "Agent skills for adopting the pixiv charcoal design system (@charcoal-ui)",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "charcoal",
+      "source": "./",
+      "description": "Set up @charcoal-ui in an app and choose between CSS variables, Tailwind, and styled-components. Covers Design Token 2.0 opt-in, theme switching, and the gotchas that silently produce an unstyled or Token 1.0 app.",
+      "version": "0.1.0",
+      "author": {
+        "name": "pixiv"
+      },
+      "license": "Apache-2.0",
+      "keywords": [
+        "charcoal",
+        "pixiv",
+        "design-system",
+        "design-tokens",
+        "css-variables",
+        "tailwind",
+        "styled-components",
+        "react"
+      ],
+      "category": "web-development"
+    }
+  ]
+}

--- a/.storybook/src/styling-guide.mdx
+++ b/.storybook/src/styling-guide.mdx
@@ -1,0 +1,102 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Styling Guide" />
+
+# スタイリングの選び方
+
+charcoal は同じデザイントークンを 3 通りの方法で使えるようにしています。このページは**なぜそうなっているか**を説明します。実際の手順は各パッケージのクイックスタート、またはエージェント向けの [skills](https://github.com/pixiv/charcoal/tree/main/skills) を参照してください。
+
+## 三層構造
+
+charcoal の設計思想は「定数」「ユーティリティ」「コンポーネント」の三層です。
+
+| 層                 | 中身                                                              | パッケージ                                                          | 選択の余地           |
+| ------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------- |
+| 定数               | デザイントークン                                                  | `@charcoal-ui/foundation` `@charcoal-ui/theme`                      | なし。全員これを使う |
+| **ユーティリティ** | 定数を CSS の表現に落とし込み、マークアップに使えるようにしたもの | `@charcoal-ui/tailwind-config` `@charcoal-ui/styled` または素の CSS | **ここだけ**         |
+| コンポーネント     | 見た目と挙動が一体の UI 部品                                      | `@charcoal-ui/react` `@charcoal-ui/icons`                           | なし                 |
+
+**利用者が選ぶのは真ん中の 1 層だけ**です。ここを押さえておかないと、次の 2 つが混ざります。
+
+- **「styled から pure CSS へ」** — コンポーネント層の内部実装が変わった話です。v4 で `@charcoal-ui/react` が styled-components への依存を捨てました。利用者に選択権はありません。
+- **「styled と Tailwind のどちらか」** — ユーティリティ層で利用者が選ぶ話です。自分のアプリのマークアップをどう書くか、という別の問題です。
+
+`@charcoal-ui/react` のコンポーネントを使うことと、styled-components や Tailwind を使うことは独立しています。「Tailwind を使っているのに `@charcoal-ui/styled` も要るのか」という疑問が出たら、この 2 つが混ざっています。答えは要りません。
+
+## 3 つの経路
+
+### CSS Variables を直接使う
+
+`@charcoal-ui/theme` が配布する静的 CSS を読み込み、`var(--charcoal-color-*)` を書きます。追加の依存がなく、素の CSS でも CSS Modules でも vanilla-extract でも同じように使えます。**新規に導入するならこれが既定**です。
+
+### Tailwind
+
+`@charcoal-ui/tailwind-config` が preset を提供します。Design Token 2.0 の新機能はまずここに入るため、**現在もっとも活発に開発されている経路**です。
+
+Tailwind 標準の `dark:` バリアントはサポートしません。charcoal のトークンは light と dark で**同じ名前のまま値が変わる**設計なので、`dark:bg-background1` という書き方が成立しないためです。代わりに preset へテーマのマップを渡し、CSS Variables の値そのものを切り替えます。
+
+### styled-components
+
+`@charcoal-ui/styled` は、すでに styled-components で書かれたコードベースのために存在します。
+
+**Design Token 2.0 には対応していません。** パッケージ全体が非推奨というわけではなく（`@deprecated` が付いているのは `createTheme` だけです）、新機能が入らないまま Token 1.0 に留まっている、という状態です。新規採用は避け、既存資産がある場合の着地点として使ってください。
+
+## Design Token 2.0 はオプトイン
+
+v6 のコンポーネントは Design Token 2.0 の CSS Variables を参照します。ただし **2.0 は既定では有効になりません。**
+
+```html
+<html lang="ja" class="ch-token-v2">
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+`css/v2/light.css` のセレクタは次の形です。
+
+```css
+:root.ch-token-v2[data-theme='light'],
+:root.ch-token-v2:not([data-theme]),
+:root[data-theme='light'] .ch-token-v2,
+:root:not([data-theme]) .ch-token-v2 {
+  --charcoal-color-…: …;
+}
+```
+
+`.ch-token-v2` がどこにも無いと、light 側の規則は 1 つもマッチせず、トークンは未定義のままになります。エラーも警告も出ません。CSS Variables は継承で効くので、クラスは対象コンポーネント自身かその祖先に付けてください。
+
+dark だけは `:root[data-theme='dark']` に定義されており、`.ch-token-v2` の有無に関係なくページ全体へ効きます。段階移行のために light 側だけをスコープした結果の非対称です。
+
+Tailwind 経路も例外ではありません。preset は `var(--charcoal-color-*)` を**参照する**クラスを生成するだけで、変数自体は定義しないためです。
+
+## v1 互換レイヤー
+
+既存画面の見た目を保ったまま v6 へ上げる場合は、2.0 の代わりに互換レイヤーを読み込みます。
+
+```tsx
+import '@charcoal-ui/theme/css/v1/remap.css'
+```
+
+2.0 のトークン名を v1 相当の値へ解決します。ただし 2.0 では複数の v1 トークンが 1 つの semantic token に統合されているため、単一の remap 値から複数の旧値を同時に再現できません。Button・Checkbox・Radio・Switch のテキスト色など、いくつかの箇所では v5 と完全に同じ配色になりません。
+
+## カスケードと優先度
+
+`@charcoal-ui/react` は CSS を 2 通りの形で配布します。
+
+|          | `dist/index.css`                   | `dist/layered.css`                                   |
+| -------- | ---------------------------------- | ---------------------------------------------------- |
+| 優先度   | 通常のカスケード（詳細度勝負）     | `@layer charcoal` に入る＝レイヤー無指定より必ず弱い |
+| 上書き   | セレクタの詳細度を上げる必要がある | そのまま上書きできる                                 |
+| 対応環境 | 広い                               | iOS 15.4+                                            |
+
+v4 で styled-components をやめた副作用として、`styled(Button)` による上書きの優先度が変わる場合があります。レイヤー無指定のスタイル（styled-components の生成 CSS も Tailwind のユーティリティも）は必ずレイヤー付きより強いため、`layered.css` に切り替えると上書きが詳細度に依存せず安定します。
+
+## 次に読むもの
+
+- [`@charcoal-ui/react` クイックスタート](/docs/react-readme--docs)
+- [`@charcoal-ui/tailwind-config` クイックスタート](/docs/tailwind-config-readme--docs)
+- [`@charcoal-ui/styled` クイックスタート](/docs/styled-readme--docs)
+- [v6.0.0 移行ガイド](/docs/v6-0-0--docs)
+
+コーディングエージェントに手順を渡したい場合は、リポジトリの [`skills/`](https://github.com/pixiv/charcoal/tree/main/skills) をインストールしてください。Claude Code のプラグインとしても `npx skills` 経由でも入ります。

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,83 @@
+# charcoal agent skills
+
+Skills that teach coding agents how to adopt `@charcoal-ui` in an application.
+
+| Skill                               | Use it for                                                      |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `choosing-charcoal-styling`         | Deciding between CSS variables, Tailwind, and styled-components |
+| `setting-up-charcoal-css-variables` | Plain CSS, CSS Modules, vanilla-extract — the default route     |
+| `setting-up-charcoal-tailwind`      | Adding the Tailwind preset                                      |
+| `setting-up-charcoal-styled`        | Existing styled-components codebases, and migrating off them    |
+
+They exist because charcoal's own documentation is not machine-readable: the docs site is a Storybook SPA that returns no content to a fetcher, npm package pages return 403, and the `pages/` docsify site has been stale since 2023. Agents that try to look charcoal up on the web reconstruct it from package internals — slowly — or invent it.
+
+## Install for Claude Code
+
+As a plugin, from this repository:
+
+```
+/plugin marketplace add pixiv/charcoal
+/plugin install charcoal@charcoal
+```
+
+## Install for Codex, Cursor, and others
+
+[`npx skills`](https://github.com/vercel-labs/skills) reads the same files and installs them for any supported agent.
+
+```bash
+# pick agents interactively
+npx skills add pixiv/charcoal
+
+# Codex, in this project
+npx skills add pixiv/charcoal -a codex
+
+# Codex, for every project on this machine
+npx skills add pixiv/charcoal -a codex --global
+
+# just one skill
+npx skills add pixiv/charcoal -s choosing-charcoal-styling -a codex
+```
+
+Where the files land:
+
+| Agent       | `-a` value    | Project           | `--global`                   |
+| ----------- | ------------- | ----------------- | ---------------------------- |
+| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/`          |
+| Codex       | `codex`       | `.agents/skills/` | `~/.codex/skills/`           |
+| Cursor      | `cursor`      | `.agents/skills/` | `~/.cursor/skills/`          |
+| OpenCode    | `opencode`    | `.agents/skills/` | `~/.config/opencode/skills/` |
+
+Other commands: `npx skills list`, `npx skills update`, `npx skills remove`, and `npx skills use pixiv/charcoal` to print the guidance without installing.
+
+## Verify
+
+```bash
+npx skills list
+```
+
+Then ask the agent something the skills cover — "charcoal のボタンに色が当たらない" should get you `.ch-token-v2`, not a Tailwind setup.
+
+## If a skill does not show up
+
+- **Wrong directory.** Older releases of the CLI wrote to `~/.agents/skills/` while Claude Code reads only `~/.claude/skills/`. Use `-a claude-code`, or move the directory. Codex, Copilot CLI, and Gemini CLI do read `~/.agents/skills/`.
+- **Stale CLI.** Skill discovery needs 1.5.16 or newer. Run `npx skills@latest add pixiv/charcoal`.
+- **Restart the agent.** Skills are read at startup.
+
+## Layout
+
+```
+charcoal/
+├── .claude-plugin/
+│   └── marketplace.json   # Claude Code plugin entry
+└── skills/
+    ├── choosing-charcoal-styling/SKILL.md
+    ├── setting-up-charcoal-css-variables/SKILL.md
+    ├── setting-up-charcoal-tailwind/SKILL.md
+    └── setting-up-charcoal-styled/SKILL.md
+```
+
+Both installers read the same `skills/` directory — `npx skills` scans it directly, and also honours the `.claude-plugin/` manifest. There is one copy of every fact.
+
+## Editing
+
+Skills are written against real failures, not from memory. Before changing one, run the scenario it covers against an agent that does _not_ have the skill, record what it actually gets wrong, and write only what closes that gap. `superpowers:writing-skills` describes the loop.

--- a/skills/choosing-charcoal-styling/SKILL.md
+++ b/skills/choosing-charcoal-styling/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: choosing-charcoal-styling
+description: Use when adding pixiv's charcoal design system (@charcoal-ui) to an app, when deciding between CSS variables, Tailwind, and styled-components with it, or when charcoal components render with no colors, transparent backgrounds, or unresolved --charcoal-* variables.
+---
+
+# Choosing a charcoal styling approach
+
+`@charcoal-ui` is pixiv's design system. It ships tokens once and lets you consume them three different ways. Picking the wrong one — or picking right but skipping the opt-in — is the main source of failure.
+
+## The official docs are not readable by agents
+
+Do not try to look this up on the web first.
+
+- `https://charcoal-web.pixiv.design/` is a Storybook SPA. Fetching it returns a title and no content.
+- The npm package pages return 403.
+- `pages/` in the GitHub repo is a docsify site last updated 2023-03-22. It predates v4 and v6. **Its instructions are wrong** — it tells you `@charcoal-ui/react` needs a styled-components `ThemeProvider`, which stopped being true in v4.
+
+Trust this skill and the package contents (`node_modules/@charcoal-ui/*`, or jsDelivr/unpkg) over search results.
+
+## Three layers, one choice
+
+| Layer         | What it is                        | Packages                                                            | Your choice?                   |
+| ------------- | --------------------------------- | ------------------------------------------------------------------- | ------------------------------ |
+| Constants     | Design tokens                     | `@charcoal-ui/foundation`, `@charcoal-ui/theme`                     | No — everyone uses these       |
+| **Utilities** | Turning tokens into CSS you write | `@charcoal-ui/tailwind-config`, `@charcoal-ui/styled`, or plain CSS | **Yes — here only**            |
+| Components    | Prebuilt UI (Button, Modal…)      | `@charcoal-ui/react`                                                | No — plain CSS, no alternative |
+
+Two things people confuse:
+
+- **"styled → pure CSS"** describes the _component layer's internals_. v4 removed styled-components from `@charcoal-ui/react`. You get no say in it.
+- **"styled vs Tailwind"** is the _utility layer_ choice — how you style your own markup.
+
+Using `@charcoal-ui/react` does not require styled-components or Tailwind. They are unrelated decisions.
+
+## Pick the utility
+
+```
+Do you use @charcoal-ui/react components?
+  → Yes: install it and load the token CSS. No styling library needed.
+  → Either way, continue below for your own markup.
+
+How do you want to style your own markup?
+  ├─ Tailwind already in the project  → setting-up-charcoal-tailwind
+  ├─ Large existing styled-components codebase → setting-up-charcoal-styled
+  └─ Anything else (plain CSS, CSS Modules, vanilla-extract)
+                                       → setting-up-charcoal-css-variables
+```
+
+Default to `setting-up-charcoal-css-variables`. It has no extra dependency and works with any stack.
+
+## Design Token 2.0 is opt-in, and the default is silent
+
+This is the single most common failure. Every route has an opt-in flag, and every route silently gives you the old generation — or nothing at all — if you skip it.
+
+| Route             | Opt-in                                                                                                         | Skip it and you get                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| CSS variables     | Load `@charcoal-ui/theme/css/v2/{light,dark}.css` **and** put `class="ch-token-v2"` on `<html>` or an ancestor | **No tokens at all** — components render with no color |
+| Tailwind          | `unstableTokenV2: true` **plus** the same two steps above                                                      | Design Token 1.0                                       |
+| styled-components | not available                                                                                                  | Design Token 1.0 only — the package has no v2 support  |
+
+No error, no warning. The page just looks wrong.
+
+`.ch-token-v2` is not a CSS-variables-route detail. It gates the v2 variables themselves, so **every route that wants Design Token 2.0 needs it** — the Tailwind preset emits `var(--charcoal-color-*)` references but never defines them.
+
+## Is @charcoal-ui/styled deprecated?
+
+Not formally — only `createTheme` carries `@deprecated`. But the package has **no Design Token 2.0 support** and receives no new features, while `@charcoal-ui/tailwind-config` keeps getting them. Treat it as a dead end you migrate off, not as a forbidden API.
+
+Packages that _are_ formally deprecated: `@charcoal-ui/react-sandbox` (removal planned) and `@charcoal-ui/tailwind-diff` (announced as 廃止予定).
+
+## Common mistakes
+
+| Mistake                                                   | Reality                                                                                                                           |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Loading only `@charcoal-ui/react/dist/index.css`          | That file uses `var(--charcoal-color-*)` but never defines them. You must also load `@charcoal-ui/theme/css/v2/{light,dark}.css`. |
+| Reading light.css's selector as `:root:not([data-theme])` | The real selector is `:root:not([data-theme]) .ch-token-v2`. Drop `.ch-token-v2` and nothing matches.                             |
+| Prescribing Tailwind to fix missing colors                | Colors are not built by Tailwind. Static CSS ships in `@charcoal-ui/theme`.                                                       |
+| Wrapping the app in `ThemeProvider` for `<Button>`        | `Button` imports its own CSS and needs no provider. Only overlays (Modal, DropdownSelector) need `CharcoalProvider`.              |
+| Assuming v6 does not exist                                | It does. Search summaries lag; check `registry.npmjs.org/@charcoal-ui/react`.                                                     |

--- a/skills/setting-up-charcoal-css-variables/SKILL.md
+++ b/skills/setting-up-charcoal-css-variables/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: setting-up-charcoal-css-variables
+description: Use when wiring pixiv's charcoal (@charcoal-ui) into an app with plain CSS, CSS Modules, vanilla-extract, or any stack that is not Tailwind or styled-components, and when charcoal components show no colors or --charcoal-color-* resolves to nothing.
+---
+
+# Setting up charcoal with CSS variables
+
+The lowest-dependency way to use charcoal: load two stylesheets, add one class, then write `var(--charcoal-*)` anywhere.
+
+## Install
+
+```bash
+npm install @charcoal-ui/react@^6 @charcoal-ui/theme@^6 react-aria react-stately
+```
+
+Pin the major. Design Token 2.0 and the CSS layout below are v6; v5 and earlier differ. Keep every `@charcoal-ui/*` package on the same major.
+
+Peer dependencies of `@charcoal-ui/react`: `react >=17.0.0`, `react-aria >=3.48.0`, `react-stately >=3.46.0`. The two react-aria packages are **not** installed for you. React 18 and 19 both satisfy the range.
+
+Skip `@charcoal-ui/react` if you only want tokens — `@charcoal-ui/theme` alone is enough.
+
+## Load the CSS
+
+```ts
+// Load once at the app root.
+import '@charcoal-ui/react/dist/index.css' // component implementation CSS
+import '@charcoal-ui/theme/css/v2/light.css' // Design Token 2.0 — light
+import '@charcoal-ui/theme/css/v2/dark.css' // Design Token 2.0 — dark
+```
+
+`dist/index.css` only _consumes_ `var(--charcoal-color-*)`. It never defines them.
+
+The failure this causes is lopsided in a way that misleads people: **colors go through `var()`, but layout does not.** Padding, radius, font-size, and line-height are written as literal values, so they keep working. Load `dist/index.css` alone and you get a correctly shaped, correctly sized button with a transparent background and default black text. Nothing errors — an undefined custom property just makes that one declaration invalid, and the property falls back to its initial value.
+
+If a charcoal component looks _structurally_ right but _colorless_, this is why.
+
+Prefer `@charcoal-ui/react/dist/layered.css` over `dist/index.css` when you need to override charcoal styles from your own CSS. Its contents are wrapped in `@layer charcoal`, so any unlayered rule of yours wins without a specificity fight. It requires iOS 15.4+.
+
+## Opt in to Design Token 2.0 — required
+
+Token 2.0 only applies inside `.ch-token-v2`.
+
+```html
+<html class="ch-token-v2" lang="ja"></html>
+```
+
+The shipped selectors are:
+
+```css
+/* light.css */
+:root.ch-token-v2[data-theme='light'],
+:root.ch-token-v2:not([data-theme]),
+:root[data-theme='light'] .ch-token-v2,
+:root:not([data-theme]) .ch-token-v2 {
+  --charcoal-color-…: …;
+}
+
+/* dark.css */
+:root[data-theme='dark'] {
+  --charcoal-color-…: …;
+}
+```
+
+Two consequences:
+
+- Without `.ch-token-v2`, **no light-theme rule matches** and every token is undefined.
+- Dark is scoped to `:root` only, so `data-theme="dark"` applies page-wide regardless of `.ch-token-v2`.
+
+Put the class on `<html>`, or on an ancestor of the components you want themed. Variables inherit, so siblings are unaffected.
+
+## Use the tokens
+
+```css
+.card {
+  background-color: var(--charcoal-color-background-default);
+  color: var(--charcoal-color-text-default);
+  border: 1px solid var(--charcoal-color-border-secondary);
+  border-radius: var(--charcoal-radius-s);
+  padding: var(--charcoal-space-40);
+}
+```
+
+Names follow `--charcoal-<category>-<semantic>-<state>`. Common ones: `color-text-default` / `-secondary-default` / `-tertiary-default`, `color-background-default` / `-secondary` / `-tertiary`, `color-border-default` / `-secondary`, `color-container-primary-default`, `radius-xs|s|m|l`, `space-*`. Read `node_modules/@charcoal-ui/theme/dist/css/v2/light.css` for the full list.
+
+## Components need no provider
+
+```tsx
+import { Button } from '@charcoal-ui/react'
+
+export const Save = () => <Button variant="Primary">保存</Button>
+```
+
+`Button` imports its own CSS and uses no context. Wrap in `CharcoalProvider` **only** when you use overlays (`Modal`, `DropdownSelector`) — it supplies react-aria's `SSRProvider` and `OverlayProvider`.
+
+## Theme switching
+
+```tsx
+document.documentElement.dataset.theme = 'dark' // or 'light'
+```
+
+For SSR, run this before paint to avoid a flash:
+
+```tsx
+import { makeSetThemeScriptCode } from '@charcoal-ui/react'
+
+;<script dangerouslySetInnerHTML={{ __html: makeSetThemeScriptCode() }} />
+```
+
+Use `makeSetThemeScriptCode()`, not `<SetThemeScript />`. The component's props type requires both `localStorageKey` and `rootAttribute`, so `<SetThemeScript />` is a type error; `makeSetThemeScriptCode()` accepts zero arguments.
+
+## System theme does not follow the OS
+
+`useThemeSetter()` **removes** `data-theme` when the user is on "system", by design — it expects CSS to handle `prefers-color-scheme`. Design Token 2.0's CSS has no `prefers-color-scheme` block, so with the attribute removed `:root:not([data-theme]) .ch-token-v2` matches and the page is **stuck on light** even on a dark OS.
+
+Either always write an explicit `data-theme`, or add the missing bridge yourself:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']).ch-token-v2,
+  :root:not([data-theme='light']) .ch-token-v2 {
+    /* copy the declarations from @charcoal-ui/theme/css/v2/dark.css */
+  }
+}
+```
+
+Mirror light.css's selector shape. Targeting bare `:root` fails when `.ch-token-v2` sits on a descendant: that descendant's own light values beat inherited dark values from an ancestor.
+
+## Common mistakes
+
+| Mistake                            | Fix                                              |
+| ---------------------------------- | ------------------------------------------------ |
+| Only `dist/index.css` loaded       | Add `@charcoal-ui/theme/css/v2/{light,dark}.css` |
+| `.ch-token-v2` missing             | Add it to `<html>` or an ancestor                |
+| `<SetThemeScript />` with no props | Use `makeSetThemeScriptCode()`                   |
+| Own CSS loses to charcoal's        | Switch to `dist/layered.css`                     |
+| Dark mode ignored on "system"      | Add the `prefers-color-scheme` bridge above      |

--- a/skills/setting-up-charcoal-styled/SKILL.md
+++ b/skills/setting-up-charcoal-styled/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: setting-up-charcoal-styled
+description: Use when an app already uses styled-components and needs pixiv's charcoal (@charcoal-ui) tokens, when working with @charcoal-ui/styled, TokenInjector, createTheme, or addThemeUtils, or when deciding whether to keep styled-components with charcoal.
+---
+
+# Setting up charcoal with styled-components
+
+`@charcoal-ui/styled` exists for codebases already written in styled-components. Read the next section before wiring it in.
+
+## Choose this only for existing code
+
+`@charcoal-ui/styled` is **frozen at Design Token 1.0**. Its source contains no reference to Token 2.0, and it receives only maintenance commits while `@charcoal-ui/tailwind-config` keeps gaining v2 features.
+
+The package is not formally deprecated — only `createTheme` carries `@deprecated`. The problem is not that it is forbidden; it is that it cannot reach the current token generation.
+
+It also drags in the component library: `@charcoal-ui/styled` peer-depends on `@charcoal-ui/react`, because `useTheme`, `useThemeSetter`, `themeSelector`, and `SetThemeScript` are re-exports whose implementations live there. You get that dependency even if you never render a charcoal component.
+
+For a new project, or when you only want tokens, use setting-up-charcoal-css-variables instead.
+
+## Install
+
+```bash
+npm install @charcoal-ui/styled@^6 @charcoal-ui/theme@^6 @charcoal-ui/react@^6
+```
+
+Pin the major and keep every `@charcoal-ui/*` package on the same one. `styled-components >=5.1.1` and `react >=17.0.0` are peers.
+
+## Provider
+
+Two independent mechanisms, both usually needed:
+
+- `ThemeProvider` (styled-components) supplies the **JS theme object** so `${({ theme }) => theme.color.text1}` resolves. The values are literal hex strings, not `var()`.
+- `TokenInjector` (`@charcoal-ui/styled`) emits `--charcoal-color-*` **CSS variables** at runtime via `createGlobalStyle`, for anything not going through styled-components.
+
+```tsx
+import { ThemeProvider } from 'styled-components'
+import {
+  TokenInjector,
+  addThemeUtils,
+  useTheme,
+  useThemeSetter,
+  themeSelector,
+} from '@charcoal-ui/styled'
+import { light, dark } from '@charcoal-ui/theme'
+
+const lightTheme = addThemeUtils(light)
+const darkTheme = addThemeUtils(dark)
+
+export function ThemeRoot({ children }: { children: React.ReactNode }) {
+  const [mode] = useTheme()
+  useThemeSetter()
+
+  return (
+    <ThemeProvider theme={mode === 'dark' ? darkTheme : lightTheme}>
+      <TokenInjector
+        theme={{ ':root': light, [themeSelector('dark')]: dark }}
+        background="background1"
+      />
+      {children}
+    </ThemeProvider>
+  )
+}
+```
+
+`TokenInjector`'s optional `background` prop takes any key of `theme.color` (`background1`, `background2`, `surface1`…) and paints it as the page background on each selector.
+
+Because the JS objects hold literal colors, switching themes requires swapping `ThemeProvider`'s `theme` prop. Rewriting CSS variables alone does not change `${({ theme }) => …}` output. The two systems must be kept in sync — that is what `useTheme` plus `useThemeSetter` do here.
+
+## Types
+
+```ts
+// styled.d.ts
+import 'styled-components'
+import type { CharcoalTheme } from '@charcoal-ui/theme'
+import type { CharcoalThemeUtils } from '@charcoal-ui/styled'
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends CharcoalTheme, CharcoalThemeUtils {}
+}
+```
+
+## Writing components
+
+Use styled-components' own theming. Do **not** use `createTheme` / `theme(o => [...])` — it is `@deprecated` for runtime performance ([PR #377](https://github.com/pixiv/charcoal/pull/377)).
+
+```tsx
+const Card = styled.div`
+  background-color: ${({ theme }) => theme.color.background1};
+  color: ${({ theme }) => theme.color.text1};
+  border-radius: ${({ theme }) => theme.borderRadius[8]}px;
+  ${({ theme }) => theme.utils.padding(16)}
+  ${({ theme }) => theme.utils.typography(16)}
+`
+```
+
+`addThemeUtils()` adds `theme.utils`: `margin*`, `padding*`, `gap`, `typography`, `focusVisibleFocusRingCss`, `assertiveRingCss`, `disabledCss`.
+
+Constraints worth knowing before you hit them:
+
+- `theme.utils.typography(size)` accepts only `12 | 14 | 16 | 20`. **32 is not supported** — expand it by hand. `theme.typography.size[n]` is `{ fontSize: number; lineHeight: number }` in px, keyed by `12 | 14 | 16 | 20 | 32`:
+
+  ```tsx
+  font-size: ${({ theme }) => theme.typography.size[32].fontSize}px;
+  line-height: ${({ theme }) => theme.typography.size[32].lineHeight}px;
+  ```
+
+- `theme.utils.margin` / `padding` accept only the spacing scale (`0, 4, 8, 16, 24, 40, 64, 104, 168, 272, 440`) or `'auto'`. Arbitrary px values are rejected by the type.
+- `theme.spacing` and `theme.typography` are identical in light and dark.
+
+## Theme switching and SSR
+
+```tsx
+import { makeSetThemeScriptCode } from '@charcoal-ui/styled'
+
+;<script dangerouslySetInnerHTML={{ __html: makeSetThemeScriptCode() }} />
+```
+
+Prefer `makeSetThemeScriptCode()` over `<SetThemeScript />`; the component's props type requires both `localStorageKey` and `rootAttribute`.
+
+## Migrating off, in dependency order
+
+You do not have to leave in one step.
+
+1. **Drop `createTheme`.** The only `@deprecated` API here. Move to plain `${({ theme }) => theme.color.*}` or `addThemeUtils`.
+2. **Drop `TokenInjector`.** Import `@charcoal-ui/theme/css/v2/{light,dark}.css` instead — static CSS supplies the same variables with no runtime `createGlobalStyle`. This is also the step that unlocks Design Token 2.0.
+3. **Drop `ThemeProvider`.** Replace `theme.color.text1` reads with `var(--charcoal-color-text-default)`.
+4. **Drop styled-components** if you want. By this point charcoal no longer cares.
+
+If you only render `@charcoal-ui/react` components, steps 1–3 are already unnecessary — since v4 it does not depend on styled-components at all.
+
+## Common mistakes
+
+| Mistake                                         | Fix                                                                               |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| Reaching for `createTheme` because docs show it | It is `@deprecated`. Use styled-components theming.                               |
+| Expecting Design Token 2.0 here                 | Not supported. Move to CSS variables or Tailwind.                                 |
+| Swapping CSS variables to change theme          | JS theme objects hold literal colors — swap `ThemeProvider`'s `theme` too.        |
+| `theme.utils.typography(32)`                    | Type error. Expand `theme.typography.size[32]` manually.                          |
+| Following `pages/` docs in the repo             | Last updated 2023-03-22, pre-v4. Its `@charcoal-ui/react` instructions are wrong. |

--- a/skills/setting-up-charcoal-tailwind/SKILL.md
+++ b/skills/setting-up-charcoal-tailwind/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: setting-up-charcoal-tailwind
+description: Use when adding pixiv's charcoal (@charcoal-ui) design tokens to a Tailwind CSS project, when charcoal Tailwind classes are missing or resolve to the wrong generation of tokens, or when Tailwind's own color and spacing utilities stop working after adding the charcoal preset.
+---
+
+# Setting up charcoal with Tailwind
+
+`@charcoal-ui/tailwind-config` turns charcoal tokens into a Tailwind preset. This is the actively developed utility route — new Design Token 2.0 features land here first.
+
+## Install
+
+```bash
+npm install --save-dev @charcoal-ui/tailwind-config @charcoal-ui/theme
+```
+
+Peer dependencies: `tailwindcss >=1.4.6`, `postcss >=7.0.32`, `csstype >=3.0.0`. Tailwind v4 support is WIP — v4 works only by pointing `@config` at a v3-shaped config.
+
+## Configure
+
+```js
+// tailwind.config.js
+const { light, dark } = require('@charcoal-ui/theme')
+const { createTailwindConfig } = require('@charcoal-ui/tailwind-config')
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  presets: [
+    createTailwindConfig({
+      version: 'v3',
+      theme: {
+        ':root': light,
+        '@media (prefers-color-scheme: dark)': dark,
+      },
+      unstableTokenV2: true, // Design Token 2.0 — omit and you get 1.0
+      iconsV2: true,
+    }),
+  ],
+}
+```
+
+`createTailwindConfig()` options: `version` (`'v1' | 'v2' | 'v3'`, Tailwind's version — unrelated to charcoal's), `theme`, `cssVariablesV1`, `unstableTokenV2`, `iconsV1`, `iconsV2`. A bare default preset is also exported as `config`.
+
+## `unstableTokenV2: true` needs the theme CSS too
+
+The preset does **not** define Design Token 2.0 variables. `unstable_createTailwindConfigTokenV2()` contains no plugin and no `addBase()` — it only emits class values that _reference_ `var(--charcoal-color-*)`. Something else has to define them.
+
+Two disjoint namespaces are in play:
+
+| Defined by                                        | Names                         | Example                                      |
+| ------------------------------------------------- | ----------------------------- | -------------------------------------------- |
+| The preset, when `cssVariablesV1` is on (default) | `--charcoal-<v1 token>`       | `--charcoal-background1`, `--charcoal-text1` |
+| `@charcoal-ui/theme/css/v2/*.css`                 | `--charcoal-color-<v2 token>` | `--charcoal-color-container-default`         |
+
+`customPropertyToken()` produces `--charcoal-${id}`, so the v1 variables never satisfy a v2 reference. Turning on `unstableTokenV2` without loading the theme CSS gives you classes that resolve to nothing — colors silently disappear.
+
+So with `unstableTokenV2: true`, do all three:
+
+```css
+/* globals.css */
+@import '@charcoal-ui/theme/css/v2/light.css';
+@import '@charcoal-ui/theme/css/v2/dark.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+```html
+<html lang="ja" class="ch-token-v2">
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+`.ch-token-v2` gates the light-theme rules in `light.css`. Without it, no light rule matches and every v2 variable is undefined — the same failure described in setting-up-charcoal-css-variables.
+
+If you stay on Design Token 1.0 (`unstableTokenV2` omitted), the preset's own `addBase()` supplies everything and the three `@tailwind` lines are all you need.
+
+## The preset replaces Tailwind's defaults
+
+`createTailwindConfig()` writes `colors`, `spacing`, `width`, `gap`, `borderRadius`, `screens`, and `transitionDuration` at the **top level of `theme`**, not under `extend`. Tailwind's preset merge therefore _replaces_ the stock scales:
+
+- `bg-red-500`, `text-blue-600` and the rest of the default palette stop existing. Only `transparent`, `current`, `black`, `white`, and charcoal tokens remain.
+- `p-4` no longer means 1rem. Spacing keys are charcoal's px values: `0, 4, 8, 16, 24, 40, 64, 104, 168, 272, 440` — so `p-16` is 16px.
+- `corePlugins: { lineHeight: false }` disables every `leading-*` utility.
+
+If existing markup relies on stock Tailwind classes, add them back explicitly:
+
+```js
+const colors = require('tailwindcss/colors')
+module.exports = {
+  presets: [createTailwindConfig({/* … */})],
+  theme: { extend: { colors: { red: colors.red } } },
+}
+```
+
+## Classes you get
+
+```tsx
+<div className="bg-background1 text-text1 rounded-8 p-16">
+  <h2 className="typography-20">タイトル</h2>
+  <button className="ch-focus-ring bg-brand hover:bg-brand-hover active:bg-brand-press">
+    送信
+  </button>
+</div>
+```
+
+- Colors carry `DEFAULT` / `hover` / `press` / `disabled` variants — `bg-brand`, `bg-brand-hover`, …
+- `typography-{12|14|16|20|32}` sets font-size and line-height together.
+- `.ch-focus-ring` reproduces the focus ring used by `@charcoal-ui/react`.
+- `w-col-span-{n}` and `w-{n}/12` come from the grid system.
+
+Those names are Design Token 1.0. They keep working when `unstableTokenV2` is on, because the preset merges v2 entries on top of v1 rather than replacing them.
+
+Design Token 2.0 adds five color groups — `background`, `border`, `container`, `icon`, `text` — folded so that a `default` key becomes the bare class:
+
+```
+color.container.default      → bg-container
+color.container.hover        → bg-container-hover
+color.text.default           → text-text
+color.text.info.default      → text-text-info
+color.text.negative.hover    → text-text-negative-hover
+color.background.secondary   → bg-background-secondary
+```
+
+Spacing splits into `component-*` and `layout-*` (`p-component-20`, `gap-layout-40`), radius becomes `rounded-{xs|s|m|l|xl|xxl|oval}`, and border colors take a `ch` prefix (`border-ch-secondary`).
+
+To see exactly what your config produces, resolve it rather than guessing:
+
+```js
+console.log(
+  require('tailwindcss/resolveConfig')(require('./tailwind.config.js')).theme
+    .colors,
+)
+```
+
+## Dark theme
+
+Tailwind's `dark:` variant is **not supported**. A charcoal token keeps its name across themes while its value changes, so `dark:bg-background1` is meaningless. Pass a theme map instead and the generated `var()` switches for you.
+
+```js
+// follow the OS
+theme: { ':root': light, '@media (prefers-color-scheme: dark)': dark }
+
+// or switch from JS
+theme: { ':root': light, 'html[data-theme="dark"]': dark }
+```
+
+```js
+document.documentElement.dataset.theme = 'dark'
+```
+
+Do not nest `:root` under the `@media` key — the build inserts it for you.
+
+**The `theme` map only drives Design Token 1.0.** It feeds `cssVariablesV1`, which defines `--charcoal-<v1 token>`. Token 2.0 variables come from `@charcoal-ui/theme/css/v2/*.css`, and that CSS defines dark only at `:root[data-theme='dark']` — it has no `prefers-color-scheme` block. So on `unstableTokenV2: true`, `'@media (prefers-color-scheme: dark)': dark` does **not** make v2 tokens follow the OS.
+
+Either write `data-theme` explicitly from JS, or add the bridge described in setting-up-charcoal-css-variables:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']).ch-token-v2,
+  :root:not([data-theme='light']) .ch-token-v2 {
+    /* copy the declarations from @charcoal-ui/theme/css/v2/dark.css */
+  }
+}
+```
+
+## Common mistakes
+
+| Mistake                                                       | Fix                                                                                                                        |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `unstableTokenV2` omitted                                     | You silently get Design Token 1.0. Set it to `true`.                                                                       |
+| `unstableTokenV2: true` but no theme CSS                      | The preset never defines `--charcoal-color-*`. Import `@charcoal-ui/theme/css/v2/{light,dark}.css` and add `.ch-token-v2`. |
+| Assuming `.ch-token-v2` is a CSS-variables-route-only concern | It gates the v2 variables themselves, so the Tailwind v2 route needs it too.                                               |
+| Confusing `version: 'v3'` with charcoal v3                    | It means Tailwind v3.                                                                                                      |
+| `dark:bg-*`                                                   | Unsupported. Use the `theme` map.                                                                                          |
+| Stock Tailwind classes vanished                               | The preset replaces the default scales — add them back under `theme.extend`.                                               |
+| `leading-*` has no effect                                     | `corePlugins.lineHeight` is off. Use `typography-*`.                                                                       |
+| Nesting `':root'` inside the `@media` key                     | Pass the theme object directly.                                                                                            |
+
+## Using charcoal React components too
+
+`@charcoal-ui/react` is independent of this preset. It needs its own CSS and the `.ch-token-v2` opt-in — see setting-up-charcoal-css-variables. Set `corePlugins: { preflight: false }` if Tailwind's reset interferes with charcoal component styles.


### PR DESCRIPTION
## やったこと

charcoal のスタイリングに関する案内を、人間向けとエージェント向けの両方に追加しました。

### Storybook に「Styling Guide」ページを追加

`.storybook/src/styling-guide.mdx`（`?path=/docs/styling-guide--docs`）

「なぜそうなっているか」を説明するページです。手順は各パッケージのクイックスタートに任せ、こちらは設計の背景に絞っています。

- 定数 / ユーティリティ / コンポーネントの三層構造。**利用者が選ぶのは真ん中の 1 層だけ**であること
- 「styled から pure CSS へ」はコンポーネント層の内部実装の話で、「styled と Tailwind のどちらか」とは別の軸であること
- Design Token 2.0 が `.ch-token-v2` によるオプトインであること。light だけがスコープされ dark は `:root` 全体に効く非対称
- `index.css` と `layered.css` の優先度の違い

### 導入手順を agent skills として追加

`skills/` と `.claude-plugin/marketplace.json`

```
skills/
├── choosing-charcoal-styling/          分岐
├── setting-up-charcoal-css-variables/  既定の経路
├── setting-up-charcoal-tailwind/       preset と Token 2.0 の有効化
└── setting-up-charcoal-styled/         既存資産向けと移行順序
```

`skills/` と `.claude-plugin/` を併置してあるので、Claude Code の plugin としても `npx skills` 経由でも**同じファイル**が入ります。Codex や Cursor への導入手順は `skills/README.md` にまとめました。

```bash
npx skills add pixiv/charcoal -a codex
```

## なぜ必要か

**公式ドキュメントがエージェントから読めない状態にあります。**

- `charcoal-web.pixiv.design` は Storybook（SPA）なので、fetch してもタイトルしか取れません
- npm のパッケージページは 403 を返します
- `pages/` の docsify は 2023-03-22 で更新が止まっており、v4 以降と食い違います（`components/react.md` は今も `ThemeProvider` が必要だと書いています）

その結果、エージェントは GitHub の README 断片やパッケージの実体から推測することになります。

## 内容の検証方法

skill なしのエージェントで失敗を再現してから記述しました（4 シナリオ）。

| シナリオ | skill なし | skill あり |
| --- | --- | --- |
| Next.js への導入 | `.ch-token-v2` を落とす | 出力する |
| Tailwind 併用 | Design Token 2.0 に言及なし | `unstableTokenV2: true` を設定 |
| 色が出ないデバッグ | Tailwind 未使用アプリに Tailwind 導入を指示 | 原因を正しく特定 |
| styled-components | `.ch-token-v2` を落とす | 凍結を告知し移行順序を提示 |

**4 件すべてが Design Token 2.0 のオプトインを落としました。** 所要も 34〜58 tool uses / 3〜9 分から、4 tool uses / 1 分未満に短縮しています。

検証中に skill 側の誤りも 1 件見つかり、修正済みです。当初「Tailwind 経路に `.ch-token-v2` は不要」と読める記述をしていましたが、`unstable_createTailwindConfigTokenV2()` にはプラグインも `addBase` もなく `var(--charcoal-color-*)` を参照するだけなので、Tailwind 経路でも theme の CSS 読み込みと `.ch-token-v2` が必要です。

## 動作確認環境

- `pnpm storybook:build` → exit 0。生成 ID は `styling-guide--docs`
- Chromium で light / dark 両方をレンダリングし、表・コードブロック・リンクの描画と console error 0 件を確認
- ページ内リンク 4 本（`react-readme--docs` ほか）が `storybook-static/index.json` に存在することを確認
- `pnpm lint:prettier` 通過

## チェックリスト

- [x] README やドキュメントに影響があることを確認した
