### PR TITLE
fix(react-sandbox): return sourcemaps from styled plugin

### DIFF
--- a/packages/react-sandbox/build-plugin-styled-components/index.ts
+++ b/packages/react-sandbox/build-plugin-styled-components/index.ts
@@ -2,20 +2,19 @@ import * as babel from '@babel/core'
 import type { ParserPlugin } from '@babel/parser'
 import type { UserConfig } from 'tsdown'
 import path from 'path'
-import fs from 'fs/promises'
 
-const cache = new Map<string, Promise<string>>()
+const cache = new Map<string, ReturnType<typeof transformStyledComponents>>()
 
 export const styledComponentsPlugin: UserConfig['plugins'] = {
   name: 'styled-components',
   async transform(code, id) {
     if (id.includes('\0') || !/\.(?:[mc]?[jt]s|[jt]sx)$/.test(id)) {
-      return code
+      return null
     }
     const cachedResult = cache.get(id)
 
     if (cachedResult === undefined) {
-      const result = transformStyledComponents(id)
+      const result = transformStyledComponents(code, id)
       cache.set(id, result)
       return await result
     }
@@ -24,9 +23,9 @@ export const styledComponentsPlugin: UserConfig['plugins'] = {
   },
 }
 
-async function transformStyledComponents(sourcePath: string): Promise<string> {
+async function transformStyledComponents(code: string, sourcePath: string) {
   if (sourcePath.includes('styledExportFix')) {
-    return fs.readFile(sourcePath, 'utf8')
+    return { code, map: null }
   }
   const plugins: ParserPlugin[] = []
   if (sourcePath.endsWith('x')) {
@@ -36,7 +35,7 @@ async function transformStyledComponents(sourcePath: string): Promise<string> {
     plugins.push('typescript')
   }
 
-  const result = await babel.transformFileAsync(sourcePath, {
+  const result = await babel.transformAsync(code, {
     caller: {
       name: '@charcoal-ui/esbuild-plugin-styled-components',
       supportsStaticESM: true,
@@ -71,7 +70,7 @@ async function transformStyledComponents(sourcePath: string): Promise<string> {
       },
     ],
     browserslistConfigFile: false,
-    sourceMaps: 'inline',
+    sourceMaps: true,
     parserOpts: { plugins },
   })
 
@@ -79,5 +78,5 @@ async function transformStyledComponents(sourcePath: string): Promise<string> {
     throw new Error('expect code to be generated')
   }
 
-  return result.code
+  return { code: result.code, map: result.map }
 }

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "run-s --print-label 'build:*'",
     "build:bundle": "tsdown",
-    "build:dts": "tsc --project tsconfig.build.json --pretty --emitDeclarationOnly",
+    "build:dts": "tsc --project tsconfig.build.json --pretty --emitDeclarationOnly --incremental false",
     "typecheck": "tsc --project tsconfig.build.json --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
     "test": "vitest run --passWithNoTests"


### PR DESCRIPTION
## やったこと

- Babelのsourcemapをinline形式からオブジェクト形式に変更
  - Rolldownがsourcemapを認識・合成できるようにするため
- 変換結果を `{ code, map }` で返すよう変更
  - `SOURCEMAP_BROKEN` 警告を解消するため
- 変換対象外では `null` を返すよう変更
  - 未変換コードを変換済みと誤認させないため
- フックに渡されたコードをBabelで変換するよう変更
  - 先行プラグインの変換結果を維持するため

- react-sandbox の型定義生成に --incremental false を設定
  - tsdownが dist を削除した後も .d.ts が確実に再生成されるようにした
    - tsdownが一度 `dist/` を削除した後に再生成するが、そこに型情報はない（別途tscが作っているから）
    - ただし、tscがソースに変更がないと判断してしまうと、 `d.ts` 生成をスキップしてしまう
    - 結果的に `d.ts` が欠損した状態となり、リポジトリルートでの `pnpm build` は失敗しがちになっていた
- react-sandbox の連続ビルドとルート全体のビルドが成功することを確認

## 動作確認環境
ローカルでのビルド / Storybook

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
