### PR TITLE
fix: Snackbarの終了アニメーションとdata属性に対応し、remapの値を修正

### DIFF
--- a/packages/react/src/components/Notification/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.test.tsx
@@ -151,12 +151,21 @@ describe('Snackbar', () => {
     expect(screen.getByText('second')).toBeInTheDocument()
   })
 
-  it('replaces the current snackbar immediately when requested', () => {
+  it('replaces the current snackbar after its exit animation', () => {
     const onClose = vi.fn()
     const { show } = renderSnackbar({ order: 'replace' })
 
     show('first', { onClose })
     show('second')
+
+    expect(screen.getByText('first')).toBeInTheDocument()
+    expect(screen.queryByText('second')).not.toBeInTheDocument()
+    expect(
+      screen.getByText('first').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-exiting', 'true')
+    expect(onClose).not.toHaveBeenCalled()
+
+    finishExitAnimation('first')
 
     expect(screen.queryByText('first')).not.toBeInTheDocument()
     expect(screen.getByText('second')).toBeInTheDocument()
@@ -172,12 +181,16 @@ describe('Snackbar', () => {
       vi.advanceTimersByTime(1)
     })
 
+    expect(onClose).not.toHaveBeenCalled()
+
+    finishExitAnimation('保存しました')
+
     expect(onClose).toHaveBeenCalledExactlyOnceWith('timeout')
   })
 
-  it('reports action when the action is clicked', () => {
-    const onClose = vi.fn()
-    const { show } = renderSnackbar()
+  it('reports action after the exit animation finishes', () => {
+    const { show, unmount } = renderSnackbar()
+    const onClose = vi.fn(() => unmount())
 
     show('保存しました', {
       action: <button type="button">取り消す</button>,
@@ -185,7 +198,15 @@ describe('Snackbar', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: '取り消す' }))
 
+    expect(
+      screen.getByText('保存しました').closest('.charcoal-snackbar'),
+    ).toHaveAttribute('data-exiting', 'true')
+    expect(onClose).not.toHaveBeenCalled()
+
+    finishExitAnimation('保存しました')
+
     expect(onClose).toHaveBeenCalledExactlyOnceWith('action')
+    expect(screen.queryByText('保存しました')).not.toBeInTheDocument()
   })
 
   it('reports unmounted only for the currently displayed snackbar', () => {

--- a/packages/react/src/components/Notification/Snackbar/index.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.tsx
@@ -59,6 +59,7 @@ export function useSnackbar(props: UseSnackbarProps = {}) {
     useNotificationQueue<SnackbarContent, SnackbarCloseReason>('snackbar', {
       duration,
       order,
+      animateReplace: true,
       timeoutReason: 'timeout',
       unmountedReason: 'unmounted',
     })

--- a/packages/react/src/components/Notification/Snackbar/index.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.tsx
@@ -11,9 +11,14 @@ import type { NotificationProps, Position } from '../types'
 export type SnackbarCloseReason =
   'timeout' | 'replaced' | 'action' | 'close' | 'unmounted'
 
+export type SnackbarRootAttributes = {
+  [key: `data-${string}`]: string | number | boolean | undefined
+}
+
 export type ShowSnackbarOptions = {
   action?: ReactNode
   onClose?: (reason: SnackbarCloseReason) => void
+  rootAttributes?: SnackbarRootAttributes
 }
 
 type SnackbarBaseProps = {
@@ -35,6 +40,7 @@ export type UseSnackbarProps = Omit<NotificationProps, 'position'> & {
 type SnackbarContent = {
   message: ReactNode
   action?: ReactNode
+  rootAttributes?: SnackbarRootAttributes
 }
 
 const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(
@@ -65,7 +71,14 @@ export function useSnackbar(props: UseSnackbarProps = {}) {
     })
 
   function show(message: ReactNode, options: ShowSnackbarOptions = {}) {
-    enqueue({ message, action: options.action }, options.onClose)
+    enqueue(
+      {
+        message,
+        action: options.action,
+        rootAttributes: options.rootAttributes,
+      },
+      options.onClose,
+    )
   }
 
   const hasAction = state.visibleToasts.some(
@@ -81,6 +94,7 @@ export function useSnackbar(props: UseSnackbarProps = {}) {
     >
       {state.visibleToasts.map((toast) => (
         <NotificationItem
+          {...toast.content.rootAttributes}
           key={toast.key}
           name="snackbar"
           toast={toast}

--- a/packages/react/src/components/Notification/useNotificationQueue.ts
+++ b/packages/react/src/components/Notification/useNotificationQueue.ts
@@ -18,11 +18,13 @@ export function useNotificationQueue<
   {
     duration: durationOption,
     order = 'queue',
+    animateReplace = false,
     timeoutReason,
     unmountedReason,
   }: {
     duration?: number
     order?: NotificationOrder
+    animateReplace?: boolean
     timeoutReason?: TCloseReason
     unmountedReason?: TCloseReason
   } = {},
@@ -57,23 +59,19 @@ export function useNotificationQueue<
         return
       }
 
-      function notifyActive() {
-        const active = activeRef.current
-        if (active === undefined || active.notified) return
-        active.notified = true
-        const reason = active.reason ?? timeoutReason
-        if (reason !== undefined) {
-          active.onClose?.(reason)
-        }
-      }
-
       function finish() {
+        const active = activeRef.current
         activeRef.current = undefined
         update()
+        if (active !== undefined && !active.notified) {
+          active.notified = true
+          const reason = active.reason ?? timeoutReason
+          if (reason !== undefined) {
+            active.onClose?.(reason)
+          }
+        }
         playNextRef.current?.()
       }
-
-      notifyActive()
 
       if (hoverRef.current.active) {
         hoverRef.current.pending = () => wrapUpdate(update, 'remove')
@@ -90,6 +88,7 @@ export function useNotificationQueue<
         finish()
         return
       }
+
       const item: HTMLDivElement = itemRef.current
 
       // allow-discreteが Newly Available で使えないので、要素の削除をアニメーション完了まで待つ
@@ -129,8 +128,10 @@ export function useNotificationQueue<
     return () => {
       const active = activeRef.current
       if (active !== undefined && !active.notified) {
-        if (unmountedReason !== undefined) {
-          active.onClose?.(unmountedReason)
+        active.notified = true
+        const reason = active.reason ?? unmountedReason
+        if (reason !== undefined) {
+          active.onClose?.(reason)
         }
       }
       activeRef.current = undefined
@@ -181,7 +182,7 @@ export function useNotificationQueue<
       if (active === undefined) return
 
       active.reason = 'replaced' as TCloseReason
-      replaceRef.current = true
+      replaceRef.current = !animateReplace
       hoverRef.current.active = false
       const pending = hoverRef.current.pending
       hoverRef.current.pending = undefined

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -112,6 +112,7 @@ export {
   type SnackbarProps as UnstableSnackbarProps,
   type UseSnackbarProps as unstable_UseSnackbarProps,
   type SnackbarCloseReason as unstable_SnackbarCloseReason,
+  type SnackbarRootAttributes as unstable_SnackbarRootAttributes,
   type ShowSnackbarOptions as unstable_ShowSnackbarOptions,
 } from './components/Notification/Snackbar'
 export {

--- a/packages/theme/src/css/v1/remap.css
+++ b/packages/theme/src/css/v1/remap.css
@@ -42,7 +42,7 @@
   --charcoal-space-64: 64px;
   /* 互換レイヤー: スペーシングの上書き */
   --charcoal-space-46: 32px;
-  --charcoal-space-40: 40px;
+  --charcoal-space-40: 24px;
   --charcoal-space-30: 16px;
   --charcoal-space-25: 12px;
   --charcoal-space-24: 24px;


### PR DESCRIPTION
## やったこと

- Snackbar のタイムアウト・アクション・置換時に、終了アニメーションの完了後に削除と `onClose` 通知を行うよう修正
- Snackbar のルート要素へ `data-*` 属性を渡せる `rootAttributes` を追加
- `--charcoal-space-40` の互換レイヤーの値を `24px` に修正
- クローズおよび置換時の挙動を検証するテストを更新

## 動作確認環境

- `pnpm test packages/react/src/components/Notification/Snackbar/index.test.tsx --run`
  - 23 tests passed
  - Type Errors: no errors

## チェックリスト

- [x] 破壊的変更がないことを確認した
- [x] 追加した型が index.ts から再 export されている
- [x] README やドキュメントへの追加対応が不要であることを確認した