### PR TITLE
feat(charcoal-skill): canonical token index を生成

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,4 @@ LICENSE
 /packages/token-cli/out/
 /packages/theme/src/unstable-css/
 .storybook/src/v4.0.0.mdx
+/skills/charcoal/data/

--- a/misc/charcoal-skill/generate.ts
+++ b/misc/charcoal-skill/generate.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { getTokenV2TailwindClassMappings } from '@charcoal-ui/tailwind-config'
+import { getTokenV2TailwindClassMappings } from '../../packages/tailwind-config/src/tokenV2Mappings'
 import { detectLayer, getCategory, getGroup } from './lookup/layer.mjs'
 
 const repoRoot = path.resolve(

--- a/misc/charcoal-skill/generate.ts
+++ b/misc/charcoal-skill/generate.ts
@@ -1,0 +1,263 @@
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getTokenV2TailwindClassMappings } from '@charcoal-ui/tailwind-config'
+import { detectLayer, getCategory, getGroup } from './lookup/layer.mjs'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+)
+const indexPath = path.join(repoRoot, 'skills/charcoal/data/index.json')
+
+const STATE_RE = /^(default|hover|press|disable|disabled)(?:-a)?$/u
+const PRIMITIVE_NOTE =
+  'Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。'
+
+type ThemeToken = { value: string }
+type ThemeJson = Record<string, Record<string, ThemeToken>>
+
+type Tailwind = {
+  key: string
+  recommended: string[]
+  alsoValid: string[]
+}
+
+export type IndexRecord = {
+  layer: 'semantic' | 'primitive'
+  tokenPath: string
+  figma: string
+  css: string
+  category?: string
+  group?: string
+  kind?: string
+  cssUsage?: string
+  tailwind?: Tailwind
+  mapping?: {
+    tokenPath: string
+    classCandidates: unknown[]
+  }
+  familyKey?: string
+  state?: string
+  recommendedSemantic?: { figma: string; reason?: string }[]
+  notes?: string[]
+  keys: string[]
+}
+
+export type TokenIndex = {
+  source: {
+    mappingPackageVersion: string
+    mappingHash: string
+  }
+  records: IndexRecord[]
+}
+
+function kebabCase(value: string) {
+  return value
+    .replace(/([\da-z])([A-Z])/gu, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][\da-z])/gu, '$1-$2')
+    .replace(/[_\s]+/gu, '-')
+    .toLowerCase()
+}
+
+function toFigma(tokenPath: string) {
+  return tokenPath.replaceAll('.', '/')
+}
+
+function toCssVariable(category: string, figmaKey: string) {
+  return `--charcoal-${[category, ...figmaKey.split('/')].map(kebabCase).join('-')}`
+}
+
+function unique(values: string[]) {
+  return [...new Set(values.filter((value) => value !== ''))]
+}
+
+function familyAndState(tokenPath: string) {
+  const parts = tokenPath.split('.')
+  const last = parts.at(-1)
+  if (last !== undefined && STATE_RE.test(last)) {
+    return { familyKey: parts.slice(0, -1).join('.'), state: last }
+  }
+  return { familyKey: tokenPath }
+}
+
+function cssUsageFor(mapping: {
+  cssVariable?: string
+  classCandidates: { utility: string; cssProperties: string[] }[]
+  sourceTokens: { tokenPath: string; cssVariable?: string }[]
+}) {
+  const css = mapping.cssVariable
+  if (css === undefined) return undefined
+  const [candidate] = mapping.classCandidates
+  if (candidate === undefined) return `var(${css})`
+
+  if (candidate.utility === 'fontSize') {
+    const usages = mapping.sourceTokens
+      .filter((token) => token.cssVariable !== undefined)
+      .map((token) => {
+        const property = token.tokenPath.includes('line-height')
+          ? 'line-height'
+          : 'font-size'
+        return `${property}: var(${token.cssVariable})`
+      })
+    return usages.join('; ')
+  }
+
+  if (mapping.classCandidates.length > 1) {
+    return mapping.classCandidates
+      .map((item) => `${item.cssProperties[0]}: var(${css})`)
+      .join('; ')
+  }
+
+  const [property] = candidate.cssProperties
+  if (property === undefined) return `var(${css})`
+  return `${property}: var(${css})`
+}
+
+function tailwindFrom(mapping: { classCandidates: { className: string }[] }) {
+  const recommended = mapping.classCandidates.map(({ className }) => className)
+  const [first] = recommended
+  const key =
+    first?.replace(
+      /^(?:bg|text|fill|stroke|rounded|font|border|gap|p|m|w)-/u,
+      '',
+    ) ?? ''
+  return { key, recommended, alsoValid: [] as string[] }
+}
+
+function recordKeys(record: Omit<IndexRecord, 'keys'>): string[] {
+  const keys = [
+    record.tokenPath,
+    record.figma,
+    record.css,
+    record.css.replace(/^--/u, ''),
+    ...(record.tailwind?.recommended ?? []),
+    record.figma.replaceAll('/', '-'),
+    record.tokenPath.split('.').slice(1).join('/'),
+    record.tokenPath.split('.').slice(1).join('-'),
+  ]
+  return unique(keys)
+}
+
+function semanticRecords() {
+  const mappings = getTokenV2TailwindClassMappings({ includeCssVariable: true })
+  return mappings.flatMap((mapping) => {
+    if (mapping.cssVariable === undefined) return []
+    const { familyKey, state } = familyAndState(mapping.tokenPath)
+    const [candidate] = mapping.classCandidates
+    const kind =
+      candidate?.utility === 'fontSize' || candidate?.utility === 'fontWeight'
+        ? candidate.utility
+        : undefined
+    const record: Omit<IndexRecord, 'keys'> = {
+      layer: 'semantic',
+      tokenPath: mapping.tokenPath,
+      figma: toFigma(mapping.tokenPath),
+      css: mapping.cssVariable,
+      category: mapping.category,
+      group: getGroup(mapping.tokenPath),
+      ...(kind === undefined ? {} : { kind }),
+      cssUsage: cssUsageFor(mapping),
+      tailwind: tailwindFrom(mapping),
+      mapping: {
+        tokenPath: mapping.tokenPath,
+        classCandidates: mapping.classCandidates,
+      },
+      familyKey,
+      ...(state === undefined ? {} : { state }),
+      notes: [],
+    }
+    const sourceKeys = mapping.sourceTokens.flatMap((source) => [
+      source.tokenPath,
+      toFigma(source.tokenPath),
+      source.cssVariable ?? '',
+    ])
+    return [{ ...record, keys: unique([...recordKeys(record), ...sourceKeys]) }]
+  })
+}
+
+function aliasReverseMap(theme: ThemeJson) {
+  const aliases = new Map<string, { figma: string }[]>()
+  for (const [category, tokens] of Object.entries(theme)) {
+    for (const [key, token] of Object.entries(tokens)) {
+      const match = /^\{([^.]+)\.(.+)\}$/u.exec(token.value)
+      if (match === null) continue
+      const primitivePath = `${match[1]}.${match[2].replaceAll('/', '.')}`
+      const semanticFigma = `${category}/${key}`
+      const current = aliases.get(primitivePath) ?? []
+      current.push({ figma: semanticFigma })
+      aliases.set(primitivePath, current)
+    }
+  }
+  return aliases
+}
+
+function primitiveRecords(
+  base: ThemeJson,
+  aliases: Map<string, { figma: string }[]>,
+) {
+  const colorTokens = base.color ?? {}
+  return Object.keys(colorTokens).flatMap((figmaKey) => {
+    const tokenPath = `color.${figmaKey.replaceAll('/', '.')}`
+    if (detectLayer(tokenPath) !== 'primitive') return []
+    const css = toCssVariable('color', figmaKey)
+    const recommendedSemantic = aliases.get(tokenPath) ?? []
+    const record: Omit<IndexRecord, 'keys'> = {
+      layer: 'primitive',
+      tokenPath,
+      figma: `color/${figmaKey}`,
+      css,
+      category: getCategory(tokenPath),
+      group: getGroup(tokenPath),
+      recommendedSemantic,
+      notes: [PRIMITIVE_NOTE],
+    }
+    return [{ ...record, keys: recordKeys(record) }]
+  })
+}
+
+export function buildIndex(): TokenIndex {
+  const mappingPackageVersion = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, 'packages/tailwind-config/package.json'),
+      'utf8',
+    ),
+  ).version as string
+  const semantics = semanticRecords()
+  const mappingHash = createHash('sha256')
+    .update(
+      JSON.stringify(
+        semantics.map((record) => [
+          record.tokenPath,
+          record.tailwind?.recommended,
+        ]),
+      ),
+    )
+    .digest('hex')
+  const light = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, 'packages/theme/src/json/pixiv-light.json'),
+      'utf8',
+    ),
+  ) as ThemeJson
+  const base = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, 'packages/theme/src/json/base.json'),
+      'utf8',
+    ),
+  ) as ThemeJson
+
+  return {
+    source: { mappingPackageVersion, mappingHash },
+    records: [...semantics, ...primitiveRecords(base, aliasReverseMap(light))],
+  }
+}
+
+export function writeIndex(filePath = indexPath) {
+  mkdirSync(path.dirname(filePath), { recursive: true })
+  writeFileSync(filePath, `${JSON.stringify(buildIndex(), null, 2)}\n`)
+  return filePath
+}
+
+export { indexPath }

--- a/misc/charcoal-skill/lookup/layer.mjs
+++ b/misc/charcoal-skill/lookup/layer.mjs
@@ -1,0 +1,69 @@
+const SEMANTIC_COLOR_GROUPS = new Set([
+  'background',
+  'container',
+  'text',
+  'icon',
+  'border',
+])
+
+const SEMANTIC_CATEGORIES = new Set([
+  'space',
+  'radius',
+  'border-width',
+  'paragraph-width',
+  'text',
+])
+
+/**
+ * @typedef {'semantic' | 'primitive' | 'unknown'} TokenLayer
+ */
+
+/**
+ * @param {string} tokenPath Figma `/` 区切りでも token path `.` 区切りでもよい
+ * @returns {TokenLayer}
+ */
+export function detectLayer(tokenPath) {
+  const parts = tokenPath.trim().replaceAll('/', '.').split('.').filter(Boolean)
+
+  const [category, group] = parts
+  if (category === undefined) {return 'unknown'}
+
+  if (category === 'color') {
+    const semanticGroup = group?.toLowerCase()
+    if (semanticGroup === 'light' || semanticGroup === 'dark') {
+      return 'primitive'
+    }
+    if (
+      semanticGroup !== undefined &&
+      SEMANTIC_COLOR_GROUPS.has(semanticGroup)
+    ) {
+      return 'semantic'
+    }
+    return 'unknown'
+  }
+
+  if (SEMANTIC_CATEGORIES.has(category)) {return 'semantic'}
+
+  return 'unknown'
+}
+
+/**
+ * @param {string} tokenPath
+ * @returns {string | undefined}
+ */
+export function getGroup(tokenPath) {
+  const parts = tokenPath.trim().replaceAll('/', '.').split('.').filter(Boolean)
+
+  if (parts[0] === 'color') {return parts[1]}
+  return parts[0]
+}
+
+/**
+ * @param {string} tokenPath
+ * @returns {string | undefined}
+ */
+export function getCategory(tokenPath) {
+  const parts = tokenPath.trim().replaceAll('/', '.').split('.').filter(Boolean)
+
+  return parts[0]
+}

--- a/misc/charcoal-skill/lookup/layer.mjs
+++ b/misc/charcoal-skill/lookup/layer.mjs
@@ -26,7 +26,9 @@ export function detectLayer(tokenPath) {
   const parts = tokenPath.trim().replaceAll('/', '.').split('.').filter(Boolean)
 
   const [category, group] = parts
-  if (category === undefined) {return 'unknown'}
+  if (category === undefined) {
+    return 'unknown'
+  }
 
   if (category === 'color') {
     const semanticGroup = group?.toLowerCase()
@@ -42,7 +44,9 @@ export function detectLayer(tokenPath) {
     return 'unknown'
   }
 
-  if (SEMANTIC_CATEGORIES.has(category)) {return 'semantic'}
+  if (SEMANTIC_CATEGORIES.has(category)) {
+    return 'semantic'
+  }
 
   return 'unknown'
 }
@@ -54,7 +58,9 @@ export function detectLayer(tokenPath) {
 export function getGroup(tokenPath) {
   const parts = tokenPath.trim().replaceAll('/', '.').split('.').filter(Boolean)
 
-  if (parts[0] === 'color') {return parts[1]}
+  if (parts[0] === 'color') {
+    return parts[1]
+  }
   return parts[0]
 }
 

--- a/misc/charcoal-skill/lookup/sources.mjs
+++ b/misc/charcoal-skill/lookup/sources.mjs
@@ -1,0 +1,29 @@
+/**
+ * generate.ts が読む正本。lookup は変換ロジックをコピーせず data/index.json だけを読む。
+ *
+ * Agent 入口: skills/charcoal/scripts/resolve.mjs
+ * 生成物: skills/charcoal/data/index.json（手書きしない）
+ */
+export const sources = {
+  mappingApi: 'packages/tailwind-config/src/tokenV2Mappings.ts',
+  mappingFunction: 'getTokenV2TailwindClassMappings',
+  themeEntries: 'packages/tailwind-config/src/tokenV2Theme.ts',
+  themeEntriesFunction: 'buildTokenV2ThemeEntries',
+  cssTokenObject: 'packages/theme/src/token-object/index.ts',
+  cssTokenObjectFunction: 'createCSSTokenObject',
+  semanticThemeJson: 'packages/theme/src/json/pixiv-light.json',
+  primitiveThemeJson: 'packages/theme/src/json/base.json',
+  indexOutput: 'skills/charcoal/data/index.json',
+  agentEntry: 'skills/charcoal/scripts/resolve.mjs',
+}
+
+/**
+ * semantic: mapping API の行。primitive は mapping に足さない。
+ * primitive と TW 未収録の CSS 変数は theme JSON から generate が載せる。
+ * alias 逆引きは pixiv-light.json の `{color.light/...}` 参照。
+ */
+export const indexLayers = {
+  semanticFrom: 'mappingApi',
+  primitiveFrom: 'primitiveThemeJson',
+  aliasReverseFrom: 'semanticThemeJson',
+}

--- a/misc/charcoal-skill/tests/generate.test.ts
+++ b/misc/charcoal-skill/tests/generate.test.ts
@@ -1,8 +1,6 @@
 import { readFileSync } from 'node:fs'
-import { getTokenV2TailwindClassMappings } from '../../../packages/tailwind-config/src/tokenV2Mappings'
 import { describe, expect, test } from 'vitest'
 import { buildIndex, indexPath, writeIndex } from '../generate.ts'
-import { run } from '../../../skills/charcoal/scripts/resolve.mjs'
 
 describe('generate index', () => {
   test('index.json is regenerated from mapping API and theme JSON', () => {
@@ -10,23 +8,5 @@ describe('generate index', () => {
       writeIndex()
     }
     expect(JSON.parse(readFileSync(indexPath, 'utf8'))).toEqual(buildIndex())
-  })
-})
-
-describe('recommended class reverse lookup', () => {
-  test('every mapping recommended class resolves back to its token', () => {
-    const mappings = getTokenV2TailwindClassMappings({
-      includeCssVariable: true,
-    })
-
-    for (const mapping of mappings) {
-      for (const { className } of mapping.classCandidates) {
-        const result = JSON.parse(run(['resolve', className]).stdout)
-        expect(result.ok, className).toBe(true)
-        expect(result.figma, className).toBe(
-          mapping.tokenPath.replaceAll('.', '/'),
-        )
-      }
-    }
   })
 })

--- a/misc/charcoal-skill/tests/generate.test.ts
+++ b/misc/charcoal-skill/tests/generate.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { getTokenV2TailwindClassMappings } from '@charcoal-ui/tailwind-config'
+import { getTokenV2TailwindClassMappings } from '../../../packages/tailwind-config/src/tokenV2Mappings'
 import { describe, expect, test } from 'vitest'
 import { buildIndex, indexPath, writeIndex } from '../generate.ts'
 import { run } from '../../../skills/charcoal/scripts/resolve.mjs'

--- a/misc/charcoal-skill/tests/generate.test.ts
+++ b/misc/charcoal-skill/tests/generate.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { getTokenV2TailwindClassMappings } from '@charcoal-ui/tailwind-config'
+import { describe, expect, test } from 'vitest'
+import { buildIndex, indexPath, writeIndex } from '../generate.ts'
+import { run } from '../../../skills/charcoal/scripts/resolve.mjs'
+
+describe('generate index', () => {
+  test('index.json is regenerated from mapping API and theme JSON', () => {
+    if (process.env.GENERATE_INDEX === '1') {
+      writeIndex()
+    }
+    expect(JSON.parse(readFileSync(indexPath, 'utf8'))).toEqual(buildIndex())
+  })
+})
+
+describe('recommended class reverse lookup', () => {
+  test('every mapping recommended class resolves back to its token', () => {
+    const mappings = getTokenV2TailwindClassMappings({
+      includeCssVariable: true,
+    })
+
+    for (const mapping of mappings) {
+      for (const { className } of mapping.classCandidates) {
+        const result = JSON.parse(run(['resolve', className]).stdout)
+        expect(result.ok, className).toBe(true)
+        expect(result.figma, className).toBe(
+          mapping.tokenPath.replaceAll('.', '/'),
+        )
+      }
+    }
+  })
+})

--- a/misc/charcoal-skill/tests/lookup/layer.test.mjs
+++ b/misc/charcoal-skill/tests/lookup/layer.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { detectLayer, getCategory, getGroup } from '../../lookup/layer.mjs'
+
+describe('detectLayer', () => {
+  test.each([
+    ['color/container/primary/default', 'semantic'],
+    ['color.text.default', 'semantic'],
+    ['color/icon/default', 'semantic'],
+    ['color/border/default', 'semantic'],
+    ['color/background/default', 'semantic'],
+    ['space/layout/40', 'semantic'],
+    ['radius/m', 'semantic'],
+    ['border-width/m', 'semantic'],
+    ['text/font-size/body', 'semantic'],
+    ['text/font-weight/bold', 'semantic'],
+    ['color/light/blue/50', 'primitive'],
+    ['color/Light/Emerald/50', 'primitive'],
+    ['color/dark/blue/40', 'primitive'],
+    ['--charcoal-color-light-blue-50', 'unknown'],
+  ])('%s → %s', (tokenPath, layer) => {
+    expect(detectLayer(tokenPath)).toBe(layer)
+  })
+})
+
+describe('getGroup / getCategory', () => {
+  test('reads color group from the second segment', () => {
+    expect(getCategory('color/container/primary/default')).toBe('color')
+    expect(getGroup('color/container/primary/default')).toBe('container')
+  })
+
+  test('uses the first segment for non-color tokens', () => {
+    expect(getCategory('radius/m')).toBe('radius')
+    expect(getGroup('radius/m')).toBe('radius')
+  })
+})

--- a/misc/charcoal-skill/tests/lookup/sources.test.mjs
+++ b/misc/charcoal-skill/tests/lookup/sources.test.mjs
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { sources } from '../../lookup/sources.mjs'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+)
+
+describe('lookup data sources', () => {
+  test('conversion sources exist as files, not copied logic', () => {
+    for (const relative of [
+      sources.mappingApi,
+      sources.themeEntries,
+      sources.cssTokenObject,
+      sources.semanticThemeJson,
+      sources.primitiveThemeJson,
+    ]) {
+      expect(existsSync(path.join(repoRoot, relative)), relative).toBe(true)
+    }
+  })
+
+  test('Agent entry lives outside packages/', () => {
+    expect(sources.agentEntry.startsWith('skills/charcoal/')).toBe(true)
+  })
+})

--- a/misc/charcoal-skill/vitest.config.ts
+++ b/misc/charcoal-skill/vitest.config.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -7,17 +6,5 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.{test,spec}.{js,mjs,ts}'],
-    alias: [
-      {
-        find: '@charcoal-ui/tailwind-config',
-        replacement: path.join(
-          path.resolve(import.meta.dirname, '../..'),
-          'packages',
-          'tailwind-config',
-          'src',
-          'tokenV2Mappings.ts',
-        ),
-      },
-    ],
   },
 })

--- a/misc/charcoal-skill/vitest.config.ts
+++ b/misc/charcoal-skill/vitest.config.ts
@@ -1,0 +1,23 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: import.meta.dirname,
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.{test,spec}.{js,mjs,ts}'],
+    alias: [
+      {
+        find: '@charcoal-ui/tailwind-config',
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '../..'),
+          'packages',
+          'tailwind-config',
+          'src',
+          'tokenV2Mappings.ts',
+        ),
+      },
+    ],
+  },
+})

--- a/skills/charcoal/data/index.json
+++ b/skills/charcoal/data/index.json
@@ -1,0 +1,15844 @@
+{
+  "source": {
+    "mappingPackageVersion": "6.1.0-beta.4",
+    "mappingHash": "074180b6b33b9ce954423aa1a2e347919fdff964815fa0137561fc5cbf956b0d"
+  },
+  "records": [
+    {
+      "layer": "semantic",
+      "tokenPath": "border-width.focus.1",
+      "figma": "border-width/focus/1",
+      "css": "--charcoal-border-width-focus-1",
+      "category": "borderWidth",
+      "group": "border-width",
+      "cssUsage": "border-width: var(--charcoal-border-width-focus-1)",
+      "tailwind": {
+        "key": "width-ch-focus-1",
+        "recommended": [
+          "border-width-ch-focus-1"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "border-width.focus.1",
+        "classCandidates": [
+          {
+            "className": "border-width-ch-focus-1",
+            "utility": "borderWidth",
+            "cssProperties": [
+              "border-width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "border-width.focus.1",
+      "notes": [],
+      "keys": [
+        "border-width.focus.1",
+        "border-width/focus/1",
+        "--charcoal-border-width-focus-1",
+        "charcoal-border-width-focus-1",
+        "border-width-ch-focus-1",
+        "border-width-focus-1",
+        "focus/1",
+        "focus-1"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "border-width.focus.2",
+      "figma": "border-width/focus/2",
+      "css": "--charcoal-border-width-focus-2",
+      "category": "borderWidth",
+      "group": "border-width",
+      "cssUsage": "border-width: var(--charcoal-border-width-focus-2)",
+      "tailwind": {
+        "key": "width-ch-focus-2",
+        "recommended": [
+          "border-width-ch-focus-2"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "border-width.focus.2",
+        "classCandidates": [
+          {
+            "className": "border-width-ch-focus-2",
+            "utility": "borderWidth",
+            "cssProperties": [
+              "border-width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "border-width.focus.2",
+      "notes": [],
+      "keys": [
+        "border-width.focus.2",
+        "border-width/focus/2",
+        "--charcoal-border-width-focus-2",
+        "charcoal-border-width-focus-2",
+        "border-width-ch-focus-2",
+        "border-width-focus-2",
+        "focus/2",
+        "focus-2"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "border-width.l",
+      "figma": "border-width/l",
+      "css": "--charcoal-border-width-l",
+      "category": "borderWidth",
+      "group": "border-width",
+      "cssUsage": "border-width: var(--charcoal-border-width-l)",
+      "tailwind": {
+        "key": "width-ch-l",
+        "recommended": [
+          "border-width-ch-l"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "border-width.l",
+        "classCandidates": [
+          {
+            "className": "border-width-ch-l",
+            "utility": "borderWidth",
+            "cssProperties": [
+              "border-width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "border-width.l",
+      "notes": [],
+      "keys": [
+        "border-width.l",
+        "border-width/l",
+        "--charcoal-border-width-l",
+        "charcoal-border-width-l",
+        "border-width-ch-l",
+        "border-width-l",
+        "l"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "border-width.m",
+      "figma": "border-width/m",
+      "css": "--charcoal-border-width-m",
+      "category": "borderWidth",
+      "group": "border-width",
+      "cssUsage": "border-width: var(--charcoal-border-width-m)",
+      "tailwind": {
+        "key": "width-ch-m",
+        "recommended": [
+          "border-width-ch-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "border-width.m",
+        "classCandidates": [
+          {
+            "className": "border-width-ch-m",
+            "utility": "borderWidth",
+            "cssProperties": [
+              "border-width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "border-width.m",
+      "notes": [],
+      "keys": [
+        "border-width.m",
+        "border-width/m",
+        "--charcoal-border-width-m",
+        "charcoal-border-width-m",
+        "border-width-ch-m",
+        "border-width-m",
+        "m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.0",
+      "figma": "radius/0",
+      "css": "--charcoal-radius-0",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-0)",
+      "tailwind": {
+        "key": "0",
+        "recommended": [
+          "rounded-0"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.0",
+        "classCandidates": [
+          {
+            "className": "rounded-0",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.0",
+      "notes": [],
+      "keys": [
+        "radius.0",
+        "radius/0",
+        "--charcoal-radius-0",
+        "charcoal-radius-0",
+        "rounded-0",
+        "radius-0",
+        "0"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.l",
+      "figma": "radius/l",
+      "css": "--charcoal-radius-l",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-l)",
+      "tailwind": {
+        "key": "l",
+        "recommended": [
+          "rounded-l"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.l",
+        "classCandidates": [
+          {
+            "className": "rounded-l",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.l",
+      "notes": [],
+      "keys": [
+        "radius.l",
+        "radius/l",
+        "--charcoal-radius-l",
+        "charcoal-radius-l",
+        "rounded-l",
+        "radius-l",
+        "l"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.m",
+      "figma": "radius/m",
+      "css": "--charcoal-radius-m",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-m)",
+      "tailwind": {
+        "key": "m",
+        "recommended": [
+          "rounded-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.m",
+        "classCandidates": [
+          {
+            "className": "rounded-m",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.m",
+      "notes": [],
+      "keys": [
+        "radius.m",
+        "radius/m",
+        "--charcoal-radius-m",
+        "charcoal-radius-m",
+        "rounded-m",
+        "radius-m",
+        "m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.oval",
+      "figma": "radius/oval",
+      "css": "--charcoal-radius-oval",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-oval)",
+      "tailwind": {
+        "key": "oval",
+        "recommended": [
+          "rounded-oval"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.oval",
+        "classCandidates": [
+          {
+            "className": "rounded-oval",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.oval",
+      "notes": [],
+      "keys": [
+        "radius.oval",
+        "radius/oval",
+        "--charcoal-radius-oval",
+        "charcoal-radius-oval",
+        "rounded-oval",
+        "radius-oval",
+        "oval"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.s",
+      "figma": "radius/s",
+      "css": "--charcoal-radius-s",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-s)",
+      "tailwind": {
+        "key": "s",
+        "recommended": [
+          "rounded-s"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.s",
+        "classCandidates": [
+          {
+            "className": "rounded-s",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.s",
+      "notes": [],
+      "keys": [
+        "radius.s",
+        "radius/s",
+        "--charcoal-radius-s",
+        "charcoal-radius-s",
+        "rounded-s",
+        "radius-s",
+        "s"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.xl",
+      "figma": "radius/xl",
+      "css": "--charcoal-radius-xl",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-xl)",
+      "tailwind": {
+        "key": "xl",
+        "recommended": [
+          "rounded-xl"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.xl",
+        "classCandidates": [
+          {
+            "className": "rounded-xl",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.xl",
+      "notes": [],
+      "keys": [
+        "radius.xl",
+        "radius/xl",
+        "--charcoal-radius-xl",
+        "charcoal-radius-xl",
+        "rounded-xl",
+        "radius-xl",
+        "xl"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.xs",
+      "figma": "radius/xs",
+      "css": "--charcoal-radius-xs",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-xs)",
+      "tailwind": {
+        "key": "xs",
+        "recommended": [
+          "rounded-xs"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.xs",
+        "classCandidates": [
+          {
+            "className": "rounded-xs",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.xs",
+      "notes": [],
+      "keys": [
+        "radius.xs",
+        "radius/xs",
+        "--charcoal-radius-xs",
+        "charcoal-radius-xs",
+        "rounded-xs",
+        "radius-xs",
+        "xs"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "radius.xxl",
+      "figma": "radius/xxl",
+      "css": "--charcoal-radius-xxl",
+      "category": "radius",
+      "group": "radius",
+      "cssUsage": "border-radius: var(--charcoal-radius-xxl)",
+      "tailwind": {
+        "key": "xxl",
+        "recommended": [
+          "rounded-xxl"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "radius.xxl",
+        "classCandidates": [
+          {
+            "className": "rounded-xxl",
+            "utility": "borderRadius",
+            "cssProperties": [
+              "border-radius"
+            ]
+          }
+        ]
+      },
+      "familyKey": "radius.xxl",
+      "notes": [],
+      "keys": [
+        "radius.xxl",
+        "radius/xxl",
+        "--charcoal-radius-xxl",
+        "charcoal-radius-xxl",
+        "rounded-xxl",
+        "radius-xxl",
+        "xxl"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.default-text3",
+      "figma": "color/border/default-text3",
+      "css": "--charcoal-color-border-default-text3",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-default-text3)",
+      "tailwind": {
+        "key": "ch-default-text3",
+        "recommended": [
+          "border-ch-default-text3"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.default-text3",
+        "classCandidates": [
+          {
+            "className": "border-ch-default-text3",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.default-text3",
+      "notes": [],
+      "keys": [
+        "color.border.default-text3",
+        "color/border/default-text3",
+        "--charcoal-color-border-default-text3",
+        "charcoal-color-border-default-text3",
+        "border-ch-default-text3",
+        "color-border-default-text3",
+        "border/default-text3",
+        "border-default-text3"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.disable",
+      "figma": "color/border/disable",
+      "css": "--charcoal-color-border-disable",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-disable)",
+      "tailwind": {
+        "key": "ch-disable",
+        "recommended": [
+          "border-ch-disable"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.disable",
+        "classCandidates": [
+          {
+            "className": "border-ch-disable",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border",
+      "state": "disable",
+      "notes": [],
+      "keys": [
+        "color.border.disable",
+        "color/border/disable",
+        "--charcoal-color-border-disable",
+        "charcoal-color-border-disable",
+        "border-ch-disable",
+        "color-border-disable",
+        "border/disable",
+        "border-disable"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.focus.1",
+      "figma": "color/border/focus/1",
+      "css": "--charcoal-color-border-focus-1",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-focus-1)",
+      "tailwind": {
+        "key": "ch-focus-1",
+        "recommended": [
+          "border-ch-focus-1"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.focus.1",
+        "classCandidates": [
+          {
+            "className": "border-ch-focus-1",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.focus.1",
+      "notes": [],
+      "keys": [
+        "color.border.focus.1",
+        "color/border/focus/1",
+        "--charcoal-color-border-focus-1",
+        "charcoal-color-border-focus-1",
+        "border-ch-focus-1",
+        "color-border-focus-1",
+        "border/focus/1",
+        "border-focus-1"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.focus.2",
+      "figma": "color/border/focus/2",
+      "css": "--charcoal-color-border-focus-2",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-focus-2)",
+      "tailwind": {
+        "key": "ch-focus-2",
+        "recommended": [
+          "border-ch-focus-2"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.focus.2",
+        "classCandidates": [
+          {
+            "className": "border-ch-focus-2",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.focus.2",
+      "notes": [],
+      "keys": [
+        "color.border.focus.2",
+        "color/border/focus/2",
+        "--charcoal-color-border-focus-2",
+        "charcoal-color-border-focus-2",
+        "border-ch-focus-2",
+        "color-border-focus-2",
+        "border/focus/2",
+        "border-focus-2"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.focus.legacy",
+      "figma": "color/border/focus/legacy",
+      "css": "--charcoal-color-border-focus-legacy",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-focus-legacy)",
+      "tailwind": {
+        "key": "ch-focus-legacy",
+        "recommended": [
+          "border-ch-focus-legacy"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.focus.legacy",
+        "classCandidates": [
+          {
+            "className": "border-ch-focus-legacy",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.focus.legacy",
+      "notes": [],
+      "keys": [
+        "color.border.focus.legacy",
+        "color/border/focus/legacy",
+        "--charcoal-color-border-focus-legacy",
+        "charcoal-color-border-focus-legacy",
+        "border-ch-focus-legacy",
+        "color-border-focus-legacy",
+        "border/focus/legacy",
+        "border-focus-legacy"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.hover",
+      "figma": "color/border/hover",
+      "css": "--charcoal-color-border-hover",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-hover)",
+      "tailwind": {
+        "key": "ch-hover",
+        "recommended": [
+          "border-ch-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.hover",
+        "classCandidates": [
+          {
+            "className": "border-ch-hover",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.border.hover",
+        "color/border/hover",
+        "--charcoal-color-border-hover",
+        "charcoal-color-border-hover",
+        "border-ch-hover",
+        "color-border-hover",
+        "border/hover",
+        "border-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.hover-text3",
+      "figma": "color/border/hover-text3",
+      "css": "--charcoal-color-border-hover-text3",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-hover-text3)",
+      "tailwind": {
+        "key": "ch-hover-text3",
+        "recommended": [
+          "border-ch-hover-text3"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.hover-text3",
+        "classCandidates": [
+          {
+            "className": "border-ch-hover-text3",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.hover-text3",
+      "notes": [],
+      "keys": [
+        "color.border.hover-text3",
+        "color/border/hover-text3",
+        "--charcoal-color-border-hover-text3",
+        "charcoal-color-border-hover-text3",
+        "border-ch-hover-text3",
+        "color-border-hover-text3",
+        "border/hover-text3",
+        "border-hover-text3"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.hud",
+      "figma": "color/border/hud",
+      "css": "--charcoal-color-border-hud",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-hud)",
+      "tailwind": {
+        "key": "ch-hud",
+        "recommended": [
+          "border-ch-hud"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.hud",
+        "classCandidates": [
+          {
+            "className": "border-ch-hud",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.hud",
+      "notes": [],
+      "keys": [
+        "color.border.hud",
+        "color/border/hud",
+        "--charcoal-color-border-hud",
+        "charcoal-color-border-hud",
+        "border-ch-hud",
+        "color-border-hud",
+        "border/hud",
+        "border-hud"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.negative",
+      "figma": "color/border/negative",
+      "css": "--charcoal-color-border-negative",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-negative)",
+      "tailwind": {
+        "key": "ch-negative",
+        "recommended": [
+          "border-ch-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.negative",
+        "classCandidates": [
+          {
+            "className": "border-ch-negative",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.negative",
+      "notes": [],
+      "keys": [
+        "color.border.negative",
+        "color/border/negative",
+        "--charcoal-color-border-negative",
+        "charcoal-color-border-negative",
+        "border-ch-negative",
+        "color-border-negative",
+        "border/negative",
+        "border-negative"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.press",
+      "figma": "color/border/press",
+      "css": "--charcoal-color-border-press",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-press)",
+      "tailwind": {
+        "key": "ch-press",
+        "recommended": [
+          "border-ch-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.press",
+        "classCandidates": [
+          {
+            "className": "border-ch-press",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.border.press",
+        "color/border/press",
+        "--charcoal-color-border-press",
+        "charcoal-color-border-press",
+        "border-ch-press",
+        "color-border-press",
+        "border/press",
+        "border-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.press-text3",
+      "figma": "color/border/press-text3",
+      "css": "--charcoal-color-border-press-text3",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-press-text3)",
+      "tailwind": {
+        "key": "ch-press-text3",
+        "recommended": [
+          "border-ch-press-text3"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.press-text3",
+        "classCandidates": [
+          {
+            "className": "border-ch-press-text3",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.press-text3",
+      "notes": [],
+      "keys": [
+        "color.border.press-text3",
+        "color/border/press-text3",
+        "--charcoal-color-border-press-text3",
+        "charcoal-color-border-press-text3",
+        "border-ch-press-text3",
+        "color-border-press-text3",
+        "border/press-text3",
+        "border-press-text3"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.secondary",
+      "figma": "color/border/secondary",
+      "css": "--charcoal-color-border-secondary",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-secondary)",
+      "tailwind": {
+        "key": "ch-secondary",
+        "recommended": [
+          "border-ch-secondary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.secondary",
+        "classCandidates": [
+          {
+            "className": "border-ch-secondary",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.secondary",
+      "notes": [],
+      "keys": [
+        "color.border.secondary",
+        "color/border/secondary",
+        "--charcoal-color-border-secondary",
+        "charcoal-color-border-secondary",
+        "border-ch-secondary",
+        "color-border-secondary",
+        "border/secondary",
+        "border-secondary"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.selected",
+      "figma": "color/border/selected",
+      "css": "--charcoal-color-border-selected",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-selected)",
+      "tailwind": {
+        "key": "ch-selected",
+        "recommended": [
+          "border-ch-selected"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.selected",
+        "classCandidates": [
+          {
+            "className": "border-ch-selected",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border.selected",
+      "notes": [],
+      "keys": [
+        "color.border.selected",
+        "color/border/selected",
+        "--charcoal-color-border-selected",
+        "charcoal-color-border-selected",
+        "border-ch-selected",
+        "color-border-selected",
+        "border/selected",
+        "border-selected"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.border.default",
+      "figma": "color/border/default",
+      "css": "--charcoal-color-border-default",
+      "category": "borderColor",
+      "group": "border",
+      "cssUsage": "border-color: var(--charcoal-color-border-default)",
+      "tailwind": {
+        "key": "ch",
+        "recommended": [
+          "border-ch"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.border.default",
+        "classCandidates": [
+          {
+            "className": "border-ch",
+            "utility": "borderColor",
+            "cssProperties": [
+              "border-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.border",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.border.default",
+        "color/border/default",
+        "--charcoal-color-border-default",
+        "charcoal-color-border-default",
+        "border-ch",
+        "color-border-default",
+        "border/default",
+        "border-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.background.overlay",
+      "figma": "color/background/overlay",
+      "css": "--charcoal-color-background-overlay",
+      "category": "color",
+      "group": "background",
+      "cssUsage": "background-color: var(--charcoal-color-background-overlay)",
+      "tailwind": {
+        "key": "background-overlay",
+        "recommended": [
+          "bg-background-overlay"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.background.overlay",
+        "classCandidates": [
+          {
+            "className": "bg-background-overlay",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.background.overlay",
+      "notes": [],
+      "keys": [
+        "color.background.overlay",
+        "color/background/overlay",
+        "--charcoal-color-background-overlay",
+        "charcoal-color-background-overlay",
+        "bg-background-overlay",
+        "color-background-overlay",
+        "background/overlay",
+        "background-overlay"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.background.secondary",
+      "figma": "color/background/secondary",
+      "css": "--charcoal-color-background-secondary",
+      "category": "color",
+      "group": "background",
+      "cssUsage": "background-color: var(--charcoal-color-background-secondary)",
+      "tailwind": {
+        "key": "background-secondary",
+        "recommended": [
+          "bg-background-secondary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.background.secondary",
+        "classCandidates": [
+          {
+            "className": "bg-background-secondary",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.background.secondary",
+      "notes": [],
+      "keys": [
+        "color.background.secondary",
+        "color/background/secondary",
+        "--charcoal-color-background-secondary",
+        "charcoal-color-background-secondary",
+        "bg-background-secondary",
+        "color-background-secondary",
+        "background/secondary",
+        "background-secondary"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.background.tertiary",
+      "figma": "color/background/tertiary",
+      "css": "--charcoal-color-background-tertiary",
+      "category": "color",
+      "group": "background",
+      "cssUsage": "background-color: var(--charcoal-color-background-tertiary)",
+      "tailwind": {
+        "key": "background-tertiary",
+        "recommended": [
+          "bg-background-tertiary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.background.tertiary",
+        "classCandidates": [
+          {
+            "className": "bg-background-tertiary",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.background.tertiary",
+      "notes": [],
+      "keys": [
+        "color.background.tertiary",
+        "color/background/tertiary",
+        "--charcoal-color-background-tertiary",
+        "charcoal-color-background-tertiary",
+        "bg-background-tertiary",
+        "color-background-tertiary",
+        "background/tertiary",
+        "background-tertiary"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.background.default",
+      "figma": "color/background/default",
+      "css": "--charcoal-color-background-default",
+      "category": "color",
+      "group": "background",
+      "cssUsage": "background-color: var(--charcoal-color-background-default)",
+      "tailwind": {
+        "key": "background",
+        "recommended": [
+          "bg-background"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.background.default",
+        "classCandidates": [
+          {
+            "className": "bg-background",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.background",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.background.default",
+        "color/background/default",
+        "--charcoal-color-background-default",
+        "charcoal-color-background-default",
+        "bg-background",
+        "color-background-default",
+        "background/default",
+        "background-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.default-a",
+      "figma": "color/container/default-a",
+      "css": "--charcoal-color-container-default-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-default-a)",
+      "tailwind": {
+        "key": "container-default-a",
+        "recommended": [
+          "bg-container-default-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.default-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-default-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "default-a",
+      "notes": [],
+      "keys": [
+        "color.container.default-a",
+        "color/container/default-a",
+        "--charcoal-color-container-default-a",
+        "charcoal-color-container-default-a",
+        "bg-container-default-a",
+        "color-container-default-a",
+        "container/default-a",
+        "container-default-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.disable",
+      "figma": "color/container/disable",
+      "css": "--charcoal-color-container-disable",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-disable)",
+      "tailwind": {
+        "key": "container-disable",
+        "recommended": [
+          "bg-container-disable"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.disable",
+        "classCandidates": [
+          {
+            "className": "bg-container-disable",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "disable",
+      "notes": [],
+      "keys": [
+        "color.container.disable",
+        "color/container/disable",
+        "--charcoal-color-container-disable",
+        "charcoal-color-container-disable",
+        "bg-container-disable",
+        "color-container-disable",
+        "container/disable",
+        "container-disable"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.discovery.hover",
+      "figma": "color/container/discovery/hover",
+      "css": "--charcoal-color-container-discovery-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-discovery-hover)",
+      "tailwind": {
+        "key": "container-discovery-hover",
+        "recommended": [
+          "bg-container-discovery-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.discovery.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-discovery-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.discovery",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.discovery.hover",
+        "color/container/discovery/hover",
+        "--charcoal-color-container-discovery-hover",
+        "charcoal-color-container-discovery-hover",
+        "bg-container-discovery-hover",
+        "color-container-discovery-hover",
+        "container/discovery/hover",
+        "container-discovery-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.discovery.press",
+      "figma": "color/container/discovery/press",
+      "css": "--charcoal-color-container-discovery-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-discovery-press)",
+      "tailwind": {
+        "key": "container-discovery-press",
+        "recommended": [
+          "bg-container-discovery-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.discovery.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-discovery-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.discovery",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.discovery.press",
+        "color/container/discovery/press",
+        "--charcoal-color-container-discovery-press",
+        "charcoal-color-container-discovery-press",
+        "bg-container-discovery-press",
+        "color-container-discovery-press",
+        "container/discovery/press",
+        "container-discovery-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.discovery.default",
+      "figma": "color/container/discovery/default",
+      "css": "--charcoal-color-container-discovery-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-discovery-default)",
+      "tailwind": {
+        "key": "container-discovery",
+        "recommended": [
+          "bg-container-discovery"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.discovery.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-discovery",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.discovery",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.discovery.default",
+        "color/container/discovery/default",
+        "--charcoal-color-container-discovery-default",
+        "charcoal-color-container-discovery-default",
+        "bg-container-discovery",
+        "color-container-discovery-default",
+        "container/discovery/default",
+        "container-discovery-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.hover",
+      "figma": "color/container/hover",
+      "css": "--charcoal-color-container-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-hover)",
+      "tailwind": {
+        "key": "container-hover",
+        "recommended": [
+          "bg-container-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.hover",
+        "color/container/hover",
+        "--charcoal-color-container-hover",
+        "charcoal-color-container-hover",
+        "bg-container-hover",
+        "color-container-hover",
+        "container/hover",
+        "container-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.hover-a",
+      "figma": "color/container/hover-a",
+      "css": "--charcoal-color-container-hover-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-hover-a)",
+      "tailwind": {
+        "key": "container-hover-a",
+        "recommended": [
+          "bg-container-hover-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.hover-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-hover-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "hover-a",
+      "notes": [],
+      "keys": [
+        "color.container.hover-a",
+        "color/container/hover-a",
+        "--charcoal-color-container-hover-a",
+        "charcoal-color-container-hover-a",
+        "bg-container-hover-a",
+        "color-container-hover-a",
+        "container/hover-a",
+        "container-hover-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.hud.hover",
+      "figma": "color/container/hud/hover",
+      "css": "--charcoal-color-container-hud-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-hud-hover)",
+      "tailwind": {
+        "key": "container-hud-hover",
+        "recommended": [
+          "bg-container-hud-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.hud.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-hud-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.hud",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.hud.hover",
+        "color/container/hud/hover",
+        "--charcoal-color-container-hud-hover",
+        "charcoal-color-container-hud-hover",
+        "bg-container-hud-hover",
+        "color-container-hud-hover",
+        "container/hud/hover",
+        "container-hud-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.hud.press",
+      "figma": "color/container/hud/press",
+      "css": "--charcoal-color-container-hud-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-hud-press)",
+      "tailwind": {
+        "key": "container-hud-press",
+        "recommended": [
+          "bg-container-hud-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.hud.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-hud-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.hud",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.hud.press",
+        "color/container/hud/press",
+        "--charcoal-color-container-hud-press",
+        "charcoal-color-container-hud-press",
+        "bg-container-hud-press",
+        "color-container-hud-press",
+        "container/hud/press",
+        "container-hud-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.hud.default",
+      "figma": "color/container/hud/default",
+      "css": "--charcoal-color-container-hud-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-hud-default)",
+      "tailwind": {
+        "key": "container-hud",
+        "recommended": [
+          "bg-container-hud"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.hud.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-hud",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.hud",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.hud.default",
+        "color/container/hud/default",
+        "--charcoal-color-container-hud-default",
+        "charcoal-color-container-hud-default",
+        "bg-container-hud",
+        "color-container-hud-default",
+        "container/hud/default",
+        "container-hud-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.negative.hover",
+      "figma": "color/container/negative/hover",
+      "css": "--charcoal-color-container-negative-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-negative-hover)",
+      "tailwind": {
+        "key": "container-negative-hover",
+        "recommended": [
+          "bg-container-negative-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.negative.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-negative-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.negative",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.negative.hover",
+        "color/container/negative/hover",
+        "--charcoal-color-container-negative-hover",
+        "charcoal-color-container-negative-hover",
+        "bg-container-negative-hover",
+        "color-container-negative-hover",
+        "container/negative/hover",
+        "container-negative-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.negative.press",
+      "figma": "color/container/negative/press",
+      "css": "--charcoal-color-container-negative-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-negative-press)",
+      "tailwind": {
+        "key": "container-negative-press",
+        "recommended": [
+          "bg-container-negative-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.negative.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-negative-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.negative",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.negative.press",
+        "color/container/negative/press",
+        "--charcoal-color-container-negative-press",
+        "charcoal-color-container-negative-press",
+        "bg-container-negative-press",
+        "color-container-negative-press",
+        "container/negative/press",
+        "container-negative-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.negative.default",
+      "figma": "color/container/negative/default",
+      "css": "--charcoal-color-container-negative-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-negative-default)",
+      "tailwind": {
+        "key": "container-negative",
+        "recommended": [
+          "bg-container-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.negative.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-negative",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.negative",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.negative.default",
+        "color/container/negative/default",
+        "--charcoal-color-container-negative-default",
+        "charcoal-color-container-negative-default",
+        "bg-container-negative",
+        "color-container-negative-default",
+        "container/negative/default",
+        "container-negative-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.neutral.hover",
+      "figma": "color/container/neutral/hover",
+      "css": "--charcoal-color-container-neutral-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-neutral-hover)",
+      "tailwind": {
+        "key": "container-neutral-hover",
+        "recommended": [
+          "bg-container-neutral-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.neutral.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-neutral-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.neutral",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.neutral.hover",
+        "color/container/neutral/hover",
+        "--charcoal-color-container-neutral-hover",
+        "charcoal-color-container-neutral-hover",
+        "bg-container-neutral-hover",
+        "color-container-neutral-hover",
+        "container/neutral/hover",
+        "container-neutral-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.neutral.press",
+      "figma": "color/container/neutral/press",
+      "css": "--charcoal-color-container-neutral-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-neutral-press)",
+      "tailwind": {
+        "key": "container-neutral-press",
+        "recommended": [
+          "bg-container-neutral-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.neutral.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-neutral-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.neutral",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.neutral.press",
+        "color/container/neutral/press",
+        "--charcoal-color-container-neutral-press",
+        "charcoal-color-container-neutral-press",
+        "bg-container-neutral-press",
+        "color-container-neutral-press",
+        "container/neutral/press",
+        "container-neutral-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.neutral.default",
+      "figma": "color/container/neutral/default",
+      "css": "--charcoal-color-container-neutral-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-neutral-default)",
+      "tailwind": {
+        "key": "container-neutral",
+        "recommended": [
+          "bg-container-neutral"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.neutral.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-neutral",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.neutral",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.neutral.default",
+        "color/container/neutral/default",
+        "--charcoal-color-container-neutral-default",
+        "charcoal-color-container-neutral-default",
+        "bg-container-neutral",
+        "color-container-neutral-default",
+        "container/neutral/default",
+        "container-neutral-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.notice.hover",
+      "figma": "color/container/notice/hover",
+      "css": "--charcoal-color-container-notice-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-notice-hover)",
+      "tailwind": {
+        "key": "container-notice-hover",
+        "recommended": [
+          "bg-container-notice-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.notice.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-notice-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.notice",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.notice.hover",
+        "color/container/notice/hover",
+        "--charcoal-color-container-notice-hover",
+        "charcoal-color-container-notice-hover",
+        "bg-container-notice-hover",
+        "color-container-notice-hover",
+        "container/notice/hover",
+        "container-notice-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.notice.press",
+      "figma": "color/container/notice/press",
+      "css": "--charcoal-color-container-notice-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-notice-press)",
+      "tailwind": {
+        "key": "container-notice-press",
+        "recommended": [
+          "bg-container-notice-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.notice.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-notice-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.notice",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.notice.press",
+        "color/container/notice/press",
+        "--charcoal-color-container-notice-press",
+        "charcoal-color-container-notice-press",
+        "bg-container-notice-press",
+        "color-container-notice-press",
+        "container/notice/press",
+        "container-notice-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.notice.default",
+      "figma": "color/container/notice/default",
+      "css": "--charcoal-color-container-notice-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-notice-default)",
+      "tailwind": {
+        "key": "container-notice",
+        "recommended": [
+          "bg-container-notice"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.notice.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-notice",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.notice",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.notice.default",
+        "color/container/notice/default",
+        "--charcoal-color-container-notice-default",
+        "charcoal-color-container-notice-default",
+        "bg-container-notice",
+        "color-container-notice-default",
+        "container/notice/default",
+        "container-notice-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.on-img.hover",
+      "figma": "color/container/on-img/hover",
+      "css": "--charcoal-color-container-on-img-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-on-img-hover)",
+      "tailwind": {
+        "key": "container-on-img-hover",
+        "recommended": [
+          "bg-container-on-img-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.on-img.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-on-img-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.on-img",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.on-img.hover",
+        "color/container/on-img/hover",
+        "--charcoal-color-container-on-img-hover",
+        "charcoal-color-container-on-img-hover",
+        "bg-container-on-img-hover",
+        "color-container-on-img-hover",
+        "container/on-img/hover",
+        "container-on-img-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.on-img.press",
+      "figma": "color/container/on-img/press",
+      "css": "--charcoal-color-container-on-img-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-on-img-press)",
+      "tailwind": {
+        "key": "container-on-img-press",
+        "recommended": [
+          "bg-container-on-img-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.on-img.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-on-img-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.on-img",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.on-img.press",
+        "color/container/on-img/press",
+        "--charcoal-color-container-on-img-press",
+        "charcoal-color-container-on-img-press",
+        "bg-container-on-img-press",
+        "color-container-on-img-press",
+        "container/on-img/press",
+        "container-on-img-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.on-img.default",
+      "figma": "color/container/on-img/default",
+      "css": "--charcoal-color-container-on-img-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-on-img-default)",
+      "tailwind": {
+        "key": "container-on-img",
+        "recommended": [
+          "bg-container-on-img"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.on-img.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-on-img",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.on-img",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.on-img.default",
+        "color/container/on-img/default",
+        "--charcoal-color-container-on-img-default",
+        "charcoal-color-container-on-img-default",
+        "bg-container-on-img",
+        "color-container-on-img-default",
+        "container/on-img/default",
+        "container-on-img-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.positive.hover",
+      "figma": "color/container/positive/hover",
+      "css": "--charcoal-color-container-positive-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-positive-hover)",
+      "tailwind": {
+        "key": "container-positive-hover",
+        "recommended": [
+          "bg-container-positive-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.positive.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-positive-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.positive",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.positive.hover",
+        "color/container/positive/hover",
+        "--charcoal-color-container-positive-hover",
+        "charcoal-color-container-positive-hover",
+        "bg-container-positive-hover",
+        "color-container-positive-hover",
+        "container/positive/hover",
+        "container-positive-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.positive.press",
+      "figma": "color/container/positive/press",
+      "css": "--charcoal-color-container-positive-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-positive-press)",
+      "tailwind": {
+        "key": "container-positive-press",
+        "recommended": [
+          "bg-container-positive-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.positive.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-positive-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.positive",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.positive.press",
+        "color/container/positive/press",
+        "--charcoal-color-container-positive-press",
+        "charcoal-color-container-positive-press",
+        "bg-container-positive-press",
+        "color-container-positive-press",
+        "container/positive/press",
+        "container-positive-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.positive.default",
+      "figma": "color/container/positive/default",
+      "css": "--charcoal-color-container-positive-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-positive-default)",
+      "tailwind": {
+        "key": "container-positive",
+        "recommended": [
+          "bg-container-positive"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.positive.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-positive",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.positive",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.positive.default",
+        "color/container/positive/default",
+        "--charcoal-color-container-positive-default",
+        "charcoal-color-container-positive-default",
+        "bg-container-positive",
+        "color-container-positive-default",
+        "container/positive/default",
+        "container-positive-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.press",
+      "figma": "color/container/press",
+      "css": "--charcoal-color-container-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-press)",
+      "tailwind": {
+        "key": "container-press",
+        "recommended": [
+          "bg-container-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.press",
+        "color/container/press",
+        "--charcoal-color-container-press",
+        "charcoal-color-container-press",
+        "bg-container-press",
+        "color-container-press",
+        "container/press",
+        "container-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.press-a",
+      "figma": "color/container/press-a",
+      "css": "--charcoal-color-container-press-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-press-a)",
+      "tailwind": {
+        "key": "container-press-a",
+        "recommended": [
+          "bg-container-press-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.press-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-press-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "press-a",
+      "notes": [],
+      "keys": [
+        "color.container.press-a",
+        "color/container/press-a",
+        "--charcoal-color-container-press-a",
+        "charcoal-color-container-press-a",
+        "bg-container-press-a",
+        "color-container-press-a",
+        "container/press-a",
+        "container-press-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.primary.hover",
+      "figma": "color/container/primary/hover",
+      "css": "--charcoal-color-container-primary-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-primary-hover)",
+      "tailwind": {
+        "key": "container-primary-hover",
+        "recommended": [
+          "bg-container-primary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.primary.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-primary-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.primary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.primary.hover",
+        "color/container/primary/hover",
+        "--charcoal-color-container-primary-hover",
+        "charcoal-color-container-primary-hover",
+        "bg-container-primary-hover",
+        "color-container-primary-hover",
+        "container/primary/hover",
+        "container-primary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.primary.press",
+      "figma": "color/container/primary/press",
+      "css": "--charcoal-color-container-primary-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-primary-press)",
+      "tailwind": {
+        "key": "container-primary-press",
+        "recommended": [
+          "bg-container-primary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.primary.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-primary-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.primary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.primary.press",
+        "color/container/primary/press",
+        "--charcoal-color-container-primary-press",
+        "charcoal-color-container-primary-press",
+        "bg-container-primary-press",
+        "color-container-primary-press",
+        "container/primary/press",
+        "container-primary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.primary.default",
+      "figma": "color/container/primary/default",
+      "css": "--charcoal-color-container-primary-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-primary-default)",
+      "tailwind": {
+        "key": "container-primary",
+        "recommended": [
+          "bg-container-primary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.primary.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-primary",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.primary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.primary.default",
+        "color/container/primary/default",
+        "--charcoal-color-container-primary-default",
+        "charcoal-color-container-primary-default",
+        "bg-container-primary",
+        "color-container-primary-default",
+        "container/primary/default",
+        "container-primary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.default-a",
+      "figma": "color/container/secondary/default-a",
+      "css": "--charcoal-color-container-secondary-default-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-default-a)",
+      "tailwind": {
+        "key": "container-secondary-default-a",
+        "recommended": [
+          "bg-container-secondary-default-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.default-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary-default-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "default-a",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.default-a",
+        "color/container/secondary/default-a",
+        "--charcoal-color-container-secondary-default-a",
+        "charcoal-color-container-secondary-default-a",
+        "bg-container-secondary-default-a",
+        "color-container-secondary-default-a",
+        "container/secondary/default-a",
+        "container-secondary-default-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.hover",
+      "figma": "color/container/secondary/hover",
+      "css": "--charcoal-color-container-secondary-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-hover)",
+      "tailwind": {
+        "key": "container-secondary-hover",
+        "recommended": [
+          "bg-container-secondary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.hover",
+        "color/container/secondary/hover",
+        "--charcoal-color-container-secondary-hover",
+        "charcoal-color-container-secondary-hover",
+        "bg-container-secondary-hover",
+        "color-container-secondary-hover",
+        "container/secondary/hover",
+        "container-secondary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.hover-a",
+      "figma": "color/container/secondary/hover-a",
+      "css": "--charcoal-color-container-secondary-hover-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-hover-a)",
+      "tailwind": {
+        "key": "container-secondary-hover-a",
+        "recommended": [
+          "bg-container-secondary-hover-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.hover-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary-hover-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "hover-a",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.hover-a",
+        "color/container/secondary/hover-a",
+        "--charcoal-color-container-secondary-hover-a",
+        "charcoal-color-container-secondary-hover-a",
+        "bg-container-secondary-hover-a",
+        "color-container-secondary-hover-a",
+        "container/secondary/hover-a",
+        "container-secondary-hover-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.press",
+      "figma": "color/container/secondary/press",
+      "css": "--charcoal-color-container-secondary-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-press)",
+      "tailwind": {
+        "key": "container-secondary-press",
+        "recommended": [
+          "bg-container-secondary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.press",
+        "color/container/secondary/press",
+        "--charcoal-color-container-secondary-press",
+        "charcoal-color-container-secondary-press",
+        "bg-container-secondary-press",
+        "color-container-secondary-press",
+        "container/secondary/press",
+        "container-secondary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.press-a",
+      "figma": "color/container/secondary/press-a",
+      "css": "--charcoal-color-container-secondary-press-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-press-a)",
+      "tailwind": {
+        "key": "container-secondary-press-a",
+        "recommended": [
+          "bg-container-secondary-press-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.press-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary-press-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "press-a",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.press-a",
+        "color/container/secondary/press-a",
+        "--charcoal-color-container-secondary-press-a",
+        "charcoal-color-container-secondary-press-a",
+        "bg-container-secondary-press-a",
+        "color-container-secondary-press-a",
+        "container/secondary/press-a",
+        "container-secondary-press-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.secondary.default",
+      "figma": "color/container/secondary/default",
+      "css": "--charcoal-color-container-secondary-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-secondary-default)",
+      "tailwind": {
+        "key": "container-secondary",
+        "recommended": [
+          "bg-container-secondary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.secondary.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-secondary",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.secondary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.secondary.default",
+        "color/container/secondary/default",
+        "--charcoal-color-container-secondary-default",
+        "charcoal-color-container-secondary-default",
+        "bg-container-secondary",
+        "color-container-secondary-default",
+        "container/secondary/default",
+        "container-secondary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.skeleton",
+      "figma": "color/container/skeleton",
+      "css": "--charcoal-color-container-skeleton",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-skeleton)",
+      "tailwind": {
+        "key": "container-skeleton",
+        "recommended": [
+          "bg-container-skeleton"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.skeleton",
+        "classCandidates": [
+          {
+            "className": "bg-container-skeleton",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.skeleton",
+      "notes": [],
+      "keys": [
+        "color.container.skeleton",
+        "color/container/skeleton",
+        "--charcoal-color-container-skeleton",
+        "charcoal-color-container-skeleton",
+        "bg-container-skeleton",
+        "color-container-skeleton",
+        "container/skeleton",
+        "container-skeleton"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.subtle",
+      "figma": "color/container/subtle",
+      "css": "--charcoal-color-container-subtle",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-subtle)",
+      "tailwind": {
+        "key": "container-subtle",
+        "recommended": [
+          "bg-container-subtle"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.subtle",
+        "classCandidates": [
+          {
+            "className": "bg-container-subtle",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.subtle",
+      "notes": [],
+      "keys": [
+        "color.container.subtle",
+        "color/container/subtle",
+        "--charcoal-color-container-subtle",
+        "charcoal-color-container-subtle",
+        "bg-container-subtle",
+        "color-container-subtle",
+        "container/subtle",
+        "container-subtle"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.default-a",
+      "figma": "color/container/tertiary/default-a",
+      "css": "--charcoal-color-container-tertiary-default-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-default-a)",
+      "tailwind": {
+        "key": "container-tertiary-default-a",
+        "recommended": [
+          "bg-container-tertiary-default-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.default-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary-default-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "default-a",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.default-a",
+        "color/container/tertiary/default-a",
+        "--charcoal-color-container-tertiary-default-a",
+        "charcoal-color-container-tertiary-default-a",
+        "bg-container-tertiary-default-a",
+        "color-container-tertiary-default-a",
+        "container/tertiary/default-a",
+        "container-tertiary-default-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.hover",
+      "figma": "color/container/tertiary/hover",
+      "css": "--charcoal-color-container-tertiary-hover",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-hover)",
+      "tailwind": {
+        "key": "container-tertiary-hover",
+        "recommended": [
+          "bg-container-tertiary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.hover",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary-hover",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.hover",
+        "color/container/tertiary/hover",
+        "--charcoal-color-container-tertiary-hover",
+        "charcoal-color-container-tertiary-hover",
+        "bg-container-tertiary-hover",
+        "color-container-tertiary-hover",
+        "container/tertiary/hover",
+        "container-tertiary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.hover-a",
+      "figma": "color/container/tertiary/hover-a",
+      "css": "--charcoal-color-container-tertiary-hover-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-hover-a)",
+      "tailwind": {
+        "key": "container-tertiary-hover-a",
+        "recommended": [
+          "bg-container-tertiary-hover-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.hover-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary-hover-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "hover-a",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.hover-a",
+        "color/container/tertiary/hover-a",
+        "--charcoal-color-container-tertiary-hover-a",
+        "charcoal-color-container-tertiary-hover-a",
+        "bg-container-tertiary-hover-a",
+        "color-container-tertiary-hover-a",
+        "container/tertiary/hover-a",
+        "container-tertiary-hover-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.press",
+      "figma": "color/container/tertiary/press",
+      "css": "--charcoal-color-container-tertiary-press",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-press)",
+      "tailwind": {
+        "key": "container-tertiary-press",
+        "recommended": [
+          "bg-container-tertiary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.press",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary-press",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.press",
+        "color/container/tertiary/press",
+        "--charcoal-color-container-tertiary-press",
+        "charcoal-color-container-tertiary-press",
+        "bg-container-tertiary-press",
+        "color-container-tertiary-press",
+        "container/tertiary/press",
+        "container-tertiary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.press-a",
+      "figma": "color/container/tertiary/press-a",
+      "css": "--charcoal-color-container-tertiary-press-a",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-press-a)",
+      "tailwind": {
+        "key": "container-tertiary-press-a",
+        "recommended": [
+          "bg-container-tertiary-press-a"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.press-a",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary-press-a",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "press-a",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.press-a",
+        "color/container/tertiary/press-a",
+        "--charcoal-color-container-tertiary-press-a",
+        "charcoal-color-container-tertiary-press-a",
+        "bg-container-tertiary-press-a",
+        "color-container-tertiary-press-a",
+        "container/tertiary/press-a",
+        "container-tertiary-press-a"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.tertiary.default",
+      "figma": "color/container/tertiary/default",
+      "css": "--charcoal-color-container-tertiary-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-tertiary-default)",
+      "tailwind": {
+        "key": "container-tertiary",
+        "recommended": [
+          "bg-container-tertiary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.tertiary.default",
+        "classCandidates": [
+          {
+            "className": "bg-container-tertiary",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container.tertiary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.tertiary.default",
+        "color/container/tertiary/default",
+        "--charcoal-color-container-tertiary-default",
+        "charcoal-color-container-tertiary-default",
+        "bg-container-tertiary",
+        "color-container-tertiary-default",
+        "container/tertiary/default",
+        "container-tertiary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.container.default",
+      "figma": "color/container/default",
+      "css": "--charcoal-color-container-default",
+      "category": "color",
+      "group": "container",
+      "cssUsage": "background-color: var(--charcoal-color-container-default)",
+      "tailwind": {
+        "key": "container",
+        "recommended": [
+          "bg-container"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.container.default",
+        "classCandidates": [
+          {
+            "className": "bg-container",
+            "utility": "backgroundColor",
+            "cssProperties": [
+              "background-color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.container",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.container.default",
+        "color/container/default",
+        "--charcoal-color-container-default",
+        "charcoal-color-container-default",
+        "bg-container",
+        "color-container-default",
+        "container/default",
+        "container-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.disable",
+      "figma": "color/icon/disable",
+      "css": "--charcoal-color-icon-disable",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-disable); fill: var(--charcoal-color-icon-disable); stroke: var(--charcoal-color-icon-disable)",
+      "tailwind": {
+        "key": "icon-disable",
+        "recommended": [
+          "text-icon-disable",
+          "fill-icon-disable",
+          "stroke-icon-disable"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.disable",
+        "classCandidates": [
+          {
+            "className": "text-icon-disable",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-disable",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-disable",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon",
+      "state": "disable",
+      "notes": [],
+      "keys": [
+        "color.icon.disable",
+        "color/icon/disable",
+        "--charcoal-color-icon-disable",
+        "charcoal-color-icon-disable",
+        "text-icon-disable",
+        "fill-icon-disable",
+        "stroke-icon-disable",
+        "color-icon-disable",
+        "icon/disable",
+        "icon-disable"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.hover",
+      "figma": "color/icon/hover",
+      "css": "--charcoal-color-icon-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-hover); fill: var(--charcoal-color-icon-hover); stroke: var(--charcoal-color-icon-hover)",
+      "tailwind": {
+        "key": "icon-hover",
+        "recommended": [
+          "text-icon-hover",
+          "fill-icon-hover",
+          "stroke-icon-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.hover",
+        "color/icon/hover",
+        "--charcoal-color-icon-hover",
+        "charcoal-color-icon-hover",
+        "text-icon-hover",
+        "fill-icon-hover",
+        "stroke-icon-hover",
+        "color-icon-hover",
+        "icon/hover",
+        "icon-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.negative.hover",
+      "figma": "color/icon/negative/hover",
+      "css": "--charcoal-color-icon-negative-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-negative-hover); fill: var(--charcoal-color-icon-negative-hover); stroke: var(--charcoal-color-icon-negative-hover)",
+      "tailwind": {
+        "key": "icon-negative-hover",
+        "recommended": [
+          "text-icon-negative-hover",
+          "fill-icon-negative-hover",
+          "stroke-icon-negative-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.negative.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-negative-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-negative-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-negative-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.negative",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.negative.hover",
+        "color/icon/negative/hover",
+        "--charcoal-color-icon-negative-hover",
+        "charcoal-color-icon-negative-hover",
+        "text-icon-negative-hover",
+        "fill-icon-negative-hover",
+        "stroke-icon-negative-hover",
+        "color-icon-negative-hover",
+        "icon/negative/hover",
+        "icon-negative-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.negative.press",
+      "figma": "color/icon/negative/press",
+      "css": "--charcoal-color-icon-negative-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-negative-press); fill: var(--charcoal-color-icon-negative-press); stroke: var(--charcoal-color-icon-negative-press)",
+      "tailwind": {
+        "key": "icon-negative-press",
+        "recommended": [
+          "text-icon-negative-press",
+          "fill-icon-negative-press",
+          "stroke-icon-negative-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.negative.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-negative-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-negative-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-negative-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.negative",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.negative.press",
+        "color/icon/negative/press",
+        "--charcoal-color-icon-negative-press",
+        "charcoal-color-icon-negative-press",
+        "text-icon-negative-press",
+        "fill-icon-negative-press",
+        "stroke-icon-negative-press",
+        "color-icon-negative-press",
+        "icon/negative/press",
+        "icon-negative-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.negative.default",
+      "figma": "color/icon/negative/default",
+      "css": "--charcoal-color-icon-negative-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-negative-default); fill: var(--charcoal-color-icon-negative-default); stroke: var(--charcoal-color-icon-negative-default)",
+      "tailwind": {
+        "key": "icon-negative",
+        "recommended": [
+          "text-icon-negative",
+          "fill-icon-negative",
+          "stroke-icon-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.negative.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-negative",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-negative",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-negative",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.negative",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.negative.default",
+        "color/icon/negative/default",
+        "--charcoal-color-icon-negative-default",
+        "charcoal-color-icon-negative-default",
+        "text-icon-negative",
+        "fill-icon-negative",
+        "stroke-icon-negative",
+        "color-icon-negative-default",
+        "icon/negative/default",
+        "icon-negative-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.notice.hover",
+      "figma": "color/icon/notice/hover",
+      "css": "--charcoal-color-icon-notice-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-notice-hover); fill: var(--charcoal-color-icon-notice-hover); stroke: var(--charcoal-color-icon-notice-hover)",
+      "tailwind": {
+        "key": "icon-notice-hover",
+        "recommended": [
+          "text-icon-notice-hover",
+          "fill-icon-notice-hover",
+          "stroke-icon-notice-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.notice.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-notice-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-notice-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-notice-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.notice",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.notice.hover",
+        "color/icon/notice/hover",
+        "--charcoal-color-icon-notice-hover",
+        "charcoal-color-icon-notice-hover",
+        "text-icon-notice-hover",
+        "fill-icon-notice-hover",
+        "stroke-icon-notice-hover",
+        "color-icon-notice-hover",
+        "icon/notice/hover",
+        "icon-notice-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.notice.press",
+      "figma": "color/icon/notice/press",
+      "css": "--charcoal-color-icon-notice-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-notice-press); fill: var(--charcoal-color-icon-notice-press); stroke: var(--charcoal-color-icon-notice-press)",
+      "tailwind": {
+        "key": "icon-notice-press",
+        "recommended": [
+          "text-icon-notice-press",
+          "fill-icon-notice-press",
+          "stroke-icon-notice-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.notice.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-notice-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-notice-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-notice-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.notice",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.notice.press",
+        "color/icon/notice/press",
+        "--charcoal-color-icon-notice-press",
+        "charcoal-color-icon-notice-press",
+        "text-icon-notice-press",
+        "fill-icon-notice-press",
+        "stroke-icon-notice-press",
+        "color-icon-notice-press",
+        "icon/notice/press",
+        "icon-notice-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.notice.default",
+      "figma": "color/icon/notice/default",
+      "css": "--charcoal-color-icon-notice-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-notice-default); fill: var(--charcoal-color-icon-notice-default); stroke: var(--charcoal-color-icon-notice-default)",
+      "tailwind": {
+        "key": "icon-notice",
+        "recommended": [
+          "text-icon-notice",
+          "fill-icon-notice",
+          "stroke-icon-notice"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.notice.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-notice",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-notice",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-notice",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.notice",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.notice.default",
+        "color/icon/notice/default",
+        "--charcoal-color-icon-notice-default",
+        "charcoal-color-icon-notice-default",
+        "text-icon-notice",
+        "fill-icon-notice",
+        "stroke-icon-notice",
+        "color-icon-notice-default",
+        "icon/notice/default",
+        "icon-notice-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-negative.hover",
+      "figma": "color/icon/on-negative/hover",
+      "css": "--charcoal-color-icon-on-negative-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-negative-hover); fill: var(--charcoal-color-icon-on-negative-hover); stroke: var(--charcoal-color-icon-on-negative-hover)",
+      "tailwind": {
+        "key": "icon-on-negative-hover",
+        "recommended": [
+          "text-icon-on-negative-hover",
+          "fill-icon-on-negative-hover",
+          "stroke-icon-on-negative-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-negative.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-negative-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-negative-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-negative-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-negative",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-negative.hover",
+        "color/icon/on-negative/hover",
+        "--charcoal-color-icon-on-negative-hover",
+        "charcoal-color-icon-on-negative-hover",
+        "text-icon-on-negative-hover",
+        "fill-icon-on-negative-hover",
+        "stroke-icon-on-negative-hover",
+        "color-icon-on-negative-hover",
+        "icon/on-negative/hover",
+        "icon-on-negative-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-negative.press",
+      "figma": "color/icon/on-negative/press",
+      "css": "--charcoal-color-icon-on-negative-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-negative-press); fill: var(--charcoal-color-icon-on-negative-press); stroke: var(--charcoal-color-icon-on-negative-press)",
+      "tailwind": {
+        "key": "icon-on-negative-press",
+        "recommended": [
+          "text-icon-on-negative-press",
+          "fill-icon-on-negative-press",
+          "stroke-icon-on-negative-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-negative.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-negative-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-negative-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-negative-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-negative",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-negative.press",
+        "color/icon/on-negative/press",
+        "--charcoal-color-icon-on-negative-press",
+        "charcoal-color-icon-on-negative-press",
+        "text-icon-on-negative-press",
+        "fill-icon-on-negative-press",
+        "stroke-icon-on-negative-press",
+        "color-icon-on-negative-press",
+        "icon/on-negative/press",
+        "icon-on-negative-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-negative.default",
+      "figma": "color/icon/on-negative/default",
+      "css": "--charcoal-color-icon-on-negative-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-negative-default); fill: var(--charcoal-color-icon-on-negative-default); stroke: var(--charcoal-color-icon-on-negative-default)",
+      "tailwind": {
+        "key": "icon-on-negative",
+        "recommended": [
+          "text-icon-on-negative",
+          "fill-icon-on-negative",
+          "stroke-icon-on-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-negative.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-negative",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-negative",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-negative",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-negative",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-negative.default",
+        "color/icon/on-negative/default",
+        "--charcoal-color-icon-on-negative-default",
+        "charcoal-color-icon-on-negative-default",
+        "text-icon-on-negative",
+        "fill-icon-on-negative",
+        "stroke-icon-on-negative",
+        "color-icon-on-negative-default",
+        "icon/on-negative/default",
+        "icon-on-negative-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-neutral.hover",
+      "figma": "color/icon/on-neutral/hover",
+      "css": "--charcoal-color-icon-on-neutral-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-neutral-hover); fill: var(--charcoal-color-icon-on-neutral-hover); stroke: var(--charcoal-color-icon-on-neutral-hover)",
+      "tailwind": {
+        "key": "icon-on-neutral-hover",
+        "recommended": [
+          "text-icon-on-neutral-hover",
+          "fill-icon-on-neutral-hover",
+          "stroke-icon-on-neutral-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-neutral.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-neutral-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-neutral-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-neutral-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-neutral",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-neutral.hover",
+        "color/icon/on-neutral/hover",
+        "--charcoal-color-icon-on-neutral-hover",
+        "charcoal-color-icon-on-neutral-hover",
+        "text-icon-on-neutral-hover",
+        "fill-icon-on-neutral-hover",
+        "stroke-icon-on-neutral-hover",
+        "color-icon-on-neutral-hover",
+        "icon/on-neutral/hover",
+        "icon-on-neutral-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-neutral.press",
+      "figma": "color/icon/on-neutral/press",
+      "css": "--charcoal-color-icon-on-neutral-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-neutral-press); fill: var(--charcoal-color-icon-on-neutral-press); stroke: var(--charcoal-color-icon-on-neutral-press)",
+      "tailwind": {
+        "key": "icon-on-neutral-press",
+        "recommended": [
+          "text-icon-on-neutral-press",
+          "fill-icon-on-neutral-press",
+          "stroke-icon-on-neutral-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-neutral.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-neutral-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-neutral-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-neutral-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-neutral",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-neutral.press",
+        "color/icon/on-neutral/press",
+        "--charcoal-color-icon-on-neutral-press",
+        "charcoal-color-icon-on-neutral-press",
+        "text-icon-on-neutral-press",
+        "fill-icon-on-neutral-press",
+        "stroke-icon-on-neutral-press",
+        "color-icon-on-neutral-press",
+        "icon/on-neutral/press",
+        "icon-on-neutral-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-neutral.default",
+      "figma": "color/icon/on-neutral/default",
+      "css": "--charcoal-color-icon-on-neutral-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-neutral-default); fill: var(--charcoal-color-icon-on-neutral-default); stroke: var(--charcoal-color-icon-on-neutral-default)",
+      "tailwind": {
+        "key": "icon-on-neutral",
+        "recommended": [
+          "text-icon-on-neutral",
+          "fill-icon-on-neutral",
+          "stroke-icon-on-neutral"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-neutral.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-neutral",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-neutral",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-neutral",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-neutral",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-neutral.default",
+        "color/icon/on-neutral/default",
+        "--charcoal-color-icon-on-neutral-default",
+        "charcoal-color-icon-on-neutral-default",
+        "text-icon-on-neutral",
+        "fill-icon-on-neutral",
+        "stroke-icon-on-neutral",
+        "color-icon-on-neutral-default",
+        "icon/on-neutral/default",
+        "icon-on-neutral-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-notice.hover",
+      "figma": "color/icon/on-notice/hover",
+      "css": "--charcoal-color-icon-on-notice-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-notice-hover); fill: var(--charcoal-color-icon-on-notice-hover); stroke: var(--charcoal-color-icon-on-notice-hover)",
+      "tailwind": {
+        "key": "icon-on-notice-hover",
+        "recommended": [
+          "text-icon-on-notice-hover",
+          "fill-icon-on-notice-hover",
+          "stroke-icon-on-notice-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-notice.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-notice-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-notice-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-notice-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-notice",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-notice.hover",
+        "color/icon/on-notice/hover",
+        "--charcoal-color-icon-on-notice-hover",
+        "charcoal-color-icon-on-notice-hover",
+        "text-icon-on-notice-hover",
+        "fill-icon-on-notice-hover",
+        "stroke-icon-on-notice-hover",
+        "color-icon-on-notice-hover",
+        "icon/on-notice/hover",
+        "icon-on-notice-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-notice.press",
+      "figma": "color/icon/on-notice/press",
+      "css": "--charcoal-color-icon-on-notice-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-notice-press); fill: var(--charcoal-color-icon-on-notice-press); stroke: var(--charcoal-color-icon-on-notice-press)",
+      "tailwind": {
+        "key": "icon-on-notice-press",
+        "recommended": [
+          "text-icon-on-notice-press",
+          "fill-icon-on-notice-press",
+          "stroke-icon-on-notice-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-notice.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-notice-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-notice-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-notice-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-notice",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-notice.press",
+        "color/icon/on-notice/press",
+        "--charcoal-color-icon-on-notice-press",
+        "charcoal-color-icon-on-notice-press",
+        "text-icon-on-notice-press",
+        "fill-icon-on-notice-press",
+        "stroke-icon-on-notice-press",
+        "color-icon-on-notice-press",
+        "icon/on-notice/press",
+        "icon-on-notice-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-notice.default",
+      "figma": "color/icon/on-notice/default",
+      "css": "--charcoal-color-icon-on-notice-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-notice-default); fill: var(--charcoal-color-icon-on-notice-default); stroke: var(--charcoal-color-icon-on-notice-default)",
+      "tailwind": {
+        "key": "icon-on-notice",
+        "recommended": [
+          "text-icon-on-notice",
+          "fill-icon-on-notice",
+          "stroke-icon-on-notice"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-notice.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-notice",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-notice",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-notice",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-notice",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-notice.default",
+        "color/icon/on-notice/default",
+        "--charcoal-color-icon-on-notice-default",
+        "charcoal-color-icon-on-notice-default",
+        "text-icon-on-notice",
+        "fill-icon-on-notice",
+        "stroke-icon-on-notice",
+        "color-icon-on-notice-default",
+        "icon/on-notice/default",
+        "icon-on-notice-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-on-img.hover",
+      "figma": "color/icon/on-on-img/hover",
+      "css": "--charcoal-color-icon-on-on-img-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-on-img-hover); fill: var(--charcoal-color-icon-on-on-img-hover); stroke: var(--charcoal-color-icon-on-on-img-hover)",
+      "tailwind": {
+        "key": "icon-on-on-img-hover",
+        "recommended": [
+          "text-icon-on-on-img-hover",
+          "fill-icon-on-on-img-hover",
+          "stroke-icon-on-on-img-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-on-img.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-on-img-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-on-img-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-on-img-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-on-img",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-on-img.hover",
+        "color/icon/on-on-img/hover",
+        "--charcoal-color-icon-on-on-img-hover",
+        "charcoal-color-icon-on-on-img-hover",
+        "text-icon-on-on-img-hover",
+        "fill-icon-on-on-img-hover",
+        "stroke-icon-on-on-img-hover",
+        "color-icon-on-on-img-hover",
+        "icon/on-on-img/hover",
+        "icon-on-on-img-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-on-img.press",
+      "figma": "color/icon/on-on-img/press",
+      "css": "--charcoal-color-icon-on-on-img-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-on-img-press); fill: var(--charcoal-color-icon-on-on-img-press); stroke: var(--charcoal-color-icon-on-on-img-press)",
+      "tailwind": {
+        "key": "icon-on-on-img-press",
+        "recommended": [
+          "text-icon-on-on-img-press",
+          "fill-icon-on-on-img-press",
+          "stroke-icon-on-on-img-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-on-img.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-on-img-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-on-img-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-on-img-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-on-img",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-on-img.press",
+        "color/icon/on-on-img/press",
+        "--charcoal-color-icon-on-on-img-press",
+        "charcoal-color-icon-on-on-img-press",
+        "text-icon-on-on-img-press",
+        "fill-icon-on-on-img-press",
+        "stroke-icon-on-on-img-press",
+        "color-icon-on-on-img-press",
+        "icon/on-on-img/press",
+        "icon-on-on-img-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-on-img.default",
+      "figma": "color/icon/on-on-img/default",
+      "css": "--charcoal-color-icon-on-on-img-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-on-img-default); fill: var(--charcoal-color-icon-on-on-img-default); stroke: var(--charcoal-color-icon-on-on-img-default)",
+      "tailwind": {
+        "key": "icon-on-on-img",
+        "recommended": [
+          "text-icon-on-on-img",
+          "fill-icon-on-on-img",
+          "stroke-icon-on-on-img"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-on-img.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-on-img",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-on-img",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-on-img",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-on-img",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-on-img.default",
+        "color/icon/on-on-img/default",
+        "--charcoal-color-icon-on-on-img-default",
+        "charcoal-color-icon-on-on-img-default",
+        "text-icon-on-on-img",
+        "fill-icon-on-on-img",
+        "stroke-icon-on-on-img",
+        "color-icon-on-on-img-default",
+        "icon/on-on-img/default",
+        "icon-on-on-img-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-positive.hover",
+      "figma": "color/icon/on-positive/hover",
+      "css": "--charcoal-color-icon-on-positive-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-positive-hover); fill: var(--charcoal-color-icon-on-positive-hover); stroke: var(--charcoal-color-icon-on-positive-hover)",
+      "tailwind": {
+        "key": "icon-on-positive-hover",
+        "recommended": [
+          "text-icon-on-positive-hover",
+          "fill-icon-on-positive-hover",
+          "stroke-icon-on-positive-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-positive.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-positive-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-positive-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-positive-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-positive",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-positive.hover",
+        "color/icon/on-positive/hover",
+        "--charcoal-color-icon-on-positive-hover",
+        "charcoal-color-icon-on-positive-hover",
+        "text-icon-on-positive-hover",
+        "fill-icon-on-positive-hover",
+        "stroke-icon-on-positive-hover",
+        "color-icon-on-positive-hover",
+        "icon/on-positive/hover",
+        "icon-on-positive-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-positive.press",
+      "figma": "color/icon/on-positive/press",
+      "css": "--charcoal-color-icon-on-positive-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-positive-press); fill: var(--charcoal-color-icon-on-positive-press); stroke: var(--charcoal-color-icon-on-positive-press)",
+      "tailwind": {
+        "key": "icon-on-positive-press",
+        "recommended": [
+          "text-icon-on-positive-press",
+          "fill-icon-on-positive-press",
+          "stroke-icon-on-positive-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-positive.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-positive-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-positive-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-positive-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-positive",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-positive.press",
+        "color/icon/on-positive/press",
+        "--charcoal-color-icon-on-positive-press",
+        "charcoal-color-icon-on-positive-press",
+        "text-icon-on-positive-press",
+        "fill-icon-on-positive-press",
+        "stroke-icon-on-positive-press",
+        "color-icon-on-positive-press",
+        "icon/on-positive/press",
+        "icon-on-positive-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-positive.default",
+      "figma": "color/icon/on-positive/default",
+      "css": "--charcoal-color-icon-on-positive-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-positive-default); fill: var(--charcoal-color-icon-on-positive-default); stroke: var(--charcoal-color-icon-on-positive-default)",
+      "tailwind": {
+        "key": "icon-on-positive",
+        "recommended": [
+          "text-icon-on-positive",
+          "fill-icon-on-positive",
+          "stroke-icon-on-positive"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-positive.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-positive",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-positive",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-positive",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-positive",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-positive.default",
+        "color/icon/on-positive/default",
+        "--charcoal-color-icon-on-positive-default",
+        "charcoal-color-icon-on-positive-default",
+        "text-icon-on-positive",
+        "fill-icon-on-positive",
+        "stroke-icon-on-positive",
+        "color-icon-on-positive-default",
+        "icon/on-positive/default",
+        "icon-on-positive-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-primary.hover",
+      "figma": "color/icon/on-primary/hover",
+      "css": "--charcoal-color-icon-on-primary-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-primary-hover); fill: var(--charcoal-color-icon-on-primary-hover); stroke: var(--charcoal-color-icon-on-primary-hover)",
+      "tailwind": {
+        "key": "icon-on-primary-hover",
+        "recommended": [
+          "text-icon-on-primary-hover",
+          "fill-icon-on-primary-hover",
+          "stroke-icon-on-primary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-primary.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-primary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-primary-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-primary-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-primary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.on-primary.hover",
+        "color/icon/on-primary/hover",
+        "--charcoal-color-icon-on-primary-hover",
+        "charcoal-color-icon-on-primary-hover",
+        "text-icon-on-primary-hover",
+        "fill-icon-on-primary-hover",
+        "stroke-icon-on-primary-hover",
+        "color-icon-on-primary-hover",
+        "icon/on-primary/hover",
+        "icon-on-primary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-primary.press",
+      "figma": "color/icon/on-primary/press",
+      "css": "--charcoal-color-icon-on-primary-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-primary-press); fill: var(--charcoal-color-icon-on-primary-press); stroke: var(--charcoal-color-icon-on-primary-press)",
+      "tailwind": {
+        "key": "icon-on-primary-press",
+        "recommended": [
+          "text-icon-on-primary-press",
+          "fill-icon-on-primary-press",
+          "stroke-icon-on-primary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-primary.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-primary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-primary-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-primary-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-primary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.on-primary.press",
+        "color/icon/on-primary/press",
+        "--charcoal-color-icon-on-primary-press",
+        "charcoal-color-icon-on-primary-press",
+        "text-icon-on-primary-press",
+        "fill-icon-on-primary-press",
+        "stroke-icon-on-primary-press",
+        "color-icon-on-primary-press",
+        "icon/on-primary/press",
+        "icon-on-primary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.on-primary.default",
+      "figma": "color/icon/on-primary/default",
+      "css": "--charcoal-color-icon-on-primary-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-on-primary-default); fill: var(--charcoal-color-icon-on-primary-default); stroke: var(--charcoal-color-icon-on-primary-default)",
+      "tailwind": {
+        "key": "icon-on-primary",
+        "recommended": [
+          "text-icon-on-primary",
+          "fill-icon-on-primary",
+          "stroke-icon-on-primary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.on-primary.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-on-primary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-on-primary",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-on-primary",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.on-primary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.on-primary.default",
+        "color/icon/on-primary/default",
+        "--charcoal-color-icon-on-primary-default",
+        "charcoal-color-icon-on-primary-default",
+        "text-icon-on-primary",
+        "fill-icon-on-primary",
+        "stroke-icon-on-primary",
+        "color-icon-on-primary-default",
+        "icon/on-primary/default",
+        "icon-on-primary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.positive.hover",
+      "figma": "color/icon/positive/hover",
+      "css": "--charcoal-color-icon-positive-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-positive-hover); fill: var(--charcoal-color-icon-positive-hover); stroke: var(--charcoal-color-icon-positive-hover)",
+      "tailwind": {
+        "key": "icon-positive-hover",
+        "recommended": [
+          "text-icon-positive-hover",
+          "fill-icon-positive-hover",
+          "stroke-icon-positive-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.positive.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-positive-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-positive-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-positive-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.positive",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.positive.hover",
+        "color/icon/positive/hover",
+        "--charcoal-color-icon-positive-hover",
+        "charcoal-color-icon-positive-hover",
+        "text-icon-positive-hover",
+        "fill-icon-positive-hover",
+        "stroke-icon-positive-hover",
+        "color-icon-positive-hover",
+        "icon/positive/hover",
+        "icon-positive-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.positive.press",
+      "figma": "color/icon/positive/press",
+      "css": "--charcoal-color-icon-positive-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-positive-press); fill: var(--charcoal-color-icon-positive-press); stroke: var(--charcoal-color-icon-positive-press)",
+      "tailwind": {
+        "key": "icon-positive-press",
+        "recommended": [
+          "text-icon-positive-press",
+          "fill-icon-positive-press",
+          "stroke-icon-positive-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.positive.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-positive-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-positive-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-positive-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.positive",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.positive.press",
+        "color/icon/positive/press",
+        "--charcoal-color-icon-positive-press",
+        "charcoal-color-icon-positive-press",
+        "text-icon-positive-press",
+        "fill-icon-positive-press",
+        "stroke-icon-positive-press",
+        "color-icon-positive-press",
+        "icon/positive/press",
+        "icon-positive-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.positive.default",
+      "figma": "color/icon/positive/default",
+      "css": "--charcoal-color-icon-positive-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-positive-default); fill: var(--charcoal-color-icon-positive-default); stroke: var(--charcoal-color-icon-positive-default)",
+      "tailwind": {
+        "key": "icon-positive",
+        "recommended": [
+          "text-icon-positive",
+          "fill-icon-positive",
+          "stroke-icon-positive"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.positive.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-positive",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-positive",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-positive",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.positive",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.positive.default",
+        "color/icon/positive/default",
+        "--charcoal-color-icon-positive-default",
+        "charcoal-color-icon-positive-default",
+        "text-icon-positive",
+        "fill-icon-positive",
+        "stroke-icon-positive",
+        "color-icon-positive-default",
+        "icon/positive/default",
+        "icon-positive-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.press",
+      "figma": "color/icon/press",
+      "css": "--charcoal-color-icon-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-press); fill: var(--charcoal-color-icon-press); stroke: var(--charcoal-color-icon-press)",
+      "tailwind": {
+        "key": "icon-press",
+        "recommended": [
+          "text-icon-press",
+          "fill-icon-press",
+          "stroke-icon-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.press",
+        "color/icon/press",
+        "--charcoal-color-icon-press",
+        "charcoal-color-icon-press",
+        "text-icon-press",
+        "fill-icon-press",
+        "stroke-icon-press",
+        "color-icon-press",
+        "icon/press",
+        "icon-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.secondary.hover",
+      "figma": "color/icon/secondary/hover",
+      "css": "--charcoal-color-icon-secondary-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-secondary-hover); fill: var(--charcoal-color-icon-secondary-hover); stroke: var(--charcoal-color-icon-secondary-hover)",
+      "tailwind": {
+        "key": "icon-secondary-hover",
+        "recommended": [
+          "text-icon-secondary-hover",
+          "fill-icon-secondary-hover",
+          "stroke-icon-secondary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.secondary.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-secondary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-secondary-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-secondary-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.secondary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.secondary.hover",
+        "color/icon/secondary/hover",
+        "--charcoal-color-icon-secondary-hover",
+        "charcoal-color-icon-secondary-hover",
+        "text-icon-secondary-hover",
+        "fill-icon-secondary-hover",
+        "stroke-icon-secondary-hover",
+        "color-icon-secondary-hover",
+        "icon/secondary/hover",
+        "icon-secondary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.secondary.press",
+      "figma": "color/icon/secondary/press",
+      "css": "--charcoal-color-icon-secondary-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-secondary-press); fill: var(--charcoal-color-icon-secondary-press); stroke: var(--charcoal-color-icon-secondary-press)",
+      "tailwind": {
+        "key": "icon-secondary-press",
+        "recommended": [
+          "text-icon-secondary-press",
+          "fill-icon-secondary-press",
+          "stroke-icon-secondary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.secondary.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-secondary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-secondary-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-secondary-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.secondary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.secondary.press",
+        "color/icon/secondary/press",
+        "--charcoal-color-icon-secondary-press",
+        "charcoal-color-icon-secondary-press",
+        "text-icon-secondary-press",
+        "fill-icon-secondary-press",
+        "stroke-icon-secondary-press",
+        "color-icon-secondary-press",
+        "icon/secondary/press",
+        "icon-secondary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.secondary.default",
+      "figma": "color/icon/secondary/default",
+      "css": "--charcoal-color-icon-secondary-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-secondary-default); fill: var(--charcoal-color-icon-secondary-default); stroke: var(--charcoal-color-icon-secondary-default)",
+      "tailwind": {
+        "key": "icon-secondary",
+        "recommended": [
+          "text-icon-secondary",
+          "fill-icon-secondary",
+          "stroke-icon-secondary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.secondary.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-secondary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-secondary",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-secondary",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.secondary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.secondary.default",
+        "color/icon/secondary/default",
+        "--charcoal-color-icon-secondary-default",
+        "charcoal-color-icon-secondary-default",
+        "text-icon-secondary",
+        "fill-icon-secondary",
+        "stroke-icon-secondary",
+        "color-icon-secondary-default",
+        "icon/secondary/default",
+        "icon-secondary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.tertiary.hover",
+      "figma": "color/icon/tertiary/hover",
+      "css": "--charcoal-color-icon-tertiary-hover",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-tertiary-hover); fill: var(--charcoal-color-icon-tertiary-hover); stroke: var(--charcoal-color-icon-tertiary-hover)",
+      "tailwind": {
+        "key": "icon-tertiary-hover",
+        "recommended": [
+          "text-icon-tertiary-hover",
+          "fill-icon-tertiary-hover",
+          "stroke-icon-tertiary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.tertiary.hover",
+        "classCandidates": [
+          {
+            "className": "text-icon-tertiary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-tertiary-hover",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-tertiary-hover",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.tertiary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.icon.tertiary.hover",
+        "color/icon/tertiary/hover",
+        "--charcoal-color-icon-tertiary-hover",
+        "charcoal-color-icon-tertiary-hover",
+        "text-icon-tertiary-hover",
+        "fill-icon-tertiary-hover",
+        "stroke-icon-tertiary-hover",
+        "color-icon-tertiary-hover",
+        "icon/tertiary/hover",
+        "icon-tertiary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.tertiary.press",
+      "figma": "color/icon/tertiary/press",
+      "css": "--charcoal-color-icon-tertiary-press",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-tertiary-press); fill: var(--charcoal-color-icon-tertiary-press); stroke: var(--charcoal-color-icon-tertiary-press)",
+      "tailwind": {
+        "key": "icon-tertiary-press",
+        "recommended": [
+          "text-icon-tertiary-press",
+          "fill-icon-tertiary-press",
+          "stroke-icon-tertiary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.tertiary.press",
+        "classCandidates": [
+          {
+            "className": "text-icon-tertiary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-tertiary-press",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-tertiary-press",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.tertiary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.icon.tertiary.press",
+        "color/icon/tertiary/press",
+        "--charcoal-color-icon-tertiary-press",
+        "charcoal-color-icon-tertiary-press",
+        "text-icon-tertiary-press",
+        "fill-icon-tertiary-press",
+        "stroke-icon-tertiary-press",
+        "color-icon-tertiary-press",
+        "icon/tertiary/press",
+        "icon-tertiary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.tertiary.default",
+      "figma": "color/icon/tertiary/default",
+      "css": "--charcoal-color-icon-tertiary-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-tertiary-default); fill: var(--charcoal-color-icon-tertiary-default); stroke: var(--charcoal-color-icon-tertiary-default)",
+      "tailwind": {
+        "key": "icon-tertiary",
+        "recommended": [
+          "text-icon-tertiary",
+          "fill-icon-tertiary",
+          "stroke-icon-tertiary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.tertiary.default",
+        "classCandidates": [
+          {
+            "className": "text-icon-tertiary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon-tertiary",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon-tertiary",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon.tertiary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.tertiary.default",
+        "color/icon/tertiary/default",
+        "--charcoal-color-icon-tertiary-default",
+        "charcoal-color-icon-tertiary-default",
+        "text-icon-tertiary",
+        "fill-icon-tertiary",
+        "stroke-icon-tertiary",
+        "color-icon-tertiary-default",
+        "icon/tertiary/default",
+        "icon-tertiary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.icon.default",
+      "figma": "color/icon/default",
+      "css": "--charcoal-color-icon-default",
+      "category": "color",
+      "group": "icon",
+      "cssUsage": "color: var(--charcoal-color-icon-default); fill: var(--charcoal-color-icon-default); stroke: var(--charcoal-color-icon-default)",
+      "tailwind": {
+        "key": "icon",
+        "recommended": [
+          "text-icon",
+          "fill-icon",
+          "stroke-icon"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.icon.default",
+        "classCandidates": [
+          {
+            "className": "text-icon",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          },
+          {
+            "className": "fill-icon",
+            "utility": "fill",
+            "cssProperties": [
+              "fill"
+            ]
+          },
+          {
+            "className": "stroke-icon",
+            "utility": "stroke",
+            "cssProperties": [
+              "stroke"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.icon",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.icon.default",
+        "color/icon/default",
+        "--charcoal-color-icon-default",
+        "charcoal-color-icon-default",
+        "text-icon",
+        "fill-icon",
+        "stroke-icon",
+        "color-icon-default",
+        "icon/default",
+        "icon-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.default-text1",
+      "figma": "color/text/default-text1",
+      "css": "--charcoal-color-text-default-text1",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-default-text1)",
+      "tailwind": {
+        "key": "text-default-text1",
+        "recommended": [
+          "text-text-default-text1"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.default-text1",
+        "classCandidates": [
+          {
+            "className": "text-text-default-text1",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.default-text1",
+      "notes": [],
+      "keys": [
+        "color.text.default-text1",
+        "color/text/default-text1",
+        "--charcoal-color-text-default-text1",
+        "charcoal-color-text-default-text1",
+        "text-text-default-text1",
+        "color-text-default-text1",
+        "text/default-text1",
+        "text-default-text1"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.disable",
+      "figma": "color/text/disable",
+      "css": "--charcoal-color-text-disable",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-disable)",
+      "tailwind": {
+        "key": "text-disable",
+        "recommended": [
+          "text-text-disable"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.disable",
+        "classCandidates": [
+          {
+            "className": "text-text-disable",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text",
+      "state": "disable",
+      "notes": [],
+      "keys": [
+        "color.text.disable",
+        "color/text/disable",
+        "--charcoal-color-text-disable",
+        "charcoal-color-text-disable",
+        "text-text-disable",
+        "color-text-disable",
+        "text/disable",
+        "text-disable"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.hover",
+      "figma": "color/text/hover",
+      "css": "--charcoal-color-text-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-hover)",
+      "tailwind": {
+        "key": "text-hover",
+        "recommended": [
+          "text-text-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.hover",
+        "color/text/hover",
+        "--charcoal-color-text-hover",
+        "charcoal-color-text-hover",
+        "text-text-hover",
+        "color-text-hover",
+        "text/hover",
+        "text-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.hover-text1",
+      "figma": "color/text/hover-text1",
+      "css": "--charcoal-color-text-hover-text1",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-hover-text1)",
+      "tailwind": {
+        "key": "text-hover-text1",
+        "recommended": [
+          "text-text-hover-text1"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.hover-text1",
+        "classCandidates": [
+          {
+            "className": "text-text-hover-text1",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.hover-text1",
+      "notes": [],
+      "keys": [
+        "color.text.hover-text1",
+        "color/text/hover-text1",
+        "--charcoal-color-text-hover-text1",
+        "charcoal-color-text-hover-text1",
+        "text-text-hover-text1",
+        "color-text-hover-text1",
+        "text/hover-text1",
+        "text-hover-text1"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.info.hover",
+      "figma": "color/text/info/hover",
+      "css": "--charcoal-color-text-info-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-info-hover)",
+      "tailwind": {
+        "key": "text-info-hover",
+        "recommended": [
+          "text-text-info-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.info.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-info-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.info",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.info.hover",
+        "color/text/info/hover",
+        "--charcoal-color-text-info-hover",
+        "charcoal-color-text-info-hover",
+        "text-text-info-hover",
+        "color-text-info-hover",
+        "text/info/hover",
+        "text-info-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.info.press",
+      "figma": "color/text/info/press",
+      "css": "--charcoal-color-text-info-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-info-press)",
+      "tailwind": {
+        "key": "text-info-press",
+        "recommended": [
+          "text-text-info-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.info.press",
+        "classCandidates": [
+          {
+            "className": "text-text-info-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.info",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.info.press",
+        "color/text/info/press",
+        "--charcoal-color-text-info-press",
+        "charcoal-color-text-info-press",
+        "text-text-info-press",
+        "color-text-info-press",
+        "text/info/press",
+        "text-info-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.info.default",
+      "figma": "color/text/info/default",
+      "css": "--charcoal-color-text-info-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-info-default)",
+      "tailwind": {
+        "key": "text-info",
+        "recommended": [
+          "text-text-info"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.info.default",
+        "classCandidates": [
+          {
+            "className": "text-text-info",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.info",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.info.default",
+        "color/text/info/default",
+        "--charcoal-color-text-info-default",
+        "charcoal-color-text-info-default",
+        "text-text-info",
+        "color-text-info-default",
+        "text/info/default",
+        "text-info-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.negative.hover",
+      "figma": "color/text/negative/hover",
+      "css": "--charcoal-color-text-negative-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-negative-hover)",
+      "tailwind": {
+        "key": "text-negative-hover",
+        "recommended": [
+          "text-text-negative-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.negative.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-negative-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.negative",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.negative.hover",
+        "color/text/negative/hover",
+        "--charcoal-color-text-negative-hover",
+        "charcoal-color-text-negative-hover",
+        "text-text-negative-hover",
+        "color-text-negative-hover",
+        "text/negative/hover",
+        "text-negative-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.negative.press",
+      "figma": "color/text/negative/press",
+      "css": "--charcoal-color-text-negative-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-negative-press)",
+      "tailwind": {
+        "key": "text-negative-press",
+        "recommended": [
+          "text-text-negative-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.negative.press",
+        "classCandidates": [
+          {
+            "className": "text-text-negative-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.negative",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.negative.press",
+        "color/text/negative/press",
+        "--charcoal-color-text-negative-press",
+        "charcoal-color-text-negative-press",
+        "text-text-negative-press",
+        "color-text-negative-press",
+        "text/negative/press",
+        "text-negative-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.negative.default",
+      "figma": "color/text/negative/default",
+      "css": "--charcoal-color-text-negative-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-negative-default)",
+      "tailwind": {
+        "key": "text-negative",
+        "recommended": [
+          "text-text-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.negative.default",
+        "classCandidates": [
+          {
+            "className": "text-text-negative",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.negative",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.negative.default",
+        "color/text/negative/default",
+        "--charcoal-color-text-negative-default",
+        "charcoal-color-text-negative-default",
+        "text-text-negative",
+        "color-text-negative-default",
+        "text/negative/default",
+        "text-negative-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.notice.hover",
+      "figma": "color/text/notice/hover",
+      "css": "--charcoal-color-text-notice-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-notice-hover)",
+      "tailwind": {
+        "key": "text-notice-hover",
+        "recommended": [
+          "text-text-notice-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.notice.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-notice-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.notice",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.notice.hover",
+        "color/text/notice/hover",
+        "--charcoal-color-text-notice-hover",
+        "charcoal-color-text-notice-hover",
+        "text-text-notice-hover",
+        "color-text-notice-hover",
+        "text/notice/hover",
+        "text-notice-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.notice.press",
+      "figma": "color/text/notice/press",
+      "css": "--charcoal-color-text-notice-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-notice-press)",
+      "tailwind": {
+        "key": "text-notice-press",
+        "recommended": [
+          "text-text-notice-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.notice.press",
+        "classCandidates": [
+          {
+            "className": "text-text-notice-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.notice",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.notice.press",
+        "color/text/notice/press",
+        "--charcoal-color-text-notice-press",
+        "charcoal-color-text-notice-press",
+        "text-text-notice-press",
+        "color-text-notice-press",
+        "text/notice/press",
+        "text-notice-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.notice.default",
+      "figma": "color/text/notice/default",
+      "css": "--charcoal-color-text-notice-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-notice-default)",
+      "tailwind": {
+        "key": "text-notice",
+        "recommended": [
+          "text-text-notice"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.notice.default",
+        "classCandidates": [
+          {
+            "className": "text-text-notice",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.notice",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.notice.default",
+        "color/text/notice/default",
+        "--charcoal-color-text-notice-default",
+        "charcoal-color-text-notice-default",
+        "text-text-notice",
+        "color-text-notice-default",
+        "text/notice/default",
+        "text-notice-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-discovery.hover",
+      "figma": "color/text/on-discovery/hover",
+      "css": "--charcoal-color-text-on-discovery-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-discovery-hover)",
+      "tailwind": {
+        "key": "text-on-discovery-hover",
+        "recommended": [
+          "text-text-on-discovery-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-discovery.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-discovery-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-discovery",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-discovery.hover",
+        "color/text/on-discovery/hover",
+        "--charcoal-color-text-on-discovery-hover",
+        "charcoal-color-text-on-discovery-hover",
+        "text-text-on-discovery-hover",
+        "color-text-on-discovery-hover",
+        "text/on-discovery/hover",
+        "text-on-discovery-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-discovery.press",
+      "figma": "color/text/on-discovery/press",
+      "css": "--charcoal-color-text-on-discovery-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-discovery-press)",
+      "tailwind": {
+        "key": "text-on-discovery-press",
+        "recommended": [
+          "text-text-on-discovery-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-discovery.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-discovery-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-discovery",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-discovery.press",
+        "color/text/on-discovery/press",
+        "--charcoal-color-text-on-discovery-press",
+        "charcoal-color-text-on-discovery-press",
+        "text-text-on-discovery-press",
+        "color-text-on-discovery-press",
+        "text/on-discovery/press",
+        "text-on-discovery-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-discovery.default",
+      "figma": "color/text/on-discovery/default",
+      "css": "--charcoal-color-text-on-discovery-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-discovery-default)",
+      "tailwind": {
+        "key": "text-on-discovery",
+        "recommended": [
+          "text-text-on-discovery"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-discovery.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-discovery",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-discovery",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-discovery.default",
+        "color/text/on-discovery/default",
+        "--charcoal-color-text-on-discovery-default",
+        "charcoal-color-text-on-discovery-default",
+        "text-text-on-discovery",
+        "color-text-on-discovery-default",
+        "text/on-discovery/default",
+        "text-on-discovery-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-hud.hover",
+      "figma": "color/text/on-hud/hover",
+      "css": "--charcoal-color-text-on-hud-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-hud-hover)",
+      "tailwind": {
+        "key": "text-on-hud-hover",
+        "recommended": [
+          "text-text-on-hud-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-hud.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-hud-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-hud",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-hud.hover",
+        "color/text/on-hud/hover",
+        "--charcoal-color-text-on-hud-hover",
+        "charcoal-color-text-on-hud-hover",
+        "text-text-on-hud-hover",
+        "color-text-on-hud-hover",
+        "text/on-hud/hover",
+        "text-on-hud-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-hud.press",
+      "figma": "color/text/on-hud/press",
+      "css": "--charcoal-color-text-on-hud-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-hud-press)",
+      "tailwind": {
+        "key": "text-on-hud-press",
+        "recommended": [
+          "text-text-on-hud-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-hud.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-hud-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-hud",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-hud.press",
+        "color/text/on-hud/press",
+        "--charcoal-color-text-on-hud-press",
+        "charcoal-color-text-on-hud-press",
+        "text-text-on-hud-press",
+        "color-text-on-hud-press",
+        "text/on-hud/press",
+        "text-on-hud-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-hud.default",
+      "figma": "color/text/on-hud/default",
+      "css": "--charcoal-color-text-on-hud-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-hud-default)",
+      "tailwind": {
+        "key": "text-on-hud",
+        "recommended": [
+          "text-text-on-hud"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-hud.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-hud",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-hud",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-hud.default",
+        "color/text/on-hud/default",
+        "--charcoal-color-text-on-hud-default",
+        "charcoal-color-text-on-hud-default",
+        "text-text-on-hud",
+        "color-text-on-hud-default",
+        "text/on-hud/default",
+        "text-on-hud-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-negative.hover",
+      "figma": "color/text/on-negative/hover",
+      "css": "--charcoal-color-text-on-negative-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-negative-hover)",
+      "tailwind": {
+        "key": "text-on-negative-hover",
+        "recommended": [
+          "text-text-on-negative-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-negative.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-negative-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-negative",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-negative.hover",
+        "color/text/on-negative/hover",
+        "--charcoal-color-text-on-negative-hover",
+        "charcoal-color-text-on-negative-hover",
+        "text-text-on-negative-hover",
+        "color-text-on-negative-hover",
+        "text/on-negative/hover",
+        "text-on-negative-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-negative.press",
+      "figma": "color/text/on-negative/press",
+      "css": "--charcoal-color-text-on-negative-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-negative-press)",
+      "tailwind": {
+        "key": "text-on-negative-press",
+        "recommended": [
+          "text-text-on-negative-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-negative.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-negative-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-negative",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-negative.press",
+        "color/text/on-negative/press",
+        "--charcoal-color-text-on-negative-press",
+        "charcoal-color-text-on-negative-press",
+        "text-text-on-negative-press",
+        "color-text-on-negative-press",
+        "text/on-negative/press",
+        "text-on-negative-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-negative.default",
+      "figma": "color/text/on-negative/default",
+      "css": "--charcoal-color-text-on-negative-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-negative-default)",
+      "tailwind": {
+        "key": "text-on-negative",
+        "recommended": [
+          "text-text-on-negative"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-negative.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-negative",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-negative",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-negative.default",
+        "color/text/on-negative/default",
+        "--charcoal-color-text-on-negative-default",
+        "charcoal-color-text-on-negative-default",
+        "text-text-on-negative",
+        "color-text-on-negative-default",
+        "text/on-negative/default",
+        "text-on-negative-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-notice.hover",
+      "figma": "color/text/on-notice/hover",
+      "css": "--charcoal-color-text-on-notice-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-notice-hover)",
+      "tailwind": {
+        "key": "text-on-notice-hover",
+        "recommended": [
+          "text-text-on-notice-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-notice.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-notice-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-notice",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-notice.hover",
+        "color/text/on-notice/hover",
+        "--charcoal-color-text-on-notice-hover",
+        "charcoal-color-text-on-notice-hover",
+        "text-text-on-notice-hover",
+        "color-text-on-notice-hover",
+        "text/on-notice/hover",
+        "text-on-notice-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-notice.press",
+      "figma": "color/text/on-notice/press",
+      "css": "--charcoal-color-text-on-notice-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-notice-press)",
+      "tailwind": {
+        "key": "text-on-notice-press",
+        "recommended": [
+          "text-text-on-notice-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-notice.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-notice-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-notice",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-notice.press",
+        "color/text/on-notice/press",
+        "--charcoal-color-text-on-notice-press",
+        "charcoal-color-text-on-notice-press",
+        "text-text-on-notice-press",
+        "color-text-on-notice-press",
+        "text/on-notice/press",
+        "text-on-notice-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-notice.default",
+      "figma": "color/text/on-notice/default",
+      "css": "--charcoal-color-text-on-notice-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-notice-default)",
+      "tailwind": {
+        "key": "text-on-notice",
+        "recommended": [
+          "text-text-on-notice"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-notice.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-notice",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-notice",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-notice.default",
+        "color/text/on-notice/default",
+        "--charcoal-color-text-on-notice-default",
+        "charcoal-color-text-on-notice-default",
+        "text-text-on-notice",
+        "color-text-on-notice-default",
+        "text/on-notice/default",
+        "text-on-notice-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-on-img.hover",
+      "figma": "color/text/on-on-img/hover",
+      "css": "--charcoal-color-text-on-on-img-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-on-img-hover)",
+      "tailwind": {
+        "key": "text-on-on-img-hover",
+        "recommended": [
+          "text-text-on-on-img-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-on-img.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-on-img-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-on-img",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-on-img.hover",
+        "color/text/on-on-img/hover",
+        "--charcoal-color-text-on-on-img-hover",
+        "charcoal-color-text-on-on-img-hover",
+        "text-text-on-on-img-hover",
+        "color-text-on-on-img-hover",
+        "text/on-on-img/hover",
+        "text-on-on-img-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-on-img.press",
+      "figma": "color/text/on-on-img/press",
+      "css": "--charcoal-color-text-on-on-img-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-on-img-press)",
+      "tailwind": {
+        "key": "text-on-on-img-press",
+        "recommended": [
+          "text-text-on-on-img-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-on-img.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-on-img-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-on-img",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-on-img.press",
+        "color/text/on-on-img/press",
+        "--charcoal-color-text-on-on-img-press",
+        "charcoal-color-text-on-on-img-press",
+        "text-text-on-on-img-press",
+        "color-text-on-on-img-press",
+        "text/on-on-img/press",
+        "text-on-on-img-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-on-img.default",
+      "figma": "color/text/on-on-img/default",
+      "css": "--charcoal-color-text-on-on-img-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-on-img-default)",
+      "tailwind": {
+        "key": "text-on-on-img",
+        "recommended": [
+          "text-text-on-on-img"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-on-img.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-on-img",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-on-img",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-on-img.default",
+        "color/text/on-on-img/default",
+        "--charcoal-color-text-on-on-img-default",
+        "charcoal-color-text-on-on-img-default",
+        "text-text-on-on-img",
+        "color-text-on-on-img-default",
+        "text/on-on-img/default",
+        "text-on-on-img-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-positive.hover",
+      "figma": "color/text/on-positive/hover",
+      "css": "--charcoal-color-text-on-positive-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-positive-hover)",
+      "tailwind": {
+        "key": "text-on-positive-hover",
+        "recommended": [
+          "text-text-on-positive-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-positive.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-positive-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-positive",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-positive.hover",
+        "color/text/on-positive/hover",
+        "--charcoal-color-text-on-positive-hover",
+        "charcoal-color-text-on-positive-hover",
+        "text-text-on-positive-hover",
+        "color-text-on-positive-hover",
+        "text/on-positive/hover",
+        "text-on-positive-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-positive.press",
+      "figma": "color/text/on-positive/press",
+      "css": "--charcoal-color-text-on-positive-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-positive-press)",
+      "tailwind": {
+        "key": "text-on-positive-press",
+        "recommended": [
+          "text-text-on-positive-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-positive.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-positive-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-positive",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-positive.press",
+        "color/text/on-positive/press",
+        "--charcoal-color-text-on-positive-press",
+        "charcoal-color-text-on-positive-press",
+        "text-text-on-positive-press",
+        "color-text-on-positive-press",
+        "text/on-positive/press",
+        "text-on-positive-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-positive.default",
+      "figma": "color/text/on-positive/default",
+      "css": "--charcoal-color-text-on-positive-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-positive-default)",
+      "tailwind": {
+        "key": "text-on-positive",
+        "recommended": [
+          "text-text-on-positive"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-positive.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-positive",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-positive",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-positive.default",
+        "color/text/on-positive/default",
+        "--charcoal-color-text-on-positive-default",
+        "charcoal-color-text-on-positive-default",
+        "text-text-on-positive",
+        "color-text-on-positive-default",
+        "text/on-positive/default",
+        "text-on-positive-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-primary.hover",
+      "figma": "color/text/on-primary/hover",
+      "css": "--charcoal-color-text-on-primary-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-primary-hover)",
+      "tailwind": {
+        "key": "text-on-primary-hover",
+        "recommended": [
+          "text-text-on-primary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-primary.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-on-primary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-primary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.on-primary.hover",
+        "color/text/on-primary/hover",
+        "--charcoal-color-text-on-primary-hover",
+        "charcoal-color-text-on-primary-hover",
+        "text-text-on-primary-hover",
+        "color-text-on-primary-hover",
+        "text/on-primary/hover",
+        "text-on-primary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-primary.press",
+      "figma": "color/text/on-primary/press",
+      "css": "--charcoal-color-text-on-primary-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-primary-press)",
+      "tailwind": {
+        "key": "text-on-primary-press",
+        "recommended": [
+          "text-text-on-primary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-primary.press",
+        "classCandidates": [
+          {
+            "className": "text-text-on-primary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-primary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.on-primary.press",
+        "color/text/on-primary/press",
+        "--charcoal-color-text-on-primary-press",
+        "charcoal-color-text-on-primary-press",
+        "text-text-on-primary-press",
+        "color-text-on-primary-press",
+        "text/on-primary/press",
+        "text-on-primary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.on-primary.default",
+      "figma": "color/text/on-primary/default",
+      "css": "--charcoal-color-text-on-primary-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-on-primary-default)",
+      "tailwind": {
+        "key": "text-on-primary",
+        "recommended": [
+          "text-text-on-primary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.on-primary.default",
+        "classCandidates": [
+          {
+            "className": "text-text-on-primary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.on-primary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.on-primary.default",
+        "color/text/on-primary/default",
+        "--charcoal-color-text-on-primary-default",
+        "charcoal-color-text-on-primary-default",
+        "text-text-on-primary",
+        "color-text-on-primary-default",
+        "text/on-primary/default",
+        "text-on-primary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.placeholder.hover",
+      "figma": "color/text/placeholder/hover",
+      "css": "--charcoal-color-text-placeholder-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-placeholder-hover)",
+      "tailwind": {
+        "key": "text-placeholder-hover",
+        "recommended": [
+          "text-text-placeholder-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.placeholder.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-placeholder-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.placeholder",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.placeholder.hover",
+        "color/text/placeholder/hover",
+        "--charcoal-color-text-placeholder-hover",
+        "charcoal-color-text-placeholder-hover",
+        "text-text-placeholder-hover",
+        "color-text-placeholder-hover",
+        "text/placeholder/hover",
+        "text-placeholder-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.placeholder.press",
+      "figma": "color/text/placeholder/press",
+      "css": "--charcoal-color-text-placeholder-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-placeholder-press)",
+      "tailwind": {
+        "key": "text-placeholder-press",
+        "recommended": [
+          "text-text-placeholder-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.placeholder.press",
+        "classCandidates": [
+          {
+            "className": "text-text-placeholder-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.placeholder",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.placeholder.press",
+        "color/text/placeholder/press",
+        "--charcoal-color-text-placeholder-press",
+        "charcoal-color-text-placeholder-press",
+        "text-text-placeholder-press",
+        "color-text-placeholder-press",
+        "text/placeholder/press",
+        "text-placeholder-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.placeholder.default",
+      "figma": "color/text/placeholder/default",
+      "css": "--charcoal-color-text-placeholder-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-placeholder-default)",
+      "tailwind": {
+        "key": "text-placeholder",
+        "recommended": [
+          "text-text-placeholder"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.placeholder.default",
+        "classCandidates": [
+          {
+            "className": "text-text-placeholder",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.placeholder",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.placeholder.default",
+        "color/text/placeholder/default",
+        "--charcoal-color-text-placeholder-default",
+        "charcoal-color-text-placeholder-default",
+        "text-text-placeholder",
+        "color-text-placeholder-default",
+        "text/placeholder/default",
+        "text-placeholder-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.positive.hover",
+      "figma": "color/text/positive/hover",
+      "css": "--charcoal-color-text-positive-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-positive-hover)",
+      "tailwind": {
+        "key": "text-positive-hover",
+        "recommended": [
+          "text-text-positive-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.positive.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-positive-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.positive",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.positive.hover",
+        "color/text/positive/hover",
+        "--charcoal-color-text-positive-hover",
+        "charcoal-color-text-positive-hover",
+        "text-text-positive-hover",
+        "color-text-positive-hover",
+        "text/positive/hover",
+        "text-positive-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.positive.press",
+      "figma": "color/text/positive/press",
+      "css": "--charcoal-color-text-positive-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-positive-press)",
+      "tailwind": {
+        "key": "text-positive-press",
+        "recommended": [
+          "text-text-positive-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.positive.press",
+        "classCandidates": [
+          {
+            "className": "text-text-positive-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.positive",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.positive.press",
+        "color/text/positive/press",
+        "--charcoal-color-text-positive-press",
+        "charcoal-color-text-positive-press",
+        "text-text-positive-press",
+        "color-text-positive-press",
+        "text/positive/press",
+        "text-positive-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.positive.default",
+      "figma": "color/text/positive/default",
+      "css": "--charcoal-color-text-positive-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-positive-default)",
+      "tailwind": {
+        "key": "text-positive",
+        "recommended": [
+          "text-text-positive"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.positive.default",
+        "classCandidates": [
+          {
+            "className": "text-text-positive",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.positive",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.positive.default",
+        "color/text/positive/default",
+        "--charcoal-color-text-positive-default",
+        "charcoal-color-text-positive-default",
+        "text-text-positive",
+        "color-text-positive-default",
+        "text/positive/default",
+        "text-positive-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.press",
+      "figma": "color/text/press",
+      "css": "--charcoal-color-text-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-press)",
+      "tailwind": {
+        "key": "text-press",
+        "recommended": [
+          "text-text-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.press",
+        "classCandidates": [
+          {
+            "className": "text-text-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.press",
+        "color/text/press",
+        "--charcoal-color-text-press",
+        "charcoal-color-text-press",
+        "text-text-press",
+        "color-text-press",
+        "text/press",
+        "text-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.press-text1",
+      "figma": "color/text/press-text1",
+      "css": "--charcoal-color-text-press-text1",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-press-text1)",
+      "tailwind": {
+        "key": "text-press-text1",
+        "recommended": [
+          "text-text-press-text1"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.press-text1",
+        "classCandidates": [
+          {
+            "className": "text-text-press-text1",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.press-text1",
+      "notes": [],
+      "keys": [
+        "color.text.press-text1",
+        "color/text/press-text1",
+        "--charcoal-color-text-press-text1",
+        "charcoal-color-text-press-text1",
+        "text-text-press-text1",
+        "color-text-press-text1",
+        "text/press-text1",
+        "text-press-text1"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.secondary.hover",
+      "figma": "color/text/secondary/hover",
+      "css": "--charcoal-color-text-secondary-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-secondary-hover)",
+      "tailwind": {
+        "key": "text-secondary-hover",
+        "recommended": [
+          "text-text-secondary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.secondary.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-secondary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.secondary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.secondary.hover",
+        "color/text/secondary/hover",
+        "--charcoal-color-text-secondary-hover",
+        "charcoal-color-text-secondary-hover",
+        "text-text-secondary-hover",
+        "color-text-secondary-hover",
+        "text/secondary/hover",
+        "text-secondary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.secondary.press",
+      "figma": "color/text/secondary/press",
+      "css": "--charcoal-color-text-secondary-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-secondary-press)",
+      "tailwind": {
+        "key": "text-secondary-press",
+        "recommended": [
+          "text-text-secondary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.secondary.press",
+        "classCandidates": [
+          {
+            "className": "text-text-secondary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.secondary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.secondary.press",
+        "color/text/secondary/press",
+        "--charcoal-color-text-secondary-press",
+        "charcoal-color-text-secondary-press",
+        "text-text-secondary-press",
+        "color-text-secondary-press",
+        "text/secondary/press",
+        "text-secondary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.secondary.default",
+      "figma": "color/text/secondary/default",
+      "css": "--charcoal-color-text-secondary-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-secondary-default)",
+      "tailwind": {
+        "key": "text-secondary",
+        "recommended": [
+          "text-text-secondary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.secondary.default",
+        "classCandidates": [
+          {
+            "className": "text-text-secondary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.secondary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.secondary.default",
+        "color/text/secondary/default",
+        "--charcoal-color-text-secondary-default",
+        "charcoal-color-text-secondary-default",
+        "text-text-secondary",
+        "color-text-secondary-default",
+        "text/secondary/default",
+        "text-secondary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.tertiary.hover",
+      "figma": "color/text/tertiary/hover",
+      "css": "--charcoal-color-text-tertiary-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-tertiary-hover)",
+      "tailwind": {
+        "key": "text-tertiary-hover",
+        "recommended": [
+          "text-text-tertiary-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.tertiary.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-tertiary-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.tertiary",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.tertiary.hover",
+        "color/text/tertiary/hover",
+        "--charcoal-color-text-tertiary-hover",
+        "charcoal-color-text-tertiary-hover",
+        "text-text-tertiary-hover",
+        "color-text-tertiary-hover",
+        "text/tertiary/hover",
+        "text-tertiary-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.tertiary.press",
+      "figma": "color/text/tertiary/press",
+      "css": "--charcoal-color-text-tertiary-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-tertiary-press)",
+      "tailwind": {
+        "key": "text-tertiary-press",
+        "recommended": [
+          "text-text-tertiary-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.tertiary.press",
+        "classCandidates": [
+          {
+            "className": "text-text-tertiary-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.tertiary",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.tertiary.press",
+        "color/text/tertiary/press",
+        "--charcoal-color-text-tertiary-press",
+        "charcoal-color-text-tertiary-press",
+        "text-text-tertiary-press",
+        "color-text-tertiary-press",
+        "text/tertiary/press",
+        "text-tertiary-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.tertiary.default",
+      "figma": "color/text/tertiary/default",
+      "css": "--charcoal-color-text-tertiary-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-tertiary-default)",
+      "tailwind": {
+        "key": "text-tertiary",
+        "recommended": [
+          "text-text-tertiary"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.tertiary.default",
+        "classCandidates": [
+          {
+            "className": "text-text-tertiary",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.tertiary",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.tertiary.default",
+        "color/text/tertiary/default",
+        "--charcoal-color-text-tertiary-default",
+        "charcoal-color-text-tertiary-default",
+        "text-text-tertiary",
+        "color-text-tertiary-default",
+        "text/tertiary/default",
+        "text-tertiary-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.visited.hover",
+      "figma": "color/text/visited/hover",
+      "css": "--charcoal-color-text-visited-hover",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-visited-hover)",
+      "tailwind": {
+        "key": "text-visited-hover",
+        "recommended": [
+          "text-text-visited-hover"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.visited.hover",
+        "classCandidates": [
+          {
+            "className": "text-text-visited-hover",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.visited",
+      "state": "hover",
+      "notes": [],
+      "keys": [
+        "color.text.visited.hover",
+        "color/text/visited/hover",
+        "--charcoal-color-text-visited-hover",
+        "charcoal-color-text-visited-hover",
+        "text-text-visited-hover",
+        "color-text-visited-hover",
+        "text/visited/hover",
+        "text-visited-hover"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.visited.press",
+      "figma": "color/text/visited/press",
+      "css": "--charcoal-color-text-visited-press",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-visited-press)",
+      "tailwind": {
+        "key": "text-visited-press",
+        "recommended": [
+          "text-text-visited-press"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.visited.press",
+        "classCandidates": [
+          {
+            "className": "text-text-visited-press",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.visited",
+      "state": "press",
+      "notes": [],
+      "keys": [
+        "color.text.visited.press",
+        "color/text/visited/press",
+        "--charcoal-color-text-visited-press",
+        "charcoal-color-text-visited-press",
+        "text-text-visited-press",
+        "color-text-visited-press",
+        "text/visited/press",
+        "text-visited-press"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.visited.default",
+      "figma": "color/text/visited/default",
+      "css": "--charcoal-color-text-visited-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-visited-default)",
+      "tailwind": {
+        "key": "text-visited",
+        "recommended": [
+          "text-text-visited"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.visited.default",
+        "classCandidates": [
+          {
+            "className": "text-text-visited",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text.visited",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.visited.default",
+        "color/text/visited/default",
+        "--charcoal-color-text-visited-default",
+        "charcoal-color-text-visited-default",
+        "text-text-visited",
+        "color-text-visited-default",
+        "text/visited/default",
+        "text-visited-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "color.text.default",
+      "figma": "color/text/default",
+      "css": "--charcoal-color-text-default",
+      "category": "color",
+      "group": "text",
+      "cssUsage": "color: var(--charcoal-color-text-default)",
+      "tailwind": {
+        "key": "text",
+        "recommended": [
+          "text-text"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "color.text.default",
+        "classCandidates": [
+          {
+            "className": "text-text",
+            "utility": "textColor",
+            "cssProperties": [
+              "color"
+            ]
+          }
+        ]
+      },
+      "familyKey": "color.text",
+      "state": "default",
+      "notes": [],
+      "keys": [
+        "color.text.default",
+        "color/text/default",
+        "--charcoal-color-text-default",
+        "charcoal-color-text-default",
+        "text-text",
+        "color-text-default",
+        "text/default",
+        "text-default"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.body",
+      "figma": "text/font-size/body",
+      "css": "--charcoal-text-font-size-body",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-body); line-height: var(--charcoal-text-line-height-body)",
+      "tailwind": {
+        "key": "body",
+        "recommended": [
+          "text-body"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.body",
+        "classCandidates": [
+          {
+            "className": "text-body",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.body",
+      "notes": [],
+      "keys": [
+        "text.font-size.body",
+        "text/font-size/body",
+        "--charcoal-text-font-size-body",
+        "charcoal-text-font-size-body",
+        "text-body",
+        "text-font-size-body",
+        "font-size/body",
+        "font-size-body",
+        "text.line-height.body",
+        "text/line-height/body",
+        "--charcoal-text-line-height-body"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.caption.m",
+      "figma": "text/font-size/caption/m",
+      "css": "--charcoal-text-font-size-caption-m",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-caption-m); line-height: var(--charcoal-text-line-height-caption-m)",
+      "tailwind": {
+        "key": "caption-m",
+        "recommended": [
+          "text-caption-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.caption.m",
+        "classCandidates": [
+          {
+            "className": "text-caption-m",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.caption.m",
+      "notes": [],
+      "keys": [
+        "text.font-size.caption.m",
+        "text/font-size/caption/m",
+        "--charcoal-text-font-size-caption-m",
+        "charcoal-text-font-size-caption-m",
+        "text-caption-m",
+        "text-font-size-caption-m",
+        "font-size/caption/m",
+        "font-size-caption-m",
+        "text.line-height.caption.m",
+        "text/line-height/caption/m",
+        "--charcoal-text-line-height-caption-m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.caption.s",
+      "figma": "text/font-size/caption/s",
+      "css": "--charcoal-text-font-size-caption-s",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-caption-s); line-height: var(--charcoal-text-line-height-caption-s)",
+      "tailwind": {
+        "key": "caption-s",
+        "recommended": [
+          "text-caption-s"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.caption.s",
+        "classCandidates": [
+          {
+            "className": "text-caption-s",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.caption.s",
+      "notes": [],
+      "keys": [
+        "text.font-size.caption.s",
+        "text/font-size/caption/s",
+        "--charcoal-text-font-size-caption-s",
+        "charcoal-text-font-size-caption-s",
+        "text-caption-s",
+        "text-font-size-caption-s",
+        "font-size/caption/s",
+        "font-size-caption-s",
+        "text.line-height.caption.s",
+        "text/line-height/caption/s",
+        "--charcoal-text-line-height-caption-s"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.l",
+      "figma": "text/font-size/heading/l",
+      "css": "--charcoal-text-font-size-heading-l",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-l); line-height: var(--charcoal-text-line-height-heading-l)",
+      "tailwind": {
+        "key": "heading-l",
+        "recommended": [
+          "text-heading-l"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.l",
+        "classCandidates": [
+          {
+            "className": "text-heading-l",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.l",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.l",
+        "text/font-size/heading/l",
+        "--charcoal-text-font-size-heading-l",
+        "charcoal-text-font-size-heading-l",
+        "text-heading-l",
+        "text-font-size-heading-l",
+        "font-size/heading/l",
+        "font-size-heading-l",
+        "text.line-height.heading.l",
+        "text/line-height/heading/l",
+        "--charcoal-text-line-height-heading-l"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.m",
+      "figma": "text/font-size/heading/m",
+      "css": "--charcoal-text-font-size-heading-m",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-m); line-height: var(--charcoal-text-line-height-heading-m)",
+      "tailwind": {
+        "key": "heading-m",
+        "recommended": [
+          "text-heading-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.m",
+        "classCandidates": [
+          {
+            "className": "text-heading-m",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.m",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.m",
+        "text/font-size/heading/m",
+        "--charcoal-text-font-size-heading-m",
+        "charcoal-text-font-size-heading-m",
+        "text-heading-m",
+        "text-font-size-heading-m",
+        "font-size/heading/m",
+        "font-size-heading-m",
+        "text.line-height.heading.m",
+        "text/line-height/heading/m",
+        "--charcoal-text-line-height-heading-m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.s",
+      "figma": "text/font-size/heading/s",
+      "css": "--charcoal-text-font-size-heading-s",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-s); line-height: var(--charcoal-text-line-height-heading-s)",
+      "tailwind": {
+        "key": "heading-s",
+        "recommended": [
+          "text-heading-s"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.s",
+        "classCandidates": [
+          {
+            "className": "text-heading-s",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.s",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.s",
+        "text/font-size/heading/s",
+        "--charcoal-text-font-size-heading-s",
+        "charcoal-text-font-size-heading-s",
+        "text-heading-s",
+        "text-font-size-heading-s",
+        "font-size/heading/s",
+        "font-size-heading-s",
+        "text.line-height.heading.s",
+        "text/line-height/heading/s",
+        "--charcoal-text-line-height-heading-s"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xl",
+      "figma": "text/font-size/heading/xl",
+      "css": "--charcoal-text-font-size-heading-xl",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xl); line-height: var(--charcoal-text-line-height-heading-xl)",
+      "tailwind": {
+        "key": "heading-xl",
+        "recommended": [
+          "text-heading-xl"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xl",
+        "classCandidates": [
+          {
+            "className": "text-heading-xl",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xl",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xl",
+        "text/font-size/heading/xl",
+        "--charcoal-text-font-size-heading-xl",
+        "charcoal-text-font-size-heading-xl",
+        "text-heading-xl",
+        "text-font-size-heading-xl",
+        "font-size/heading/xl",
+        "font-size-heading-xl",
+        "text.line-height.heading.xl",
+        "text/line-height/heading/xl",
+        "--charcoal-text-line-height-heading-xl"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xs",
+      "figma": "text/font-size/heading/xs",
+      "css": "--charcoal-text-font-size-heading-xs",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xs); line-height: var(--charcoal-text-line-height-heading-xs)",
+      "tailwind": {
+        "key": "heading-xs",
+        "recommended": [
+          "text-heading-xs"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xs",
+        "classCandidates": [
+          {
+            "className": "text-heading-xs",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xs",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xs",
+        "text/font-size/heading/xs",
+        "--charcoal-text-font-size-heading-xs",
+        "charcoal-text-font-size-heading-xs",
+        "text-heading-xs",
+        "text-font-size-heading-xs",
+        "font-size/heading/xs",
+        "font-size-heading-xs",
+        "text.line-height.heading.xs",
+        "text/line-height/heading/xs",
+        "--charcoal-text-line-height-heading-xs"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xxl",
+      "figma": "text/font-size/heading/xxl",
+      "css": "--charcoal-text-font-size-heading-xxl",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xxl); line-height: var(--charcoal-text-line-height-heading-xxl)",
+      "tailwind": {
+        "key": "heading-xxl",
+        "recommended": [
+          "text-heading-xxl"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xxl",
+        "classCandidates": [
+          {
+            "className": "text-heading-xxl",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xxl",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xxl",
+        "text/font-size/heading/xxl",
+        "--charcoal-text-font-size-heading-xxl",
+        "charcoal-text-font-size-heading-xxl",
+        "text-heading-xxl",
+        "text-font-size-heading-xxl",
+        "font-size/heading/xxl",
+        "font-size-heading-xxl",
+        "text.line-height.heading.xxl",
+        "text/line-height/heading/xxl",
+        "--charcoal-text-line-height-heading-xxl"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xxs",
+      "figma": "text/font-size/heading/xxs",
+      "css": "--charcoal-text-font-size-heading-xxs",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xxs); line-height: var(--charcoal-text-line-height-heading-xxs)",
+      "tailwind": {
+        "key": "heading-xxs",
+        "recommended": [
+          "text-heading-xxs"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xxs",
+        "classCandidates": [
+          {
+            "className": "text-heading-xxs",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xxs",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xxs",
+        "text/font-size/heading/xxs",
+        "--charcoal-text-font-size-heading-xxs",
+        "charcoal-text-font-size-heading-xxs",
+        "text-heading-xxs",
+        "text-font-size-heading-xxs",
+        "font-size/heading/xxs",
+        "font-size-heading-xxs",
+        "text.line-height.heading.xxs",
+        "text/line-height/heading/xxs",
+        "--charcoal-text-line-height-heading-xxs"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xxxl",
+      "figma": "text/font-size/heading/xxxl",
+      "css": "--charcoal-text-font-size-heading-xxxl",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xxxl); line-height: var(--charcoal-text-line-height-heading-xxxl)",
+      "tailwind": {
+        "key": "heading-xxxl",
+        "recommended": [
+          "text-heading-xxxl"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xxxl",
+        "classCandidates": [
+          {
+            "className": "text-heading-xxxl",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xxxl",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xxxl",
+        "text/font-size/heading/xxxl",
+        "--charcoal-text-font-size-heading-xxxl",
+        "charcoal-text-font-size-heading-xxxl",
+        "text-heading-xxxl",
+        "text-font-size-heading-xxxl",
+        "font-size/heading/xxxl",
+        "font-size-heading-xxxl",
+        "text.line-height.heading.xxxl",
+        "text/line-height/heading/xxxl",
+        "--charcoal-text-line-height-heading-xxxl"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.heading.xxxs",
+      "figma": "text/font-size/heading/xxxs",
+      "css": "--charcoal-text-font-size-heading-xxxs",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-heading-xxxs); line-height: var(--charcoal-text-line-height-heading-xxxs)",
+      "tailwind": {
+        "key": "heading-xxxs",
+        "recommended": [
+          "text-heading-xxxs"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.heading.xxxs",
+        "classCandidates": [
+          {
+            "className": "text-heading-xxxs",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.heading.xxxs",
+      "notes": [],
+      "keys": [
+        "text.font-size.heading.xxxs",
+        "text/font-size/heading/xxxs",
+        "--charcoal-text-font-size-heading-xxxs",
+        "charcoal-text-font-size-heading-xxxs",
+        "text-heading-xxxs",
+        "text-font-size-heading-xxxs",
+        "font-size/heading/xxxs",
+        "font-size-heading-xxxs",
+        "text.line-height.heading.xxxs",
+        "text/line-height/heading/xxxs",
+        "--charcoal-text-line-height-heading-xxxs"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-size.paragraph",
+      "figma": "text/font-size/paragraph",
+      "css": "--charcoal-text-font-size-paragraph",
+      "category": "text",
+      "group": "text",
+      "kind": "fontSize",
+      "cssUsage": "font-size: var(--charcoal-text-font-size-paragraph); line-height: var(--charcoal-text-line-height-paragraph)",
+      "tailwind": {
+        "key": "paragraph",
+        "recommended": [
+          "text-paragraph"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-size.paragraph",
+        "classCandidates": [
+          {
+            "className": "text-paragraph",
+            "utility": "fontSize",
+            "cssProperties": [
+              "font-size",
+              "line-height"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-size.paragraph",
+      "notes": [],
+      "keys": [
+        "text.font-size.paragraph",
+        "text/font-size/paragraph",
+        "--charcoal-text-font-size-paragraph",
+        "charcoal-text-font-size-paragraph",
+        "text-paragraph",
+        "text-font-size-paragraph",
+        "font-size/paragraph",
+        "font-size-paragraph",
+        "text.line-height.paragraph",
+        "text/line-height/paragraph",
+        "--charcoal-text-line-height-paragraph"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-weight.bold",
+      "figma": "text/font-weight/bold",
+      "css": "--charcoal-text-font-weight-bold",
+      "category": "text",
+      "group": "text",
+      "kind": "fontWeight",
+      "cssUsage": "font-weight: var(--charcoal-text-font-weight-bold)",
+      "tailwind": {
+        "key": "ch-bold",
+        "recommended": [
+          "font-ch-bold"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-weight.bold",
+        "classCandidates": [
+          {
+            "className": "font-ch-bold",
+            "utility": "fontWeight",
+            "cssProperties": [
+              "font-weight"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-weight.bold",
+      "notes": [],
+      "keys": [
+        "text.font-weight.bold",
+        "text/font-weight/bold",
+        "--charcoal-text-font-weight-bold",
+        "charcoal-text-font-weight-bold",
+        "font-ch-bold",
+        "text-font-weight-bold",
+        "font-weight/bold",
+        "font-weight-bold"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "text.font-weight.regular",
+      "figma": "text/font-weight/regular",
+      "css": "--charcoal-text-font-weight-regular",
+      "category": "text",
+      "group": "text",
+      "kind": "fontWeight",
+      "cssUsage": "font-weight: var(--charcoal-text-font-weight-regular)",
+      "tailwind": {
+        "key": "ch-regular",
+        "recommended": [
+          "font-ch-regular"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "text.font-weight.regular",
+        "classCandidates": [
+          {
+            "className": "font-ch-regular",
+            "utility": "fontWeight",
+            "cssProperties": [
+              "font-weight"
+            ]
+          }
+        ]
+      },
+      "familyKey": "text.font-weight.regular",
+      "notes": [],
+      "keys": [
+        "text.font-weight.regular",
+        "text/font-weight/regular",
+        "--charcoal-text-font-weight-regular",
+        "charcoal-text-font-weight-regular",
+        "font-ch-regular",
+        "text-font-weight-regular",
+        "font-weight/regular",
+        "font-weight-regular"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.0",
+      "figma": "space/component/0",
+      "css": "--charcoal-space-component-0",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-0); margin: var(--charcoal-space-component-0); gap: var(--charcoal-space-component-0)",
+      "tailwind": {
+        "key": "component-0",
+        "recommended": [
+          "p-component-0",
+          "m-component-0",
+          "gap-component-0"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.0",
+        "classCandidates": [
+          {
+            "className": "p-component-0",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-0",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-0",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.0",
+      "notes": [],
+      "keys": [
+        "space.component.0",
+        "space/component/0",
+        "--charcoal-space-component-0",
+        "charcoal-space-component-0",
+        "p-component-0",
+        "m-component-0",
+        "gap-component-0",
+        "space-component-0",
+        "component/0",
+        "component-0"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.10",
+      "figma": "space/component/10",
+      "css": "--charcoal-space-component-10",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-10); margin: var(--charcoal-space-component-10); gap: var(--charcoal-space-component-10)",
+      "tailwind": {
+        "key": "component-10",
+        "recommended": [
+          "p-component-10",
+          "m-component-10",
+          "gap-component-10"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.10",
+        "classCandidates": [
+          {
+            "className": "p-component-10",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-10",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-10",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.10",
+      "notes": [],
+      "keys": [
+        "space.component.10",
+        "space/component/10",
+        "--charcoal-space-component-10",
+        "charcoal-space-component-10",
+        "p-component-10",
+        "m-component-10",
+        "gap-component-10",
+        "space-component-10",
+        "component/10",
+        "component-10"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.20",
+      "figma": "space/component/20",
+      "css": "--charcoal-space-component-20",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-20); margin: var(--charcoal-space-component-20); gap: var(--charcoal-space-component-20)",
+      "tailwind": {
+        "key": "component-20",
+        "recommended": [
+          "p-component-20",
+          "m-component-20",
+          "gap-component-20"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.20",
+        "classCandidates": [
+          {
+            "className": "p-component-20",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-20",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-20",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.20",
+      "notes": [],
+      "keys": [
+        "space.component.20",
+        "space/component/20",
+        "--charcoal-space-component-20",
+        "charcoal-space-component-20",
+        "p-component-20",
+        "m-component-20",
+        "gap-component-20",
+        "space-component-20",
+        "component/20",
+        "component-20"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.25",
+      "figma": "space/component/25",
+      "css": "--charcoal-space-component-25",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-25); margin: var(--charcoal-space-component-25); gap: var(--charcoal-space-component-25)",
+      "tailwind": {
+        "key": "component-25",
+        "recommended": [
+          "p-component-25",
+          "m-component-25",
+          "gap-component-25"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.25",
+        "classCandidates": [
+          {
+            "className": "p-component-25",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-25",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-25",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.25",
+      "notes": [],
+      "keys": [
+        "space.component.25",
+        "space/component/25",
+        "--charcoal-space-component-25",
+        "charcoal-space-component-25",
+        "p-component-25",
+        "m-component-25",
+        "gap-component-25",
+        "space-component-25",
+        "component/25",
+        "component-25"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.30",
+      "figma": "space/component/30",
+      "css": "--charcoal-space-component-30",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-30); margin: var(--charcoal-space-component-30); gap: var(--charcoal-space-component-30)",
+      "tailwind": {
+        "key": "component-30",
+        "recommended": [
+          "p-component-30",
+          "m-component-30",
+          "gap-component-30"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.30",
+        "classCandidates": [
+          {
+            "className": "p-component-30",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-30",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-30",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.30",
+      "notes": [],
+      "keys": [
+        "space.component.30",
+        "space/component/30",
+        "--charcoal-space-component-30",
+        "charcoal-space-component-30",
+        "p-component-30",
+        "m-component-30",
+        "gap-component-30",
+        "space-component-30",
+        "component/30",
+        "component-30"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.40",
+      "figma": "space/component/40",
+      "css": "--charcoal-space-component-40",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-40); margin: var(--charcoal-space-component-40); gap: var(--charcoal-space-component-40)",
+      "tailwind": {
+        "key": "component-40",
+        "recommended": [
+          "p-component-40",
+          "m-component-40",
+          "gap-component-40"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.40",
+        "classCandidates": [
+          {
+            "className": "p-component-40",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-40",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-40",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.40",
+      "notes": [],
+      "keys": [
+        "space.component.40",
+        "space/component/40",
+        "--charcoal-space-component-40",
+        "charcoal-space-component-40",
+        "p-component-40",
+        "m-component-40",
+        "gap-component-40",
+        "space-component-40",
+        "component/40",
+        "component-40"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.component.50",
+      "figma": "space/component/50",
+      "css": "--charcoal-space-component-50",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-component-50); margin: var(--charcoal-space-component-50); gap: var(--charcoal-space-component-50)",
+      "tailwind": {
+        "key": "component-50",
+        "recommended": [
+          "p-component-50",
+          "m-component-50",
+          "gap-component-50"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.component.50",
+        "classCandidates": [
+          {
+            "className": "p-component-50",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-component-50",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-component-50",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.component.50",
+      "notes": [],
+      "keys": [
+        "space.component.50",
+        "space/component/50",
+        "--charcoal-space-component-50",
+        "charcoal-space-component-50",
+        "p-component-50",
+        "m-component-50",
+        "gap-component-50",
+        "space-component-50",
+        "component/50",
+        "component-50"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.0",
+      "figma": "space/layout/0",
+      "css": "--charcoal-space-layout-0",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-0); margin: var(--charcoal-space-layout-0); gap: var(--charcoal-space-layout-0)",
+      "tailwind": {
+        "key": "layout-0",
+        "recommended": [
+          "p-layout-0",
+          "m-layout-0",
+          "gap-layout-0"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.0",
+        "classCandidates": [
+          {
+            "className": "p-layout-0",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-0",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-0",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.0",
+      "notes": [],
+      "keys": [
+        "space.layout.0",
+        "space/layout/0",
+        "--charcoal-space-layout-0",
+        "charcoal-space-layout-0",
+        "p-layout-0",
+        "m-layout-0",
+        "gap-layout-0",
+        "space-layout-0",
+        "layout/0",
+        "layout-0"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.10",
+      "figma": "space/layout/10",
+      "css": "--charcoal-space-layout-10",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-10); margin: var(--charcoal-space-layout-10); gap: var(--charcoal-space-layout-10)",
+      "tailwind": {
+        "key": "layout-10",
+        "recommended": [
+          "p-layout-10",
+          "m-layout-10",
+          "gap-layout-10"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.10",
+        "classCandidates": [
+          {
+            "className": "p-layout-10",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-10",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-10",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.10",
+      "notes": [],
+      "keys": [
+        "space.layout.10",
+        "space/layout/10",
+        "--charcoal-space-layout-10",
+        "charcoal-space-layout-10",
+        "p-layout-10",
+        "m-layout-10",
+        "gap-layout-10",
+        "space-layout-10",
+        "layout/10",
+        "layout-10"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.20",
+      "figma": "space/layout/20",
+      "css": "--charcoal-space-layout-20",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-20); margin: var(--charcoal-space-layout-20); gap: var(--charcoal-space-layout-20)",
+      "tailwind": {
+        "key": "layout-20",
+        "recommended": [
+          "p-layout-20",
+          "m-layout-20",
+          "gap-layout-20"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.20",
+        "classCandidates": [
+          {
+            "className": "p-layout-20",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-20",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-20",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.20",
+      "notes": [],
+      "keys": [
+        "space.layout.20",
+        "space/layout/20",
+        "--charcoal-space-layout-20",
+        "charcoal-space-layout-20",
+        "p-layout-20",
+        "m-layout-20",
+        "gap-layout-20",
+        "space-layout-20",
+        "layout/20",
+        "layout-20"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.25",
+      "figma": "space/layout/25",
+      "css": "--charcoal-space-layout-25",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-25); margin: var(--charcoal-space-layout-25); gap: var(--charcoal-space-layout-25)",
+      "tailwind": {
+        "key": "layout-25",
+        "recommended": [
+          "p-layout-25",
+          "m-layout-25",
+          "gap-layout-25"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.25",
+        "classCandidates": [
+          {
+            "className": "p-layout-25",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-25",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-25",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.25",
+      "notes": [],
+      "keys": [
+        "space.layout.25",
+        "space/layout/25",
+        "--charcoal-space-layout-25",
+        "charcoal-space-layout-25",
+        "p-layout-25",
+        "m-layout-25",
+        "gap-layout-25",
+        "space-layout-25",
+        "layout/25",
+        "layout-25"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.30",
+      "figma": "space/layout/30",
+      "css": "--charcoal-space-layout-30",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-30); margin: var(--charcoal-space-layout-30); gap: var(--charcoal-space-layout-30)",
+      "tailwind": {
+        "key": "layout-30",
+        "recommended": [
+          "p-layout-30",
+          "m-layout-30",
+          "gap-layout-30"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.30",
+        "classCandidates": [
+          {
+            "className": "p-layout-30",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-30",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-30",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.30",
+      "notes": [],
+      "keys": [
+        "space.layout.30",
+        "space/layout/30",
+        "--charcoal-space-layout-30",
+        "charcoal-space-layout-30",
+        "p-layout-30",
+        "m-layout-30",
+        "gap-layout-30",
+        "space-layout-30",
+        "layout/30",
+        "layout-30"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.40",
+      "figma": "space/layout/40",
+      "css": "--charcoal-space-layout-40",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-40); margin: var(--charcoal-space-layout-40); gap: var(--charcoal-space-layout-40)",
+      "tailwind": {
+        "key": "layout-40",
+        "recommended": [
+          "p-layout-40",
+          "m-layout-40",
+          "gap-layout-40"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.40",
+        "classCandidates": [
+          {
+            "className": "p-layout-40",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-40",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-40",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.40",
+      "notes": [],
+      "keys": [
+        "space.layout.40",
+        "space/layout/40",
+        "--charcoal-space-layout-40",
+        "charcoal-space-layout-40",
+        "p-layout-40",
+        "m-layout-40",
+        "gap-layout-40",
+        "space-layout-40",
+        "layout/40",
+        "layout-40"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.50",
+      "figma": "space/layout/50",
+      "css": "--charcoal-space-layout-50",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-50); margin: var(--charcoal-space-layout-50); gap: var(--charcoal-space-layout-50)",
+      "tailwind": {
+        "key": "layout-50",
+        "recommended": [
+          "p-layout-50",
+          "m-layout-50",
+          "gap-layout-50"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.50",
+        "classCandidates": [
+          {
+            "className": "p-layout-50",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-50",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-50",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.50",
+      "notes": [],
+      "keys": [
+        "space.layout.50",
+        "space/layout/50",
+        "--charcoal-space-layout-50",
+        "charcoal-space-layout-50",
+        "p-layout-50",
+        "m-layout-50",
+        "gap-layout-50",
+        "space-layout-50",
+        "layout/50",
+        "layout-50"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.60",
+      "figma": "space/layout/60",
+      "css": "--charcoal-space-layout-60",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-60); margin: var(--charcoal-space-layout-60); gap: var(--charcoal-space-layout-60)",
+      "tailwind": {
+        "key": "layout-60",
+        "recommended": [
+          "p-layout-60",
+          "m-layout-60",
+          "gap-layout-60"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.60",
+        "classCandidates": [
+          {
+            "className": "p-layout-60",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-60",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-60",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.60",
+      "notes": [],
+      "keys": [
+        "space.layout.60",
+        "space/layout/60",
+        "--charcoal-space-layout-60",
+        "charcoal-space-layout-60",
+        "p-layout-60",
+        "m-layout-60",
+        "gap-layout-60",
+        "space-layout-60",
+        "layout/60",
+        "layout-60"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.70",
+      "figma": "space/layout/70",
+      "css": "--charcoal-space-layout-70",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-70); margin: var(--charcoal-space-layout-70); gap: var(--charcoal-space-layout-70)",
+      "tailwind": {
+        "key": "layout-70",
+        "recommended": [
+          "p-layout-70",
+          "m-layout-70",
+          "gap-layout-70"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.70",
+        "classCandidates": [
+          {
+            "className": "p-layout-70",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-70",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-70",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.70",
+      "notes": [],
+      "keys": [
+        "space.layout.70",
+        "space/layout/70",
+        "--charcoal-space-layout-70",
+        "charcoal-space-layout-70",
+        "p-layout-70",
+        "m-layout-70",
+        "gap-layout-70",
+        "space-layout-70",
+        "layout/70",
+        "layout-70"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.80",
+      "figma": "space/layout/80",
+      "css": "--charcoal-space-layout-80",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-80); margin: var(--charcoal-space-layout-80); gap: var(--charcoal-space-layout-80)",
+      "tailwind": {
+        "key": "layout-80",
+        "recommended": [
+          "p-layout-80",
+          "m-layout-80",
+          "gap-layout-80"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.80",
+        "classCandidates": [
+          {
+            "className": "p-layout-80",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-80",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-80",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.80",
+      "notes": [],
+      "keys": [
+        "space.layout.80",
+        "space/layout/80",
+        "--charcoal-space-layout-80",
+        "charcoal-space-layout-80",
+        "p-layout-80",
+        "m-layout-80",
+        "gap-layout-80",
+        "space-layout-80",
+        "layout/80",
+        "layout-80"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.90",
+      "figma": "space/layout/90",
+      "css": "--charcoal-space-layout-90",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-90); margin: var(--charcoal-space-layout-90); gap: var(--charcoal-space-layout-90)",
+      "tailwind": {
+        "key": "layout-90",
+        "recommended": [
+          "p-layout-90",
+          "m-layout-90",
+          "gap-layout-90"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.90",
+        "classCandidates": [
+          {
+            "className": "p-layout-90",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-90",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-90",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.90",
+      "notes": [],
+      "keys": [
+        "space.layout.90",
+        "space/layout/90",
+        "--charcoal-space-layout-90",
+        "charcoal-space-layout-90",
+        "p-layout-90",
+        "m-layout-90",
+        "gap-layout-90",
+        "space-layout-90",
+        "layout/90",
+        "layout-90"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.layout.100",
+      "figma": "space/layout/100",
+      "css": "--charcoal-space-layout-100",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-layout-100); margin: var(--charcoal-space-layout-100); gap: var(--charcoal-space-layout-100)",
+      "tailwind": {
+        "key": "layout-100",
+        "recommended": [
+          "p-layout-100",
+          "m-layout-100",
+          "gap-layout-100"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.layout.100",
+        "classCandidates": [
+          {
+            "className": "p-layout-100",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-layout-100",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-layout-100",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.layout.100",
+      "notes": [],
+      "keys": [
+        "space.layout.100",
+        "space/layout/100",
+        "--charcoal-space-layout-100",
+        "charcoal-space-layout-100",
+        "p-layout-100",
+        "m-layout-100",
+        "gap-layout-100",
+        "space-layout-100",
+        "layout/100",
+        "layout-100"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.padding.padding-card",
+      "figma": "space/padding/padding-card",
+      "css": "--charcoal-space-padding-padding-card",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-padding-padding-card); margin: var(--charcoal-space-padding-padding-card); gap: var(--charcoal-space-padding-padding-card)",
+      "tailwind": {
+        "key": "padding-card",
+        "recommended": [
+          "p-padding-card",
+          "m-padding-card",
+          "gap-padding-card"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.padding.padding-card",
+        "classCandidates": [
+          {
+            "className": "p-padding-card",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-padding-card",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-padding-card",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.padding.padding-card",
+      "notes": [],
+      "keys": [
+        "space.padding.padding-card",
+        "space/padding/padding-card",
+        "--charcoal-space-padding-padding-card",
+        "charcoal-space-padding-padding-card",
+        "p-padding-card",
+        "m-padding-card",
+        "gap-padding-card",
+        "space-padding-padding-card",
+        "padding/padding-card",
+        "padding-padding-card"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.target.l",
+      "figma": "space/target/l",
+      "css": "--charcoal-space-target-l",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-target-l); margin: var(--charcoal-space-target-l); gap: var(--charcoal-space-target-l)",
+      "tailwind": {
+        "key": "target-l",
+        "recommended": [
+          "p-target-l",
+          "m-target-l",
+          "gap-target-l"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.target.l",
+        "classCandidates": [
+          {
+            "className": "p-target-l",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-target-l",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-target-l",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.target.l",
+      "notes": [],
+      "keys": [
+        "space.target.l",
+        "space/target/l",
+        "--charcoal-space-target-l",
+        "charcoal-space-target-l",
+        "p-target-l",
+        "m-target-l",
+        "gap-target-l",
+        "space-target-l",
+        "target/l",
+        "target-l"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.target.m",
+      "figma": "space/target/m",
+      "css": "--charcoal-space-target-m",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-target-m); margin: var(--charcoal-space-target-m); gap: var(--charcoal-space-target-m)",
+      "tailwind": {
+        "key": "target-m",
+        "recommended": [
+          "p-target-m",
+          "m-target-m",
+          "gap-target-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.target.m",
+        "classCandidates": [
+          {
+            "className": "p-target-m",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-target-m",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-target-m",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.target.m",
+      "notes": [],
+      "keys": [
+        "space.target.m",
+        "space/target/m",
+        "--charcoal-space-target-m",
+        "charcoal-space-target-m",
+        "p-target-m",
+        "m-target-m",
+        "gap-target-m",
+        "space-target-m",
+        "target/m",
+        "target-m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.target.s",
+      "figma": "space/target/s",
+      "css": "--charcoal-space-target-s",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-target-s); margin: var(--charcoal-space-target-s); gap: var(--charcoal-space-target-s)",
+      "tailwind": {
+        "key": "target-s",
+        "recommended": [
+          "p-target-s",
+          "m-target-s",
+          "gap-target-s"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.target.s",
+        "classCandidates": [
+          {
+            "className": "p-target-s",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-target-s",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-target-s",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.target.s",
+      "notes": [],
+      "keys": [
+        "space.target.s",
+        "space/target/s",
+        "--charcoal-space-target-s",
+        "charcoal-space-target-s",
+        "p-target-s",
+        "m-target-s",
+        "gap-target-s",
+        "space-target-s",
+        "target/s",
+        "target-s"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "space.target.xs",
+      "figma": "space/target/xs",
+      "css": "--charcoal-space-target-xs",
+      "category": "space",
+      "group": "space",
+      "cssUsage": "padding: var(--charcoal-space-target-xs); margin: var(--charcoal-space-target-xs); gap: var(--charcoal-space-target-xs)",
+      "tailwind": {
+        "key": "target-xs",
+        "recommended": [
+          "p-target-xs",
+          "m-target-xs",
+          "gap-target-xs"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "space.target.xs",
+        "classCandidates": [
+          {
+            "className": "p-target-xs",
+            "utility": "spacing",
+            "cssProperties": [
+              "padding"
+            ]
+          },
+          {
+            "className": "m-target-xs",
+            "utility": "margin",
+            "cssProperties": [
+              "margin"
+            ]
+          },
+          {
+            "className": "gap-target-xs",
+            "utility": "gap",
+            "cssProperties": [
+              "gap"
+            ]
+          }
+        ]
+      },
+      "familyKey": "space.target.xs",
+      "notes": [],
+      "keys": [
+        "space.target.xs",
+        "space/target/xs",
+        "--charcoal-space-target-xs",
+        "charcoal-space-target-xs",
+        "p-target-xs",
+        "m-target-xs",
+        "gap-target-xs",
+        "space-target-xs",
+        "target/xs",
+        "target-xs"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.l",
+      "figma": "paragraph-width/l",
+      "css": "--charcoal-paragraph-width-l",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-l)",
+      "tailwind": {
+        "key": "l",
+        "recommended": [
+          "w-l"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.l",
+        "classCandidates": [
+          {
+            "className": "w-l",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.l",
+      "notes": [],
+      "keys": [
+        "paragraph-width.l",
+        "paragraph-width/l",
+        "--charcoal-paragraph-width-l",
+        "charcoal-paragraph-width-l",
+        "w-l",
+        "paragraph-width-l",
+        "l"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.l-compact",
+      "figma": "paragraph-width/l-compact",
+      "css": "--charcoal-paragraph-width-l-compact",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-l-compact)",
+      "tailwind": {
+        "key": "l-compact",
+        "recommended": [
+          "w-l-compact"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.l-compact",
+        "classCandidates": [
+          {
+            "className": "w-l-compact",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.l-compact",
+      "notes": [],
+      "keys": [
+        "paragraph-width.l-compact",
+        "paragraph-width/l-compact",
+        "--charcoal-paragraph-width-l-compact",
+        "charcoal-paragraph-width-l-compact",
+        "w-l-compact",
+        "paragraph-width-l-compact",
+        "l-compact"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.l-cozy",
+      "figma": "paragraph-width/l-cozy",
+      "css": "--charcoal-paragraph-width-l-cozy",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-l-cozy)",
+      "tailwind": {
+        "key": "l-cozy",
+        "recommended": [
+          "w-l-cozy"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.l-cozy",
+        "classCandidates": [
+          {
+            "className": "w-l-cozy",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.l-cozy",
+      "notes": [],
+      "keys": [
+        "paragraph-width.l-cozy",
+        "paragraph-width/l-cozy",
+        "--charcoal-paragraph-width-l-cozy",
+        "charcoal-paragraph-width-l-cozy",
+        "w-l-cozy",
+        "paragraph-width-l-cozy",
+        "l-cozy"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.m",
+      "figma": "paragraph-width/m",
+      "css": "--charcoal-paragraph-width-m",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-m)",
+      "tailwind": {
+        "key": "m",
+        "recommended": [
+          "w-m"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.m",
+        "classCandidates": [
+          {
+            "className": "w-m",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.m",
+      "notes": [],
+      "keys": [
+        "paragraph-width.m",
+        "paragraph-width/m",
+        "--charcoal-paragraph-width-m",
+        "charcoal-paragraph-width-m",
+        "w-m",
+        "paragraph-width-m",
+        "m"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.m-compact",
+      "figma": "paragraph-width/m-compact",
+      "css": "--charcoal-paragraph-width-m-compact",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-m-compact)",
+      "tailwind": {
+        "key": "m-compact",
+        "recommended": [
+          "w-m-compact"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.m-compact",
+        "classCandidates": [
+          {
+            "className": "w-m-compact",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.m-compact",
+      "notes": [],
+      "keys": [
+        "paragraph-width.m-compact",
+        "paragraph-width/m-compact",
+        "--charcoal-paragraph-width-m-compact",
+        "charcoal-paragraph-width-m-compact",
+        "w-m-compact",
+        "paragraph-width-m-compact",
+        "m-compact"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.m-cozy",
+      "figma": "paragraph-width/m-cozy",
+      "css": "--charcoal-paragraph-width-m-cozy",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-m-cozy)",
+      "tailwind": {
+        "key": "m-cozy",
+        "recommended": [
+          "w-m-cozy"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.m-cozy",
+        "classCandidates": [
+          {
+            "className": "w-m-cozy",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.m-cozy",
+      "notes": [],
+      "keys": [
+        "paragraph-width.m-cozy",
+        "paragraph-width/m-cozy",
+        "--charcoal-paragraph-width-m-cozy",
+        "charcoal-paragraph-width-m-cozy",
+        "w-m-cozy",
+        "paragraph-width-m-cozy",
+        "m-cozy"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.s",
+      "figma": "paragraph-width/s",
+      "css": "--charcoal-paragraph-width-s",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-s)",
+      "tailwind": {
+        "key": "s",
+        "recommended": [
+          "w-s"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.s",
+        "classCandidates": [
+          {
+            "className": "w-s",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.s",
+      "notes": [],
+      "keys": [
+        "paragraph-width.s",
+        "paragraph-width/s",
+        "--charcoal-paragraph-width-s",
+        "charcoal-paragraph-width-s",
+        "w-s",
+        "paragraph-width-s",
+        "s"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.s-compact",
+      "figma": "paragraph-width/s-compact",
+      "css": "--charcoal-paragraph-width-s-compact",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-s-compact)",
+      "tailwind": {
+        "key": "s-compact",
+        "recommended": [
+          "w-s-compact"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.s-compact",
+        "classCandidates": [
+          {
+            "className": "w-s-compact",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.s-compact",
+      "notes": [],
+      "keys": [
+        "paragraph-width.s-compact",
+        "paragraph-width/s-compact",
+        "--charcoal-paragraph-width-s-compact",
+        "charcoal-paragraph-width-s-compact",
+        "w-s-compact",
+        "paragraph-width-s-compact",
+        "s-compact"
+      ]
+    },
+    {
+      "layer": "semantic",
+      "tokenPath": "paragraph-width.s-cozy",
+      "figma": "paragraph-width/s-cozy",
+      "css": "--charcoal-paragraph-width-s-cozy",
+      "category": "paragraphWidth",
+      "group": "paragraph-width",
+      "cssUsage": "width: var(--charcoal-paragraph-width-s-cozy)",
+      "tailwind": {
+        "key": "s-cozy",
+        "recommended": [
+          "w-s-cozy"
+        ],
+        "alsoValid": []
+      },
+      "mapping": {
+        "tokenPath": "paragraph-width.s-cozy",
+        "classCandidates": [
+          {
+            "className": "w-s-cozy",
+            "utility": "width",
+            "cssProperties": [
+              "width"
+            ]
+          }
+        ]
+      },
+      "familyKey": "paragraph-width.s-cozy",
+      "notes": [],
+      "keys": [
+        "paragraph-width.s-cozy",
+        "paragraph-width/s-cozy",
+        "--charcoal-paragraph-width-s-cozy",
+        "charcoal-paragraph-width-s-cozy",
+        "w-s-cozy",
+        "paragraph-width-s-cozy",
+        "s-cozy"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Cyan.50",
+      "figma": "color/Light/Cyan/50",
+      "css": "--charcoal-color-light-cyan-50",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Cyan.50",
+        "color/Light/Cyan/50",
+        "--charcoal-color-light-cyan-50",
+        "charcoal-color-light-cyan-50",
+        "color-Light-Cyan-50",
+        "Light/Cyan/50",
+        "Light-Cyan-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.10",
+      "figma": "color/Light/Emerald/10",
+      "css": "--charcoal-color-light-emerald-10",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.10",
+        "color/Light/Emerald/10",
+        "--charcoal-color-light-emerald-10",
+        "charcoal-color-light-emerald-10",
+        "color-Light-Emerald-10",
+        "Light/Emerald/10",
+        "Light-Emerald-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.20",
+      "figma": "color/Light/Emerald/20",
+      "css": "--charcoal-color-light-emerald-20",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.20",
+        "color/Light/Emerald/20",
+        "--charcoal-color-light-emerald-20",
+        "charcoal-color-light-emerald-20",
+        "color-Light-Emerald-20",
+        "Light/Emerald/20",
+        "Light-Emerald-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.30",
+      "figma": "color/Light/Emerald/30",
+      "css": "--charcoal-color-light-emerald-30",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.30",
+        "color/Light/Emerald/30",
+        "--charcoal-color-light-emerald-30",
+        "charcoal-color-light-emerald-30",
+        "color-Light-Emerald-30",
+        "Light/Emerald/30",
+        "Light-Emerald-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.40",
+      "figma": "color/Light/Emerald/40",
+      "css": "--charcoal-color-light-emerald-40",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.40",
+        "color/Light/Emerald/40",
+        "--charcoal-color-light-emerald-40",
+        "charcoal-color-light-emerald-40",
+        "color-Light-Emerald-40",
+        "Light/Emerald/40",
+        "Light-Emerald-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.5",
+      "figma": "color/Light/Emerald/5",
+      "css": "--charcoal-color-light-emerald-5",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.5",
+        "color/Light/Emerald/5",
+        "--charcoal-color-light-emerald-5",
+        "charcoal-color-light-emerald-5",
+        "color-Light-Emerald-5",
+        "Light/Emerald/5",
+        "Light-Emerald-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.50",
+      "figma": "color/Light/Emerald/50",
+      "css": "--charcoal-color-light-emerald-50",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.50",
+        "color/Light/Emerald/50",
+        "--charcoal-color-light-emerald-50",
+        "charcoal-color-light-emerald-50",
+        "color-Light-Emerald-50",
+        "Light/Emerald/50",
+        "Light-Emerald-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.60",
+      "figma": "color/Light/Emerald/60",
+      "css": "--charcoal-color-light-emerald-60",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.60",
+        "color/Light/Emerald/60",
+        "--charcoal-color-light-emerald-60",
+        "charcoal-color-light-emerald-60",
+        "color-Light-Emerald-60",
+        "Light/Emerald/60",
+        "Light-Emerald-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.70",
+      "figma": "color/Light/Emerald/70",
+      "css": "--charcoal-color-light-emerald-70",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.70",
+        "color/Light/Emerald/70",
+        "--charcoal-color-light-emerald-70",
+        "charcoal-color-light-emerald-70",
+        "color-Light-Emerald-70",
+        "Light/Emerald/70",
+        "Light-Emerald-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.80",
+      "figma": "color/Light/Emerald/80",
+      "css": "--charcoal-color-light-emerald-80",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.80",
+        "color/Light/Emerald/80",
+        "--charcoal-color-light-emerald-80",
+        "charcoal-color-light-emerald-80",
+        "color-Light-Emerald-80",
+        "Light/Emerald/80",
+        "Light-Emerald-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.Light.Emerald.90",
+      "figma": "color/Light/Emerald/90",
+      "css": "--charcoal-color-light-emerald-90",
+      "category": "color",
+      "group": "Light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.Light.Emerald.90",
+        "color/Light/Emerald/90",
+        "--charcoal-color-light-emerald-90",
+        "charcoal-color-light-emerald-90",
+        "color-Light-Emerald-90",
+        "Light/Emerald/90",
+        "Light-Emerald-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.-10",
+      "figma": "color/dark/blue/-10",
+      "css": "--charcoal-color-dark-blue--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.-10",
+        "color/dark/blue/-10",
+        "--charcoal-color-dark-blue--10",
+        "charcoal-color-dark-blue--10",
+        "color-dark-blue--10",
+        "dark/blue/-10",
+        "dark-blue--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.-5",
+      "figma": "color/dark/blue/-5",
+      "css": "--charcoal-color-dark-blue--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.-5",
+        "color/dark/blue/-5",
+        "--charcoal-color-dark-blue--5",
+        "charcoal-color-dark-blue--5",
+        "color-dark-blue--5",
+        "dark/blue/-5",
+        "dark-blue--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.0",
+      "figma": "color/dark/blue/0",
+      "css": "--charcoal-color-dark-blue-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.0",
+        "color/dark/blue/0",
+        "--charcoal-color-dark-blue-0",
+        "charcoal-color-dark-blue-0",
+        "color-dark-blue-0",
+        "dark/blue/0",
+        "dark-blue-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.10",
+      "figma": "color/dark/blue/10",
+      "css": "--charcoal-color-dark-blue-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.10",
+        "color/dark/blue/10",
+        "--charcoal-color-dark-blue-10",
+        "charcoal-color-dark-blue-10",
+        "color-dark-blue-10",
+        "dark/blue/10",
+        "dark-blue-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.20",
+      "figma": "color/dark/blue/20",
+      "css": "--charcoal-color-dark-blue-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.20",
+        "color/dark/blue/20",
+        "--charcoal-color-dark-blue-20",
+        "charcoal-color-dark-blue-20",
+        "color-dark-blue-20",
+        "dark/blue/20",
+        "dark-blue-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.30",
+      "figma": "color/dark/blue/30",
+      "css": "--charcoal-color-dark-blue-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.30",
+        "color/dark/blue/30",
+        "--charcoal-color-dark-blue-30",
+        "charcoal-color-dark-blue-30",
+        "color-dark-blue-30",
+        "dark/blue/30",
+        "dark-blue-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.40",
+      "figma": "color/dark/blue/40",
+      "css": "--charcoal-color-dark-blue-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.40",
+        "color/dark/blue/40",
+        "--charcoal-color-dark-blue-40",
+        "charcoal-color-dark-blue-40",
+        "color-dark-blue-40",
+        "dark/blue/40",
+        "dark-blue-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.5",
+      "figma": "color/dark/blue/5",
+      "css": "--charcoal-color-dark-blue-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.5",
+        "color/dark/blue/5",
+        "--charcoal-color-dark-blue-5",
+        "charcoal-color-dark-blue-5",
+        "color-dark-blue-5",
+        "dark/blue/5",
+        "dark-blue-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.50",
+      "figma": "color/dark/blue/50",
+      "css": "--charcoal-color-dark-blue-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.50",
+        "color/dark/blue/50",
+        "--charcoal-color-dark-blue-50",
+        "charcoal-color-dark-blue-50",
+        "color-dark-blue-50",
+        "dark/blue/50",
+        "dark-blue-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.60",
+      "figma": "color/dark/blue/60",
+      "css": "--charcoal-color-dark-blue-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.60",
+        "color/dark/blue/60",
+        "--charcoal-color-dark-blue-60",
+        "charcoal-color-dark-blue-60",
+        "color-dark-blue-60",
+        "dark/blue/60",
+        "dark-blue-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.70",
+      "figma": "color/dark/blue/70",
+      "css": "--charcoal-color-dark-blue-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.70",
+        "color/dark/blue/70",
+        "--charcoal-color-dark-blue-70",
+        "charcoal-color-dark-blue-70",
+        "color-dark-blue-70",
+        "dark/blue/70",
+        "dark-blue-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.80",
+      "figma": "color/dark/blue/80",
+      "css": "--charcoal-color-dark-blue-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.80",
+        "color/dark/blue/80",
+        "--charcoal-color-dark-blue-80",
+        "charcoal-color-dark-blue-80",
+        "color-dark-blue-80",
+        "dark/blue/80",
+        "dark-blue-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.blue.90",
+      "figma": "color/dark/blue/90",
+      "css": "--charcoal-color-dark-blue-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.blue.90",
+        "color/dark/blue/90",
+        "--charcoal-color-dark-blue-90",
+        "charcoal-color-dark-blue-90",
+        "color-dark-blue-90",
+        "dark/blue/90",
+        "dark-blue-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.-10",
+      "figma": "color/dark/green/-10",
+      "css": "--charcoal-color-dark-green--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.-10",
+        "color/dark/green/-10",
+        "--charcoal-color-dark-green--10",
+        "charcoal-color-dark-green--10",
+        "color-dark-green--10",
+        "dark/green/-10",
+        "dark-green--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.-5",
+      "figma": "color/dark/green/-5",
+      "css": "--charcoal-color-dark-green--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.-5",
+        "color/dark/green/-5",
+        "--charcoal-color-dark-green--5",
+        "charcoal-color-dark-green--5",
+        "color-dark-green--5",
+        "dark/green/-5",
+        "dark-green--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.0",
+      "figma": "color/dark/green/0",
+      "css": "--charcoal-color-dark-green-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.0",
+        "color/dark/green/0",
+        "--charcoal-color-dark-green-0",
+        "charcoal-color-dark-green-0",
+        "color-dark-green-0",
+        "dark/green/0",
+        "dark-green-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.10",
+      "figma": "color/dark/green/10",
+      "css": "--charcoal-color-dark-green-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.10",
+        "color/dark/green/10",
+        "--charcoal-color-dark-green-10",
+        "charcoal-color-dark-green-10",
+        "color-dark-green-10",
+        "dark/green/10",
+        "dark-green-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.20",
+      "figma": "color/dark/green/20",
+      "css": "--charcoal-color-dark-green-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.20",
+        "color/dark/green/20",
+        "--charcoal-color-dark-green-20",
+        "charcoal-color-dark-green-20",
+        "color-dark-green-20",
+        "dark/green/20",
+        "dark-green-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.30",
+      "figma": "color/dark/green/30",
+      "css": "--charcoal-color-dark-green-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.30",
+        "color/dark/green/30",
+        "--charcoal-color-dark-green-30",
+        "charcoal-color-dark-green-30",
+        "color-dark-green-30",
+        "dark/green/30",
+        "dark-green-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.40",
+      "figma": "color/dark/green/40",
+      "css": "--charcoal-color-dark-green-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.40",
+        "color/dark/green/40",
+        "--charcoal-color-dark-green-40",
+        "charcoal-color-dark-green-40",
+        "color-dark-green-40",
+        "dark/green/40",
+        "dark-green-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.5",
+      "figma": "color/dark/green/5",
+      "css": "--charcoal-color-dark-green-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.5",
+        "color/dark/green/5",
+        "--charcoal-color-dark-green-5",
+        "charcoal-color-dark-green-5",
+        "color-dark-green-5",
+        "dark/green/5",
+        "dark-green-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.50",
+      "figma": "color/dark/green/50",
+      "css": "--charcoal-color-dark-green-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.50",
+        "color/dark/green/50",
+        "--charcoal-color-dark-green-50",
+        "charcoal-color-dark-green-50",
+        "color-dark-green-50",
+        "dark/green/50",
+        "dark-green-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.60",
+      "figma": "color/dark/green/60",
+      "css": "--charcoal-color-dark-green-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.60",
+        "color/dark/green/60",
+        "--charcoal-color-dark-green-60",
+        "charcoal-color-dark-green-60",
+        "color-dark-green-60",
+        "dark/green/60",
+        "dark-green-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.70",
+      "figma": "color/dark/green/70",
+      "css": "--charcoal-color-dark-green-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.70",
+        "color/dark/green/70",
+        "--charcoal-color-dark-green-70",
+        "charcoal-color-dark-green-70",
+        "color-dark-green-70",
+        "dark/green/70",
+        "dark-green-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.80",
+      "figma": "color/dark/green/80",
+      "css": "--charcoal-color-dark-green-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.80",
+        "color/dark/green/80",
+        "--charcoal-color-dark-green-80",
+        "charcoal-color-dark-green-80",
+        "color-dark-green-80",
+        "dark/green/80",
+        "dark-green-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.green.90",
+      "figma": "color/dark/green/90",
+      "css": "--charcoal-color-dark-green-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.green.90",
+        "color/dark/green/90",
+        "--charcoal-color-dark-green-90",
+        "charcoal-color-dark-green-90",
+        "color-dark-green-90",
+        "dark/green/90",
+        "dark-green-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.-10",
+      "figma": "color/dark/indigo/-10",
+      "css": "--charcoal-color-dark-indigo--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.-10",
+        "color/dark/indigo/-10",
+        "--charcoal-color-dark-indigo--10",
+        "charcoal-color-dark-indigo--10",
+        "color-dark-indigo--10",
+        "dark/indigo/-10",
+        "dark-indigo--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.-5",
+      "figma": "color/dark/indigo/-5",
+      "css": "--charcoal-color-dark-indigo--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.-5",
+        "color/dark/indigo/-5",
+        "--charcoal-color-dark-indigo--5",
+        "charcoal-color-dark-indigo--5",
+        "color-dark-indigo--5",
+        "dark/indigo/-5",
+        "dark-indigo--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.0",
+      "figma": "color/dark/indigo/0",
+      "css": "--charcoal-color-dark-indigo-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.0",
+        "color/dark/indigo/0",
+        "--charcoal-color-dark-indigo-0",
+        "charcoal-color-dark-indigo-0",
+        "color-dark-indigo-0",
+        "dark/indigo/0",
+        "dark-indigo-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.10",
+      "figma": "color/dark/indigo/10",
+      "css": "--charcoal-color-dark-indigo-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.10",
+        "color/dark/indigo/10",
+        "--charcoal-color-dark-indigo-10",
+        "charcoal-color-dark-indigo-10",
+        "color-dark-indigo-10",
+        "dark/indigo/10",
+        "dark-indigo-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.20",
+      "figma": "color/dark/indigo/20",
+      "css": "--charcoal-color-dark-indigo-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.20",
+        "color/dark/indigo/20",
+        "--charcoal-color-dark-indigo-20",
+        "charcoal-color-dark-indigo-20",
+        "color-dark-indigo-20",
+        "dark/indigo/20",
+        "dark-indigo-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.30",
+      "figma": "color/dark/indigo/30",
+      "css": "--charcoal-color-dark-indigo-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.30",
+        "color/dark/indigo/30",
+        "--charcoal-color-dark-indigo-30",
+        "charcoal-color-dark-indigo-30",
+        "color-dark-indigo-30",
+        "dark/indigo/30",
+        "dark-indigo-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.40",
+      "figma": "color/dark/indigo/40",
+      "css": "--charcoal-color-dark-indigo-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.40",
+        "color/dark/indigo/40",
+        "--charcoal-color-dark-indigo-40",
+        "charcoal-color-dark-indigo-40",
+        "color-dark-indigo-40",
+        "dark/indigo/40",
+        "dark-indigo-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.5",
+      "figma": "color/dark/indigo/5",
+      "css": "--charcoal-color-dark-indigo-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.5",
+        "color/dark/indigo/5",
+        "--charcoal-color-dark-indigo-5",
+        "charcoal-color-dark-indigo-5",
+        "color-dark-indigo-5",
+        "dark/indigo/5",
+        "dark-indigo-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.50",
+      "figma": "color/dark/indigo/50",
+      "css": "--charcoal-color-dark-indigo-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.50",
+        "color/dark/indigo/50",
+        "--charcoal-color-dark-indigo-50",
+        "charcoal-color-dark-indigo-50",
+        "color-dark-indigo-50",
+        "dark/indigo/50",
+        "dark-indigo-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.60",
+      "figma": "color/dark/indigo/60",
+      "css": "--charcoal-color-dark-indigo-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.60",
+        "color/dark/indigo/60",
+        "--charcoal-color-dark-indigo-60",
+        "charcoal-color-dark-indigo-60",
+        "color-dark-indigo-60",
+        "dark/indigo/60",
+        "dark-indigo-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.70",
+      "figma": "color/dark/indigo/70",
+      "css": "--charcoal-color-dark-indigo-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.70",
+        "color/dark/indigo/70",
+        "--charcoal-color-dark-indigo-70",
+        "charcoal-color-dark-indigo-70",
+        "color-dark-indigo-70",
+        "dark/indigo/70",
+        "dark-indigo-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.80",
+      "figma": "color/dark/indigo/80",
+      "css": "--charcoal-color-dark-indigo-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.80",
+        "color/dark/indigo/80",
+        "--charcoal-color-dark-indigo-80",
+        "charcoal-color-dark-indigo-80",
+        "color-dark-indigo-80",
+        "dark/indigo/80",
+        "dark-indigo-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.indigo.90",
+      "figma": "color/dark/indigo/90",
+      "css": "--charcoal-color-dark-indigo-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.indigo.90",
+        "color/dark/indigo/90",
+        "--charcoal-color-dark-indigo-90",
+        "charcoal-color-dark-indigo-90",
+        "color-dark-indigo-90",
+        "dark/indigo/90",
+        "dark-indigo-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.-10",
+      "figma": "color/dark/magenta/-10",
+      "css": "--charcoal-color-dark-magenta--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.-10",
+        "color/dark/magenta/-10",
+        "--charcoal-color-dark-magenta--10",
+        "charcoal-color-dark-magenta--10",
+        "color-dark-magenta--10",
+        "dark/magenta/-10",
+        "dark-magenta--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.-5",
+      "figma": "color/dark/magenta/-5",
+      "css": "--charcoal-color-dark-magenta--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.-5",
+        "color/dark/magenta/-5",
+        "--charcoal-color-dark-magenta--5",
+        "charcoal-color-dark-magenta--5",
+        "color-dark-magenta--5",
+        "dark/magenta/-5",
+        "dark-magenta--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.0",
+      "figma": "color/dark/magenta/0",
+      "css": "--charcoal-color-dark-magenta-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.0",
+        "color/dark/magenta/0",
+        "--charcoal-color-dark-magenta-0",
+        "charcoal-color-dark-magenta-0",
+        "color-dark-magenta-0",
+        "dark/magenta/0",
+        "dark-magenta-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.10",
+      "figma": "color/dark/magenta/10",
+      "css": "--charcoal-color-dark-magenta-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.10",
+        "color/dark/magenta/10",
+        "--charcoal-color-dark-magenta-10",
+        "charcoal-color-dark-magenta-10",
+        "color-dark-magenta-10",
+        "dark/magenta/10",
+        "dark-magenta-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.20",
+      "figma": "color/dark/magenta/20",
+      "css": "--charcoal-color-dark-magenta-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.20",
+        "color/dark/magenta/20",
+        "--charcoal-color-dark-magenta-20",
+        "charcoal-color-dark-magenta-20",
+        "color-dark-magenta-20",
+        "dark/magenta/20",
+        "dark-magenta-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.30",
+      "figma": "color/dark/magenta/30",
+      "css": "--charcoal-color-dark-magenta-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.30",
+        "color/dark/magenta/30",
+        "--charcoal-color-dark-magenta-30",
+        "charcoal-color-dark-magenta-30",
+        "color-dark-magenta-30",
+        "dark/magenta/30",
+        "dark-magenta-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.40",
+      "figma": "color/dark/magenta/40",
+      "css": "--charcoal-color-dark-magenta-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.40",
+        "color/dark/magenta/40",
+        "--charcoal-color-dark-magenta-40",
+        "charcoal-color-dark-magenta-40",
+        "color-dark-magenta-40",
+        "dark/magenta/40",
+        "dark-magenta-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.5",
+      "figma": "color/dark/magenta/5",
+      "css": "--charcoal-color-dark-magenta-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.5",
+        "color/dark/magenta/5",
+        "--charcoal-color-dark-magenta-5",
+        "charcoal-color-dark-magenta-5",
+        "color-dark-magenta-5",
+        "dark/magenta/5",
+        "dark-magenta-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.50",
+      "figma": "color/dark/magenta/50",
+      "css": "--charcoal-color-dark-magenta-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.50",
+        "color/dark/magenta/50",
+        "--charcoal-color-dark-magenta-50",
+        "charcoal-color-dark-magenta-50",
+        "color-dark-magenta-50",
+        "dark/magenta/50",
+        "dark-magenta-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.60",
+      "figma": "color/dark/magenta/60",
+      "css": "--charcoal-color-dark-magenta-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.60",
+        "color/dark/magenta/60",
+        "--charcoal-color-dark-magenta-60",
+        "charcoal-color-dark-magenta-60",
+        "color-dark-magenta-60",
+        "dark/magenta/60",
+        "dark-magenta-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.70",
+      "figma": "color/dark/magenta/70",
+      "css": "--charcoal-color-dark-magenta-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.70",
+        "color/dark/magenta/70",
+        "--charcoal-color-dark-magenta-70",
+        "charcoal-color-dark-magenta-70",
+        "color-dark-magenta-70",
+        "dark/magenta/70",
+        "dark-magenta-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.80",
+      "figma": "color/dark/magenta/80",
+      "css": "--charcoal-color-dark-magenta-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.80",
+        "color/dark/magenta/80",
+        "--charcoal-color-dark-magenta-80",
+        "charcoal-color-dark-magenta-80",
+        "color-dark-magenta-80",
+        "dark/magenta/80",
+        "dark-magenta-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.magenta.90",
+      "figma": "color/dark/magenta/90",
+      "css": "--charcoal-color-dark-magenta-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.magenta.90",
+        "color/dark/magenta/90",
+        "--charcoal-color-dark-magenta-90",
+        "charcoal-color-dark-magenta-90",
+        "color-dark-magenta-90",
+        "dark/magenta/90",
+        "dark-magenta-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.-10",
+      "figma": "color/dark/neutral-a/-10",
+      "css": "--charcoal-color-dark-neutral-a--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.-10",
+        "color/dark/neutral-a/-10",
+        "--charcoal-color-dark-neutral-a--10",
+        "charcoal-color-dark-neutral-a--10",
+        "color-dark-neutral-a--10",
+        "dark/neutral-a/-10",
+        "dark-neutral-a--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.-5",
+      "figma": "color/dark/neutral-a/-5",
+      "css": "--charcoal-color-dark-neutral-a--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.-5",
+        "color/dark/neutral-a/-5",
+        "--charcoal-color-dark-neutral-a--5",
+        "charcoal-color-dark-neutral-a--5",
+        "color-dark-neutral-a--5",
+        "dark/neutral-a/-5",
+        "dark-neutral-a--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.0",
+      "figma": "color/dark/neutral-a/0",
+      "css": "--charcoal-color-dark-neutral-a-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.0",
+        "color/dark/neutral-a/0",
+        "--charcoal-color-dark-neutral-a-0",
+        "charcoal-color-dark-neutral-a-0",
+        "color-dark-neutral-a-0",
+        "dark/neutral-a/0",
+        "dark-neutral-a-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.10",
+      "figma": "color/dark/neutral-a/10",
+      "css": "--charcoal-color-dark-neutral-a-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.10",
+        "color/dark/neutral-a/10",
+        "--charcoal-color-dark-neutral-a-10",
+        "charcoal-color-dark-neutral-a-10",
+        "color-dark-neutral-a-10",
+        "dark/neutral-a/10",
+        "dark-neutral-a-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.20",
+      "figma": "color/dark/neutral-a/20",
+      "css": "--charcoal-color-dark-neutral-a-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.20",
+        "color/dark/neutral-a/20",
+        "--charcoal-color-dark-neutral-a-20",
+        "charcoal-color-dark-neutral-a-20",
+        "color-dark-neutral-a-20",
+        "dark/neutral-a/20",
+        "dark-neutral-a-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.30",
+      "figma": "color/dark/neutral-a/30",
+      "css": "--charcoal-color-dark-neutral-a-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.30",
+        "color/dark/neutral-a/30",
+        "--charcoal-color-dark-neutral-a-30",
+        "charcoal-color-dark-neutral-a-30",
+        "color-dark-neutral-a-30",
+        "dark/neutral-a/30",
+        "dark-neutral-a-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.40",
+      "figma": "color/dark/neutral-a/40",
+      "css": "--charcoal-color-dark-neutral-a-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.40",
+        "color/dark/neutral-a/40",
+        "--charcoal-color-dark-neutral-a-40",
+        "charcoal-color-dark-neutral-a-40",
+        "color-dark-neutral-a-40",
+        "dark/neutral-a/40",
+        "dark-neutral-a-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.5",
+      "figma": "color/dark/neutral-a/5",
+      "css": "--charcoal-color-dark-neutral-a-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.5",
+        "color/dark/neutral-a/5",
+        "--charcoal-color-dark-neutral-a-5",
+        "charcoal-color-dark-neutral-a-5",
+        "color-dark-neutral-a-5",
+        "dark/neutral-a/5",
+        "dark-neutral-a-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.50",
+      "figma": "color/dark/neutral-a/50",
+      "css": "--charcoal-color-dark-neutral-a-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.50",
+        "color/dark/neutral-a/50",
+        "--charcoal-color-dark-neutral-a-50",
+        "charcoal-color-dark-neutral-a-50",
+        "color-dark-neutral-a-50",
+        "dark/neutral-a/50",
+        "dark-neutral-a-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.60",
+      "figma": "color/dark/neutral-a/60",
+      "css": "--charcoal-color-dark-neutral-a-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.60",
+        "color/dark/neutral-a/60",
+        "--charcoal-color-dark-neutral-a-60",
+        "charcoal-color-dark-neutral-a-60",
+        "color-dark-neutral-a-60",
+        "dark/neutral-a/60",
+        "dark-neutral-a-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.70",
+      "figma": "color/dark/neutral-a/70",
+      "css": "--charcoal-color-dark-neutral-a-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.70",
+        "color/dark/neutral-a/70",
+        "--charcoal-color-dark-neutral-a-70",
+        "charcoal-color-dark-neutral-a-70",
+        "color-dark-neutral-a-70",
+        "dark/neutral-a/70",
+        "dark-neutral-a-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.80",
+      "figma": "color/dark/neutral-a/80",
+      "css": "--charcoal-color-dark-neutral-a-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.80",
+        "color/dark/neutral-a/80",
+        "--charcoal-color-dark-neutral-a-80",
+        "charcoal-color-dark-neutral-a-80",
+        "color-dark-neutral-a-80",
+        "dark/neutral-a/80",
+        "dark-neutral-a-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral-a.90",
+      "figma": "color/dark/neutral-a/90",
+      "css": "--charcoal-color-dark-neutral-a-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral-a.90",
+        "color/dark/neutral-a/90",
+        "--charcoal-color-dark-neutral-a-90",
+        "charcoal-color-dark-neutral-a-90",
+        "color-dark-neutral-a-90",
+        "dark/neutral-a/90",
+        "dark-neutral-a-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.-10",
+      "figma": "color/dark/neutral/-10",
+      "css": "--charcoal-color-dark-neutral--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.-10",
+        "color/dark/neutral/-10",
+        "--charcoal-color-dark-neutral--10",
+        "charcoal-color-dark-neutral--10",
+        "color-dark-neutral--10",
+        "dark/neutral/-10",
+        "dark-neutral--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.-5",
+      "figma": "color/dark/neutral/-5",
+      "css": "--charcoal-color-dark-neutral--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.-5",
+        "color/dark/neutral/-5",
+        "--charcoal-color-dark-neutral--5",
+        "charcoal-color-dark-neutral--5",
+        "color-dark-neutral--5",
+        "dark/neutral/-5",
+        "dark-neutral--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.0",
+      "figma": "color/dark/neutral/0",
+      "css": "--charcoal-color-dark-neutral-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.0",
+        "color/dark/neutral/0",
+        "--charcoal-color-dark-neutral-0",
+        "charcoal-color-dark-neutral-0",
+        "color-dark-neutral-0",
+        "dark/neutral/0",
+        "dark-neutral-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.10",
+      "figma": "color/dark/neutral/10",
+      "css": "--charcoal-color-dark-neutral-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.10",
+        "color/dark/neutral/10",
+        "--charcoal-color-dark-neutral-10",
+        "charcoal-color-dark-neutral-10",
+        "color-dark-neutral-10",
+        "dark/neutral/10",
+        "dark-neutral-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.20",
+      "figma": "color/dark/neutral/20",
+      "css": "--charcoal-color-dark-neutral-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.20",
+        "color/dark/neutral/20",
+        "--charcoal-color-dark-neutral-20",
+        "charcoal-color-dark-neutral-20",
+        "color-dark-neutral-20",
+        "dark/neutral/20",
+        "dark-neutral-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.30",
+      "figma": "color/dark/neutral/30",
+      "css": "--charcoal-color-dark-neutral-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.30",
+        "color/dark/neutral/30",
+        "--charcoal-color-dark-neutral-30",
+        "charcoal-color-dark-neutral-30",
+        "color-dark-neutral-30",
+        "dark/neutral/30",
+        "dark-neutral-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.40",
+      "figma": "color/dark/neutral/40",
+      "css": "--charcoal-color-dark-neutral-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.40",
+        "color/dark/neutral/40",
+        "--charcoal-color-dark-neutral-40",
+        "charcoal-color-dark-neutral-40",
+        "color-dark-neutral-40",
+        "dark/neutral/40",
+        "dark-neutral-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.5",
+      "figma": "color/dark/neutral/5",
+      "css": "--charcoal-color-dark-neutral-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.5",
+        "color/dark/neutral/5",
+        "--charcoal-color-dark-neutral-5",
+        "charcoal-color-dark-neutral-5",
+        "color-dark-neutral-5",
+        "dark/neutral/5",
+        "dark-neutral-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.50",
+      "figma": "color/dark/neutral/50",
+      "css": "--charcoal-color-dark-neutral-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.50",
+        "color/dark/neutral/50",
+        "--charcoal-color-dark-neutral-50",
+        "charcoal-color-dark-neutral-50",
+        "color-dark-neutral-50",
+        "dark/neutral/50",
+        "dark-neutral-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.60",
+      "figma": "color/dark/neutral/60",
+      "css": "--charcoal-color-dark-neutral-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.60",
+        "color/dark/neutral/60",
+        "--charcoal-color-dark-neutral-60",
+        "charcoal-color-dark-neutral-60",
+        "color-dark-neutral-60",
+        "dark/neutral/60",
+        "dark-neutral-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.70",
+      "figma": "color/dark/neutral/70",
+      "css": "--charcoal-color-dark-neutral-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.70",
+        "color/dark/neutral/70",
+        "--charcoal-color-dark-neutral-70",
+        "charcoal-color-dark-neutral-70",
+        "color-dark-neutral-70",
+        "dark/neutral/70",
+        "dark-neutral-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.80",
+      "figma": "color/dark/neutral/80",
+      "css": "--charcoal-color-dark-neutral-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.80",
+        "color/dark/neutral/80",
+        "--charcoal-color-dark-neutral-80",
+        "charcoal-color-dark-neutral-80",
+        "color-dark-neutral-80",
+        "dark/neutral/80",
+        "dark-neutral-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.neutral.90",
+      "figma": "color/dark/neutral/90",
+      "css": "--charcoal-color-dark-neutral-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/on-hud/default"
+        },
+        {
+          "figma": "color/text/on-hud/hover"
+        },
+        {
+          "figma": "color/text/on-hud/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.neutral.90",
+        "color/dark/neutral/90",
+        "--charcoal-color-dark-neutral-90",
+        "charcoal-color-dark-neutral-90",
+        "color-dark-neutral-90",
+        "dark/neutral/90",
+        "dark-neutral-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.-10",
+      "figma": "color/dark/orange/-10",
+      "css": "--charcoal-color-dark-orange--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.-10",
+        "color/dark/orange/-10",
+        "--charcoal-color-dark-orange--10",
+        "charcoal-color-dark-orange--10",
+        "color-dark-orange--10",
+        "dark/orange/-10",
+        "dark-orange--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.-5",
+      "figma": "color/dark/orange/-5",
+      "css": "--charcoal-color-dark-orange--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.-5",
+        "color/dark/orange/-5",
+        "--charcoal-color-dark-orange--5",
+        "charcoal-color-dark-orange--5",
+        "color-dark-orange--5",
+        "dark/orange/-5",
+        "dark-orange--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.0",
+      "figma": "color/dark/orange/0",
+      "css": "--charcoal-color-dark-orange-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.0",
+        "color/dark/orange/0",
+        "--charcoal-color-dark-orange-0",
+        "charcoal-color-dark-orange-0",
+        "color-dark-orange-0",
+        "dark/orange/0",
+        "dark-orange-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.10",
+      "figma": "color/dark/orange/10",
+      "css": "--charcoal-color-dark-orange-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.10",
+        "color/dark/orange/10",
+        "--charcoal-color-dark-orange-10",
+        "charcoal-color-dark-orange-10",
+        "color-dark-orange-10",
+        "dark/orange/10",
+        "dark-orange-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.20",
+      "figma": "color/dark/orange/20",
+      "css": "--charcoal-color-dark-orange-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.20",
+        "color/dark/orange/20",
+        "--charcoal-color-dark-orange-20",
+        "charcoal-color-dark-orange-20",
+        "color-dark-orange-20",
+        "dark/orange/20",
+        "dark-orange-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.30",
+      "figma": "color/dark/orange/30",
+      "css": "--charcoal-color-dark-orange-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.30",
+        "color/dark/orange/30",
+        "--charcoal-color-dark-orange-30",
+        "charcoal-color-dark-orange-30",
+        "color-dark-orange-30",
+        "dark/orange/30",
+        "dark-orange-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.40",
+      "figma": "color/dark/orange/40",
+      "css": "--charcoal-color-dark-orange-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.40",
+        "color/dark/orange/40",
+        "--charcoal-color-dark-orange-40",
+        "charcoal-color-dark-orange-40",
+        "color-dark-orange-40",
+        "dark/orange/40",
+        "dark-orange-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.5",
+      "figma": "color/dark/orange/5",
+      "css": "--charcoal-color-dark-orange-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.5",
+        "color/dark/orange/5",
+        "--charcoal-color-dark-orange-5",
+        "charcoal-color-dark-orange-5",
+        "color-dark-orange-5",
+        "dark/orange/5",
+        "dark-orange-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.50",
+      "figma": "color/dark/orange/50",
+      "css": "--charcoal-color-dark-orange-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.50",
+        "color/dark/orange/50",
+        "--charcoal-color-dark-orange-50",
+        "charcoal-color-dark-orange-50",
+        "color-dark-orange-50",
+        "dark/orange/50",
+        "dark-orange-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.60",
+      "figma": "color/dark/orange/60",
+      "css": "--charcoal-color-dark-orange-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.60",
+        "color/dark/orange/60",
+        "--charcoal-color-dark-orange-60",
+        "charcoal-color-dark-orange-60",
+        "color-dark-orange-60",
+        "dark/orange/60",
+        "dark-orange-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.70",
+      "figma": "color/dark/orange/70",
+      "css": "--charcoal-color-dark-orange-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.70",
+        "color/dark/orange/70",
+        "--charcoal-color-dark-orange-70",
+        "charcoal-color-dark-orange-70",
+        "color-dark-orange-70",
+        "dark/orange/70",
+        "dark-orange-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.80",
+      "figma": "color/dark/orange/80",
+      "css": "--charcoal-color-dark-orange-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.80",
+        "color/dark/orange/80",
+        "--charcoal-color-dark-orange-80",
+        "charcoal-color-dark-orange-80",
+        "color-dark-orange-80",
+        "dark/orange/80",
+        "dark-orange-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.orange.90",
+      "figma": "color/dark/orange/90",
+      "css": "--charcoal-color-dark-orange-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.orange.90",
+        "color/dark/orange/90",
+        "--charcoal-color-dark-orange-90",
+        "charcoal-color-dark-orange-90",
+        "color-dark-orange-90",
+        "dark/orange/90",
+        "dark-orange-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.-10",
+      "figma": "color/dark/purple/-10",
+      "css": "--charcoal-color-dark-purple--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.-10",
+        "color/dark/purple/-10",
+        "--charcoal-color-dark-purple--10",
+        "charcoal-color-dark-purple--10",
+        "color-dark-purple--10",
+        "dark/purple/-10",
+        "dark-purple--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.-5",
+      "figma": "color/dark/purple/-5",
+      "css": "--charcoal-color-dark-purple--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.-5",
+        "color/dark/purple/-5",
+        "--charcoal-color-dark-purple--5",
+        "charcoal-color-dark-purple--5",
+        "color-dark-purple--5",
+        "dark/purple/-5",
+        "dark-purple--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.0",
+      "figma": "color/dark/purple/0",
+      "css": "--charcoal-color-dark-purple-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.0",
+        "color/dark/purple/0",
+        "--charcoal-color-dark-purple-0",
+        "charcoal-color-dark-purple-0",
+        "color-dark-purple-0",
+        "dark/purple/0",
+        "dark-purple-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.10",
+      "figma": "color/dark/purple/10",
+      "css": "--charcoal-color-dark-purple-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.10",
+        "color/dark/purple/10",
+        "--charcoal-color-dark-purple-10",
+        "charcoal-color-dark-purple-10",
+        "color-dark-purple-10",
+        "dark/purple/10",
+        "dark-purple-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.20",
+      "figma": "color/dark/purple/20",
+      "css": "--charcoal-color-dark-purple-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.20",
+        "color/dark/purple/20",
+        "--charcoal-color-dark-purple-20",
+        "charcoal-color-dark-purple-20",
+        "color-dark-purple-20",
+        "dark/purple/20",
+        "dark-purple-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.30",
+      "figma": "color/dark/purple/30",
+      "css": "--charcoal-color-dark-purple-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.30",
+        "color/dark/purple/30",
+        "--charcoal-color-dark-purple-30",
+        "charcoal-color-dark-purple-30",
+        "color-dark-purple-30",
+        "dark/purple/30",
+        "dark-purple-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.40",
+      "figma": "color/dark/purple/40",
+      "css": "--charcoal-color-dark-purple-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.40",
+        "color/dark/purple/40",
+        "--charcoal-color-dark-purple-40",
+        "charcoal-color-dark-purple-40",
+        "color-dark-purple-40",
+        "dark/purple/40",
+        "dark-purple-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.5",
+      "figma": "color/dark/purple/5",
+      "css": "--charcoal-color-dark-purple-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.5",
+        "color/dark/purple/5",
+        "--charcoal-color-dark-purple-5",
+        "charcoal-color-dark-purple-5",
+        "color-dark-purple-5",
+        "dark/purple/5",
+        "dark-purple-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.50",
+      "figma": "color/dark/purple/50",
+      "css": "--charcoal-color-dark-purple-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.50",
+        "color/dark/purple/50",
+        "--charcoal-color-dark-purple-50",
+        "charcoal-color-dark-purple-50",
+        "color-dark-purple-50",
+        "dark/purple/50",
+        "dark-purple-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.60",
+      "figma": "color/dark/purple/60",
+      "css": "--charcoal-color-dark-purple-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.60",
+        "color/dark/purple/60",
+        "--charcoal-color-dark-purple-60",
+        "charcoal-color-dark-purple-60",
+        "color-dark-purple-60",
+        "dark/purple/60",
+        "dark-purple-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.70",
+      "figma": "color/dark/purple/70",
+      "css": "--charcoal-color-dark-purple-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.70",
+        "color/dark/purple/70",
+        "--charcoal-color-dark-purple-70",
+        "charcoal-color-dark-purple-70",
+        "color-dark-purple-70",
+        "dark/purple/70",
+        "dark-purple-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.80",
+      "figma": "color/dark/purple/80",
+      "css": "--charcoal-color-dark-purple-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.80",
+        "color/dark/purple/80",
+        "--charcoal-color-dark-purple-80",
+        "charcoal-color-dark-purple-80",
+        "color-dark-purple-80",
+        "dark/purple/80",
+        "dark-purple-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.purple.90",
+      "figma": "color/dark/purple/90",
+      "css": "--charcoal-color-dark-purple-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.purple.90",
+        "color/dark/purple/90",
+        "--charcoal-color-dark-purple-90",
+        "charcoal-color-dark-purple-90",
+        "color-dark-purple-90",
+        "dark/purple/90",
+        "dark-purple-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.-10",
+      "figma": "color/dark/red/-10",
+      "css": "--charcoal-color-dark-red--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.-10",
+        "color/dark/red/-10",
+        "--charcoal-color-dark-red--10",
+        "charcoal-color-dark-red--10",
+        "color-dark-red--10",
+        "dark/red/-10",
+        "dark-red--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.-5",
+      "figma": "color/dark/red/-5",
+      "css": "--charcoal-color-dark-red--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.-5",
+        "color/dark/red/-5",
+        "--charcoal-color-dark-red--5",
+        "charcoal-color-dark-red--5",
+        "color-dark-red--5",
+        "dark/red/-5",
+        "dark-red--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.0",
+      "figma": "color/dark/red/0",
+      "css": "--charcoal-color-dark-red-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.0",
+        "color/dark/red/0",
+        "--charcoal-color-dark-red-0",
+        "charcoal-color-dark-red-0",
+        "color-dark-red-0",
+        "dark/red/0",
+        "dark-red-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.10",
+      "figma": "color/dark/red/10",
+      "css": "--charcoal-color-dark-red-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.10",
+        "color/dark/red/10",
+        "--charcoal-color-dark-red-10",
+        "charcoal-color-dark-red-10",
+        "color-dark-red-10",
+        "dark/red/10",
+        "dark-red-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.20",
+      "figma": "color/dark/red/20",
+      "css": "--charcoal-color-dark-red-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.20",
+        "color/dark/red/20",
+        "--charcoal-color-dark-red-20",
+        "charcoal-color-dark-red-20",
+        "color-dark-red-20",
+        "dark/red/20",
+        "dark-red-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.30",
+      "figma": "color/dark/red/30",
+      "css": "--charcoal-color-dark-red-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.30",
+        "color/dark/red/30",
+        "--charcoal-color-dark-red-30",
+        "charcoal-color-dark-red-30",
+        "color-dark-red-30",
+        "dark/red/30",
+        "dark-red-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.40",
+      "figma": "color/dark/red/40",
+      "css": "--charcoal-color-dark-red-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.40",
+        "color/dark/red/40",
+        "--charcoal-color-dark-red-40",
+        "charcoal-color-dark-red-40",
+        "color-dark-red-40",
+        "dark/red/40",
+        "dark-red-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.5",
+      "figma": "color/dark/red/5",
+      "css": "--charcoal-color-dark-red-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.5",
+        "color/dark/red/5",
+        "--charcoal-color-dark-red-5",
+        "charcoal-color-dark-red-5",
+        "color-dark-red-5",
+        "dark/red/5",
+        "dark-red-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.50",
+      "figma": "color/dark/red/50",
+      "css": "--charcoal-color-dark-red-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.50",
+        "color/dark/red/50",
+        "--charcoal-color-dark-red-50",
+        "charcoal-color-dark-red-50",
+        "color-dark-red-50",
+        "dark/red/50",
+        "dark-red-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.60",
+      "figma": "color/dark/red/60",
+      "css": "--charcoal-color-dark-red-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.60",
+        "color/dark/red/60",
+        "--charcoal-color-dark-red-60",
+        "charcoal-color-dark-red-60",
+        "color-dark-red-60",
+        "dark/red/60",
+        "dark-red-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.70",
+      "figma": "color/dark/red/70",
+      "css": "--charcoal-color-dark-red-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.70",
+        "color/dark/red/70",
+        "--charcoal-color-dark-red-70",
+        "charcoal-color-dark-red-70",
+        "color-dark-red-70",
+        "dark/red/70",
+        "dark-red-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.80",
+      "figma": "color/dark/red/80",
+      "css": "--charcoal-color-dark-red-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.80",
+        "color/dark/red/80",
+        "--charcoal-color-dark-red-80",
+        "charcoal-color-dark-red-80",
+        "color-dark-red-80",
+        "dark/red/80",
+        "dark-red-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.red.90",
+      "figma": "color/dark/red/90",
+      "css": "--charcoal-color-dark-red-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.red.90",
+        "color/dark/red/90",
+        "--charcoal-color-dark-red-90",
+        "charcoal-color-dark-red-90",
+        "color-dark-red-90",
+        "dark/red/90",
+        "dark-red-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.-10",
+      "figma": "color/dark/turquoise/-10",
+      "css": "--charcoal-color-dark-turquoise--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.-10",
+        "color/dark/turquoise/-10",
+        "--charcoal-color-dark-turquoise--10",
+        "charcoal-color-dark-turquoise--10",
+        "color-dark-turquoise--10",
+        "dark/turquoise/-10",
+        "dark-turquoise--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.-5",
+      "figma": "color/dark/turquoise/-5",
+      "css": "--charcoal-color-dark-turquoise--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.-5",
+        "color/dark/turquoise/-5",
+        "--charcoal-color-dark-turquoise--5",
+        "charcoal-color-dark-turquoise--5",
+        "color-dark-turquoise--5",
+        "dark/turquoise/-5",
+        "dark-turquoise--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.0",
+      "figma": "color/dark/turquoise/0",
+      "css": "--charcoal-color-dark-turquoise-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.0",
+        "color/dark/turquoise/0",
+        "--charcoal-color-dark-turquoise-0",
+        "charcoal-color-dark-turquoise-0",
+        "color-dark-turquoise-0",
+        "dark/turquoise/0",
+        "dark-turquoise-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.10",
+      "figma": "color/dark/turquoise/10",
+      "css": "--charcoal-color-dark-turquoise-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.10",
+        "color/dark/turquoise/10",
+        "--charcoal-color-dark-turquoise-10",
+        "charcoal-color-dark-turquoise-10",
+        "color-dark-turquoise-10",
+        "dark/turquoise/10",
+        "dark-turquoise-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.20",
+      "figma": "color/dark/turquoise/20",
+      "css": "--charcoal-color-dark-turquoise-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.20",
+        "color/dark/turquoise/20",
+        "--charcoal-color-dark-turquoise-20",
+        "charcoal-color-dark-turquoise-20",
+        "color-dark-turquoise-20",
+        "dark/turquoise/20",
+        "dark-turquoise-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.30",
+      "figma": "color/dark/turquoise/30",
+      "css": "--charcoal-color-dark-turquoise-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.30",
+        "color/dark/turquoise/30",
+        "--charcoal-color-dark-turquoise-30",
+        "charcoal-color-dark-turquoise-30",
+        "color-dark-turquoise-30",
+        "dark/turquoise/30",
+        "dark-turquoise-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.40",
+      "figma": "color/dark/turquoise/40",
+      "css": "--charcoal-color-dark-turquoise-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.40",
+        "color/dark/turquoise/40",
+        "--charcoal-color-dark-turquoise-40",
+        "charcoal-color-dark-turquoise-40",
+        "color-dark-turquoise-40",
+        "dark/turquoise/40",
+        "dark-turquoise-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.5",
+      "figma": "color/dark/turquoise/5",
+      "css": "--charcoal-color-dark-turquoise-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.5",
+        "color/dark/turquoise/5",
+        "--charcoal-color-dark-turquoise-5",
+        "charcoal-color-dark-turquoise-5",
+        "color-dark-turquoise-5",
+        "dark/turquoise/5",
+        "dark-turquoise-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.50",
+      "figma": "color/dark/turquoise/50",
+      "css": "--charcoal-color-dark-turquoise-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.50",
+        "color/dark/turquoise/50",
+        "--charcoal-color-dark-turquoise-50",
+        "charcoal-color-dark-turquoise-50",
+        "color-dark-turquoise-50",
+        "dark/turquoise/50",
+        "dark-turquoise-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.60",
+      "figma": "color/dark/turquoise/60",
+      "css": "--charcoal-color-dark-turquoise-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.60",
+        "color/dark/turquoise/60",
+        "--charcoal-color-dark-turquoise-60",
+        "charcoal-color-dark-turquoise-60",
+        "color-dark-turquoise-60",
+        "dark/turquoise/60",
+        "dark-turquoise-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.70",
+      "figma": "color/dark/turquoise/70",
+      "css": "--charcoal-color-dark-turquoise-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.70",
+        "color/dark/turquoise/70",
+        "--charcoal-color-dark-turquoise-70",
+        "charcoal-color-dark-turquoise-70",
+        "color-dark-turquoise-70",
+        "dark/turquoise/70",
+        "dark-turquoise-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.80",
+      "figma": "color/dark/turquoise/80",
+      "css": "--charcoal-color-dark-turquoise-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.80",
+        "color/dark/turquoise/80",
+        "--charcoal-color-dark-turquoise-80",
+        "charcoal-color-dark-turquoise-80",
+        "color-dark-turquoise-80",
+        "dark/turquoise/80",
+        "dark-turquoise-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.turquoise.90",
+      "figma": "color/dark/turquoise/90",
+      "css": "--charcoal-color-dark-turquoise-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.turquoise.90",
+        "color/dark/turquoise/90",
+        "--charcoal-color-dark-turquoise-90",
+        "charcoal-color-dark-turquoise-90",
+        "color-dark-turquoise-90",
+        "dark/turquoise/90",
+        "dark-turquoise-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.-10",
+      "figma": "color/dark/yellow/-10",
+      "css": "--charcoal-color-dark-yellow--10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.-10",
+        "color/dark/yellow/-10",
+        "--charcoal-color-dark-yellow--10",
+        "charcoal-color-dark-yellow--10",
+        "color-dark-yellow--10",
+        "dark/yellow/-10",
+        "dark-yellow--10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.-5",
+      "figma": "color/dark/yellow/-5",
+      "css": "--charcoal-color-dark-yellow--5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.-5",
+        "color/dark/yellow/-5",
+        "--charcoal-color-dark-yellow--5",
+        "charcoal-color-dark-yellow--5",
+        "color-dark-yellow--5",
+        "dark/yellow/-5",
+        "dark-yellow--5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.0",
+      "figma": "color/dark/yellow/0",
+      "css": "--charcoal-color-dark-yellow-0",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.0",
+        "color/dark/yellow/0",
+        "--charcoal-color-dark-yellow-0",
+        "charcoal-color-dark-yellow-0",
+        "color-dark-yellow-0",
+        "dark/yellow/0",
+        "dark-yellow-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.10",
+      "figma": "color/dark/yellow/10",
+      "css": "--charcoal-color-dark-yellow-10",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.10",
+        "color/dark/yellow/10",
+        "--charcoal-color-dark-yellow-10",
+        "charcoal-color-dark-yellow-10",
+        "color-dark-yellow-10",
+        "dark/yellow/10",
+        "dark-yellow-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.20",
+      "figma": "color/dark/yellow/20",
+      "css": "--charcoal-color-dark-yellow-20",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.20",
+        "color/dark/yellow/20",
+        "--charcoal-color-dark-yellow-20",
+        "charcoal-color-dark-yellow-20",
+        "color-dark-yellow-20",
+        "dark/yellow/20",
+        "dark-yellow-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.30",
+      "figma": "color/dark/yellow/30",
+      "css": "--charcoal-color-dark-yellow-30",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.30",
+        "color/dark/yellow/30",
+        "--charcoal-color-dark-yellow-30",
+        "charcoal-color-dark-yellow-30",
+        "color-dark-yellow-30",
+        "dark/yellow/30",
+        "dark-yellow-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.40",
+      "figma": "color/dark/yellow/40",
+      "css": "--charcoal-color-dark-yellow-40",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.40",
+        "color/dark/yellow/40",
+        "--charcoal-color-dark-yellow-40",
+        "charcoal-color-dark-yellow-40",
+        "color-dark-yellow-40",
+        "dark/yellow/40",
+        "dark-yellow-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.5",
+      "figma": "color/dark/yellow/5",
+      "css": "--charcoal-color-dark-yellow-5",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.5",
+        "color/dark/yellow/5",
+        "--charcoal-color-dark-yellow-5",
+        "charcoal-color-dark-yellow-5",
+        "color-dark-yellow-5",
+        "dark/yellow/5",
+        "dark-yellow-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.50",
+      "figma": "color/dark/yellow/50",
+      "css": "--charcoal-color-dark-yellow-50",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.50",
+        "color/dark/yellow/50",
+        "--charcoal-color-dark-yellow-50",
+        "charcoal-color-dark-yellow-50",
+        "color-dark-yellow-50",
+        "dark/yellow/50",
+        "dark-yellow-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.60",
+      "figma": "color/dark/yellow/60",
+      "css": "--charcoal-color-dark-yellow-60",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.60",
+        "color/dark/yellow/60",
+        "--charcoal-color-dark-yellow-60",
+        "charcoal-color-dark-yellow-60",
+        "color-dark-yellow-60",
+        "dark/yellow/60",
+        "dark-yellow-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.70",
+      "figma": "color/dark/yellow/70",
+      "css": "--charcoal-color-dark-yellow-70",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.70",
+        "color/dark/yellow/70",
+        "--charcoal-color-dark-yellow-70",
+        "charcoal-color-dark-yellow-70",
+        "color-dark-yellow-70",
+        "dark/yellow/70",
+        "dark-yellow-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.80",
+      "figma": "color/dark/yellow/80",
+      "css": "--charcoal-color-dark-yellow-80",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.80",
+        "color/dark/yellow/80",
+        "--charcoal-color-dark-yellow-80",
+        "charcoal-color-dark-yellow-80",
+        "color-dark-yellow-80",
+        "dark/yellow/80",
+        "dark-yellow-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.dark.yellow.90",
+      "figma": "color/dark/yellow/90",
+      "css": "--charcoal-color-dark-yellow-90",
+      "category": "color",
+      "group": "dark",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.dark.yellow.90",
+        "color/dark/yellow/90",
+        "--charcoal-color-dark-yellow-90",
+        "charcoal-color-dark-yellow-90",
+        "color-dark-yellow-90",
+        "dark/yellow/90",
+        "dark-yellow-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.0",
+      "figma": "color/light/blue/0",
+      "css": "--charcoal-color-light-blue-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.0",
+        "color/light/blue/0",
+        "--charcoal-color-light-blue-0",
+        "charcoal-color-light-blue-0",
+        "color-light-blue-0",
+        "light/blue/0",
+        "light-blue-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.10",
+      "figma": "color/light/blue/10",
+      "css": "--charcoal-color-light-blue-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.10",
+        "color/light/blue/10",
+        "--charcoal-color-light-blue-10",
+        "charcoal-color-light-blue-10",
+        "color-light-blue-10",
+        "light/blue/10",
+        "light-blue-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.20",
+      "figma": "color/light/blue/20",
+      "css": "--charcoal-color-light-blue-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/focus/2"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.20",
+        "color/light/blue/20",
+        "--charcoal-color-light-blue-20",
+        "charcoal-color-light-blue-20",
+        "color-light-blue-20",
+        "light/blue/20",
+        "light-blue-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.30",
+      "figma": "color/light/blue/30",
+      "css": "--charcoal-color-light-blue-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.30",
+        "color/light/blue/30",
+        "--charcoal-color-light-blue-30",
+        "charcoal-color-light-blue-30",
+        "color-light-blue-30",
+        "light/blue/30",
+        "light-blue-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.40",
+      "figma": "color/light/blue/40",
+      "css": "--charcoal-color-light-blue-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.40",
+        "color/light/blue/40",
+        "--charcoal-color-light-blue-40",
+        "charcoal-color-light-blue-40",
+        "color-light-blue-40",
+        "light/blue/40",
+        "light-blue-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.5",
+      "figma": "color/light/blue/5",
+      "css": "--charcoal-color-light-blue-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.5",
+        "color/light/blue/5",
+        "--charcoal-color-light-blue-5",
+        "charcoal-color-light-blue-5",
+        "color-light-blue-5",
+        "light/blue/5",
+        "light-blue-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.50",
+      "figma": "color/light/blue/50",
+      "css": "--charcoal-color-light-blue-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/primary/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.50",
+        "color/light/blue/50",
+        "--charcoal-color-light-blue-50",
+        "charcoal-color-light-blue-50",
+        "color-light-blue-50",
+        "light/blue/50",
+        "light-blue-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.60",
+      "figma": "color/light/blue/60",
+      "css": "--charcoal-color-light-blue-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/focus/1"
+        },
+        {
+          "figma": "color/container/primary/hover"
+        },
+        {
+          "figma": "color/text/info/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.60",
+        "color/light/blue/60",
+        "--charcoal-color-light-blue-60",
+        "charcoal-color-light-blue-60",
+        "color-light-blue-60",
+        "light/blue/60",
+        "light-blue-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.70",
+      "figma": "color/light/blue/70",
+      "css": "--charcoal-color-light-blue-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/primary/press"
+        },
+        {
+          "figma": "color/text/info/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.70",
+        "color/light/blue/70",
+        "--charcoal-color-light-blue-70",
+        "charcoal-color-light-blue-70",
+        "color-light-blue-70",
+        "light/blue/70",
+        "light-blue-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.80",
+      "figma": "color/light/blue/80",
+      "css": "--charcoal-color-light-blue-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/info/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.80",
+        "color/light/blue/80",
+        "--charcoal-color-light-blue-80",
+        "charcoal-color-light-blue-80",
+        "color-light-blue-80",
+        "light/blue/80",
+        "light-blue-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.blue.90",
+      "figma": "color/light/blue/90",
+      "css": "--charcoal-color-light-blue-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.blue.90",
+        "color/light/blue/90",
+        "--charcoal-color-light-blue-90",
+        "charcoal-color-light-blue-90",
+        "color-light-blue-90",
+        "light/blue/90",
+        "light-blue-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.0",
+      "figma": "color/light/green/0",
+      "css": "--charcoal-color-light-green-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.0",
+        "color/light/green/0",
+        "--charcoal-color-light-green-0",
+        "charcoal-color-light-green-0",
+        "color-light-green-0",
+        "light/green/0",
+        "light-green-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.10",
+      "figma": "color/light/green/10",
+      "css": "--charcoal-color-light-green-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.10",
+        "color/light/green/10",
+        "--charcoal-color-light-green-10",
+        "charcoal-color-light-green-10",
+        "color-light-green-10",
+        "light/green/10",
+        "light-green-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.20",
+      "figma": "color/light/green/20",
+      "css": "--charcoal-color-light-green-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.20",
+        "color/light/green/20",
+        "--charcoal-color-light-green-20",
+        "charcoal-color-light-green-20",
+        "color-light-green-20",
+        "light/green/20",
+        "light-green-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.30",
+      "figma": "color/light/green/30",
+      "css": "--charcoal-color-light-green-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.30",
+        "color/light/green/30",
+        "--charcoal-color-light-green-30",
+        "charcoal-color-light-green-30",
+        "color-light-green-30",
+        "light/green/30",
+        "light-green-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.40",
+      "figma": "color/light/green/40",
+      "css": "--charcoal-color-light-green-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.40",
+        "color/light/green/40",
+        "--charcoal-color-light-green-40",
+        "charcoal-color-light-green-40",
+        "color-light-green-40",
+        "light/green/40",
+        "light-green-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.5",
+      "figma": "color/light/green/5",
+      "css": "--charcoal-color-light-green-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.5",
+        "color/light/green/5",
+        "--charcoal-color-light-green-5",
+        "charcoal-color-light-green-5",
+        "color-light-green-5",
+        "light/green/5",
+        "light-green-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.50",
+      "figma": "color/light/green/50",
+      "css": "--charcoal-color-light-green-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.50",
+        "color/light/green/50",
+        "--charcoal-color-light-green-50",
+        "charcoal-color-light-green-50",
+        "color-light-green-50",
+        "light/green/50",
+        "light-green-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.60",
+      "figma": "color/light/green/60",
+      "css": "--charcoal-color-light-green-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/hover"
+        },
+        {
+          "figma": "color/text/positive/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.60",
+        "color/light/green/60",
+        "--charcoal-color-light-green-60",
+        "charcoal-color-light-green-60",
+        "color-light-green-60",
+        "light/green/60",
+        "light-green-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.70",
+      "figma": "color/light/green/70",
+      "css": "--charcoal-color-light-green-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/press"
+        },
+        {
+          "figma": "color/text/positive/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.70",
+        "color/light/green/70",
+        "--charcoal-color-light-green-70",
+        "charcoal-color-light-green-70",
+        "color-light-green-70",
+        "light/green/70",
+        "light-green-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.80",
+      "figma": "color/light/green/80",
+      "css": "--charcoal-color-light-green-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/positive/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.80",
+        "color/light/green/80",
+        "--charcoal-color-light-green-80",
+        "charcoal-color-light-green-80",
+        "color-light-green-80",
+        "light/green/80",
+        "light-green-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.green.90",
+      "figma": "color/light/green/90",
+      "css": "--charcoal-color-light-green-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.green.90",
+        "color/light/green/90",
+        "--charcoal-color-light-green-90",
+        "charcoal-color-light-green-90",
+        "color-light-green-90",
+        "light/green/90",
+        "light-green-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.10",
+      "figma": "color/light/indigo/10",
+      "css": "--charcoal-color-light-indigo-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.10",
+        "color/light/indigo/10",
+        "--charcoal-color-light-indigo-10",
+        "charcoal-color-light-indigo-10",
+        "color-light-indigo-10",
+        "light/indigo/10",
+        "light-indigo-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.20",
+      "figma": "color/light/indigo/20",
+      "css": "--charcoal-color-light-indigo-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.20",
+        "color/light/indigo/20",
+        "--charcoal-color-light-indigo-20",
+        "charcoal-color-light-indigo-20",
+        "color-light-indigo-20",
+        "light/indigo/20",
+        "light-indigo-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.30",
+      "figma": "color/light/indigo/30",
+      "css": "--charcoal-color-light-indigo-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.30",
+        "color/light/indigo/30",
+        "--charcoal-color-light-indigo-30",
+        "charcoal-color-light-indigo-30",
+        "color-light-indigo-30",
+        "light/indigo/30",
+        "light-indigo-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.40",
+      "figma": "color/light/indigo/40",
+      "css": "--charcoal-color-light-indigo-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.40",
+        "color/light/indigo/40",
+        "--charcoal-color-light-indigo-40",
+        "charcoal-color-light-indigo-40",
+        "color-light-indigo-40",
+        "light/indigo/40",
+        "light-indigo-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.5",
+      "figma": "color/light/indigo/5",
+      "css": "--charcoal-color-light-indigo-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.5",
+        "color/light/indigo/5",
+        "--charcoal-color-light-indigo-5",
+        "charcoal-color-light-indigo-5",
+        "color-light-indigo-5",
+        "light/indigo/5",
+        "light-indigo-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.50",
+      "figma": "color/light/indigo/50",
+      "css": "--charcoal-color-light-indigo-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.50",
+        "color/light/indigo/50",
+        "--charcoal-color-light-indigo-50",
+        "charcoal-color-light-indigo-50",
+        "color-light-indigo-50",
+        "light/indigo/50",
+        "light-indigo-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.60",
+      "figma": "color/light/indigo/60",
+      "css": "--charcoal-color-light-indigo-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.60",
+        "color/light/indigo/60",
+        "--charcoal-color-light-indigo-60",
+        "charcoal-color-light-indigo-60",
+        "color-light-indigo-60",
+        "light/indigo/60",
+        "light-indigo-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.70",
+      "figma": "color/light/indigo/70",
+      "css": "--charcoal-color-light-indigo-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.70",
+        "color/light/indigo/70",
+        "--charcoal-color-light-indigo-70",
+        "charcoal-color-light-indigo-70",
+        "color-light-indigo-70",
+        "light/indigo/70",
+        "light-indigo-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.80",
+      "figma": "color/light/indigo/80",
+      "css": "--charcoal-color-light-indigo-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.80",
+        "color/light/indigo/80",
+        "--charcoal-color-light-indigo-80",
+        "charcoal-color-light-indigo-80",
+        "color-light-indigo-80",
+        "light/indigo/80",
+        "light-indigo-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.indigo.90",
+      "figma": "color/light/indigo/90",
+      "css": "--charcoal-color-light-indigo-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.indigo.90",
+        "color/light/indigo/90",
+        "--charcoal-color-light-indigo-90",
+        "charcoal-color-light-indigo-90",
+        "color-light-indigo-90",
+        "light/indigo/90",
+        "light-indigo-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.10",
+      "figma": "color/light/magenta/10",
+      "css": "--charcoal-color-light-magenta-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.10",
+        "color/light/magenta/10",
+        "--charcoal-color-light-magenta-10",
+        "charcoal-color-light-magenta-10",
+        "color-light-magenta-10",
+        "light/magenta/10",
+        "light-magenta-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.20",
+      "figma": "color/light/magenta/20",
+      "css": "--charcoal-color-light-magenta-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.20",
+        "color/light/magenta/20",
+        "--charcoal-color-light-magenta-20",
+        "charcoal-color-light-magenta-20",
+        "color-light-magenta-20",
+        "light/magenta/20",
+        "light-magenta-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.30",
+      "figma": "color/light/magenta/30",
+      "css": "--charcoal-color-light-magenta-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.30",
+        "color/light/magenta/30",
+        "--charcoal-color-light-magenta-30",
+        "charcoal-color-light-magenta-30",
+        "color-light-magenta-30",
+        "light/magenta/30",
+        "light-magenta-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.40",
+      "figma": "color/light/magenta/40",
+      "css": "--charcoal-color-light-magenta-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.40",
+        "color/light/magenta/40",
+        "--charcoal-color-light-magenta-40",
+        "charcoal-color-light-magenta-40",
+        "color-light-magenta-40",
+        "light/magenta/40",
+        "light-magenta-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.5",
+      "figma": "color/light/magenta/5",
+      "css": "--charcoal-color-light-magenta-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.5",
+        "color/light/magenta/5",
+        "--charcoal-color-light-magenta-5",
+        "charcoal-color-light-magenta-5",
+        "color-light-magenta-5",
+        "light/magenta/5",
+        "light-magenta-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.50",
+      "figma": "color/light/magenta/50",
+      "css": "--charcoal-color-light-magenta-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.50",
+        "color/light/magenta/50",
+        "--charcoal-color-light-magenta-50",
+        "charcoal-color-light-magenta-50",
+        "color-light-magenta-50",
+        "light/magenta/50",
+        "light-magenta-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.60",
+      "figma": "color/light/magenta/60",
+      "css": "--charcoal-color-light-magenta-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.60",
+        "color/light/magenta/60",
+        "--charcoal-color-light-magenta-60",
+        "charcoal-color-light-magenta-60",
+        "color-light-magenta-60",
+        "light/magenta/60",
+        "light-magenta-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.70",
+      "figma": "color/light/magenta/70",
+      "css": "--charcoal-color-light-magenta-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.70",
+        "color/light/magenta/70",
+        "--charcoal-color-light-magenta-70",
+        "charcoal-color-light-magenta-70",
+        "color-light-magenta-70",
+        "light/magenta/70",
+        "light-magenta-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.80",
+      "figma": "color/light/magenta/80",
+      "css": "--charcoal-color-light-magenta-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.80",
+        "color/light/magenta/80",
+        "--charcoal-color-light-magenta-80",
+        "charcoal-color-light-magenta-80",
+        "color-light-magenta-80",
+        "light/magenta/80",
+        "light-magenta-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.magenta.90",
+      "figma": "color/light/magenta/90",
+      "css": "--charcoal-color-light-magenta-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.magenta.90",
+        "color/light/magenta/90",
+        "--charcoal-color-light-magenta-90",
+        "charcoal-color-light-magenta-90",
+        "color-light-magenta-90",
+        "light/magenta/90",
+        "light-magenta-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.0",
+      "figma": "color/light/neutral-a/0",
+      "css": "--charcoal-color-light-neutral-a-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/default-a"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.0",
+        "color/light/neutral-a/0",
+        "--charcoal-color-light-neutral-a-0",
+        "charcoal-color-light-neutral-a-0",
+        "color-light-neutral-a-0",
+        "light/neutral-a/0",
+        "light-neutral-a-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.10",
+      "figma": "color/light/neutral-a/10",
+      "css": "--charcoal-color-light-neutral-a-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/disable"
+        },
+        {
+          "figma": "color/border/secondary"
+        },
+        {
+          "figma": "color/container/press-a"
+        },
+        {
+          "figma": "color/container/secondary/hover-a"
+        },
+        {
+          "figma": "color/container/tertiary/default-a"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.10",
+        "color/light/neutral-a/10",
+        "--charcoal-color-light-neutral-a-10",
+        "charcoal-color-light-neutral-a-10",
+        "color-light-neutral-a-10",
+        "light/neutral-a/10",
+        "light-neutral-a-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.20",
+      "figma": "color/light/neutral-a/20",
+      "css": "--charcoal-color-light-neutral-a-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/secondary/press-a"
+        },
+        {
+          "figma": "color/container/tertiary/hover-a"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.20",
+        "color/light/neutral-a/20",
+        "--charcoal-color-light-neutral-a-20",
+        "charcoal-color-light-neutral-a-20",
+        "color-light-neutral-a-20",
+        "light/neutral-a/20",
+        "light-neutral-a-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.30",
+      "figma": "color/light/neutral-a/30",
+      "css": "--charcoal-color-light-neutral-a-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/tertiary/press-a"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.30",
+        "color/light/neutral-a/30",
+        "--charcoal-color-light-neutral-a-30",
+        "charcoal-color-light-neutral-a-30",
+        "color-light-neutral-a-30",
+        "light/neutral-a/30",
+        "light-neutral-a-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.40",
+      "figma": "color/light/neutral-a/40",
+      "css": "--charcoal-color-light-neutral-a-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/overlay"
+        },
+        {
+          "figma": "color/container/on-img/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.40",
+        "color/light/neutral-a/40",
+        "--charcoal-color-light-neutral-a-40",
+        "charcoal-color-light-neutral-a-40",
+        "color-light-neutral-a-40",
+        "light/neutral-a/40",
+        "light-neutral-a-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.5",
+      "figma": "color/light/neutral-a/5",
+      "css": "--charcoal-color-light-neutral-a-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hover-a"
+        },
+        {
+          "figma": "color/container/secondary/default-a"
+        },
+        {
+          "figma": "color/container/skeleton"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.5",
+        "color/light/neutral-a/5",
+        "--charcoal-color-light-neutral-a-5",
+        "charcoal-color-light-neutral-a-5",
+        "color-light-neutral-a-5",
+        "light/neutral-a/5",
+        "light-neutral-a-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.50",
+      "figma": "color/light/neutral-a/50",
+      "css": "--charcoal-color-light-neutral-a-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/default"
+        },
+        {
+          "figma": "color/border/default-text3"
+        },
+        {
+          "figma": "color/container/on-img/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.50",
+        "color/light/neutral-a/50",
+        "--charcoal-color-light-neutral-a-50",
+        "charcoal-color-light-neutral-a-50",
+        "color-light-neutral-a-50",
+        "light/neutral-a/50",
+        "light-neutral-a-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.60",
+      "figma": "color/light/neutral-a/60",
+      "css": "--charcoal-color-light-neutral-a-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/hover"
+        },
+        {
+          "figma": "color/border/hover-text3"
+        },
+        {
+          "figma": "color/container/on-img/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.60",
+        "color/light/neutral-a/60",
+        "--charcoal-color-light-neutral-a-60",
+        "charcoal-color-light-neutral-a-60",
+        "color-light-neutral-a-60",
+        "light/neutral-a/60",
+        "light-neutral-a-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.70",
+      "figma": "color/light/neutral-a/70",
+      "css": "--charcoal-color-light-neutral-a-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/press"
+        },
+        {
+          "figma": "color/border/press-text3"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.70",
+        "color/light/neutral-a/70",
+        "--charcoal-color-light-neutral-a-70",
+        "charcoal-color-light-neutral-a-70",
+        "color-light-neutral-a-70",
+        "light/neutral-a/70",
+        "light-neutral-a-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.80",
+      "figma": "color/light/neutral-a/80",
+      "css": "--charcoal-color-light-neutral-a-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.80",
+        "color/light/neutral-a/80",
+        "--charcoal-color-light-neutral-a-80",
+        "charcoal-color-light-neutral-a-80",
+        "color-light-neutral-a-80",
+        "light/neutral-a/80",
+        "light-neutral-a-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral-a.90",
+      "figma": "color/light/neutral-a/90",
+      "css": "--charcoal-color-light-neutral-a-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral-a.90",
+        "color/light/neutral-a/90",
+        "--charcoal-color-light-neutral-a-90",
+        "charcoal-color-light-neutral-a-90",
+        "color-light-neutral-a-90",
+        "light/neutral-a/90",
+        "light-neutral-a-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.0",
+      "figma": "color/light/neutral/0",
+      "css": "--charcoal-color-light-neutral-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/default"
+        },
+        {
+          "figma": "color/container/default"
+        },
+        {
+          "figma": "color/icon/on-neutral/default"
+        },
+        {
+          "figma": "color/text/on-discovery/default"
+        },
+        {
+          "figma": "color/text/on-discovery/hover"
+        },
+        {
+          "figma": "color/text/on-discovery/press"
+        },
+        {
+          "figma": "color/text/on-negative/default"
+        },
+        {
+          "figma": "color/text/on-negative/hover"
+        },
+        {
+          "figma": "color/text/on-negative/press"
+        },
+        {
+          "figma": "color/text/on-on-img/default"
+        },
+        {
+          "figma": "color/text/on-on-img/hover"
+        },
+        {
+          "figma": "color/text/on-on-img/press"
+        },
+        {
+          "figma": "color/text/on-positive/default"
+        },
+        {
+          "figma": "color/text/on-positive/hover"
+        },
+        {
+          "figma": "color/text/on-positive/press"
+        },
+        {
+          "figma": "color/text/on-primary/default"
+        },
+        {
+          "figma": "color/text/on-primary/hover"
+        },
+        {
+          "figma": "color/text/on-primary/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.0",
+        "color/light/neutral/0",
+        "--charcoal-color-light-neutral-0",
+        "charcoal-color-light-neutral-0",
+        "color-light-neutral-0",
+        "light/neutral/0",
+        "light-neutral-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.10",
+      "figma": "color/light/neutral/10",
+      "css": "--charcoal-color-light-neutral-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/tertiary"
+        },
+        {
+          "figma": "color/container/disable"
+        },
+        {
+          "figma": "color/container/press"
+        },
+        {
+          "figma": "color/container/secondary/hover"
+        },
+        {
+          "figma": "color/container/tertiary/default"
+        },
+        {
+          "figma": "color/icon/on-neutral/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.10",
+        "color/light/neutral/10",
+        "--charcoal-color-light-neutral-10",
+        "charcoal-color-light-neutral-10",
+        "color-light-neutral-10",
+        "light/neutral/10",
+        "light-neutral-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.20",
+      "figma": "color/light/neutral/20",
+      "css": "--charcoal-color-light-neutral-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/secondary/press"
+        },
+        {
+          "figma": "color/container/tertiary/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.20",
+        "color/light/neutral/20",
+        "--charcoal-color-light-neutral-20",
+        "charcoal-color-light-neutral-20",
+        "color-light-neutral-20",
+        "light/neutral/20",
+        "light-neutral-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.30",
+      "figma": "color/light/neutral/30",
+      "css": "--charcoal-color-light-neutral-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/tertiary/press"
+        },
+        {
+          "figma": "color/text/disable"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.30",
+        "color/light/neutral/30",
+        "--charcoal-color-light-neutral-30",
+        "charcoal-color-light-neutral-30",
+        "color-light-neutral-30",
+        "light/neutral/30",
+        "light-neutral-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.40",
+      "figma": "color/light/neutral/40",
+      "css": "--charcoal-color-light-neutral-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.40",
+        "color/light/neutral/40",
+        "--charcoal-color-light-neutral-40",
+        "charcoal-color-light-neutral-40",
+        "color-light-neutral-40",
+        "light/neutral/40",
+        "light-neutral-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.5",
+      "figma": "color/light/neutral/5",
+      "css": "--charcoal-color-light-neutral-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/secondary"
+        },
+        {
+          "figma": "color/container/hover"
+        },
+        {
+          "figma": "color/container/secondary/default"
+        },
+        {
+          "figma": "color/icon/on-neutral/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.5",
+        "color/light/neutral/5",
+        "--charcoal-color-light-neutral-5",
+        "charcoal-color-light-neutral-5",
+        "color-light-neutral-5",
+        "light/neutral/5",
+        "light-neutral-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.50",
+      "figma": "color/light/neutral/50",
+      "css": "--charcoal-color-light-neutral-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/neutral/default"
+        },
+        {
+          "figma": "color/text/placeholder/default"
+        },
+        {
+          "figma": "color/text/placeholder/hover"
+        },
+        {
+          "figma": "color/text/placeholder/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.50",
+        "color/light/neutral/50",
+        "--charcoal-color-light-neutral-50",
+        "charcoal-color-light-neutral-50",
+        "color-light-neutral-50",
+        "light/neutral/50",
+        "light-neutral-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.60",
+      "figma": "color/light/neutral/60",
+      "css": "--charcoal-color-light-neutral-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hud/press"
+        },
+        {
+          "figma": "color/container/neutral/hover"
+        },
+        {
+          "figma": "color/text/tertiary/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.60",
+        "color/light/neutral/60",
+        "--charcoal-color-light-neutral-60",
+        "charcoal-color-light-neutral-60",
+        "color-light-neutral-60",
+        "light/neutral/60",
+        "light-neutral-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.70",
+      "figma": "color/light/neutral/70",
+      "css": "--charcoal-color-light-neutral-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hud/hover"
+        },
+        {
+          "figma": "color/container/neutral/press"
+        },
+        {
+          "figma": "color/text/press"
+        },
+        {
+          "figma": "color/text/secondary/default"
+        },
+        {
+          "figma": "color/text/tertiary/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.70",
+        "color/light/neutral/70",
+        "--charcoal-color-light-neutral-70",
+        "charcoal-color-light-neutral-70",
+        "color-light-neutral-70",
+        "light/neutral/70",
+        "light-neutral-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.80",
+      "figma": "color/light/neutral/80",
+      "css": "--charcoal-color-light-neutral-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hud/default"
+        },
+        {
+          "figma": "color/text/hover"
+        },
+        {
+          "figma": "color/text/secondary/hover"
+        },
+        {
+          "figma": "color/text/tertiary/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.80",
+        "color/light/neutral/80",
+        "--charcoal-color-light-neutral-80",
+        "charcoal-color-light-neutral-80",
+        "color-light-neutral-80",
+        "light/neutral/80",
+        "light-neutral-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.neutral.90",
+      "figma": "color/light/neutral/90",
+      "css": "--charcoal-color-light-neutral-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/default"
+        },
+        {
+          "figma": "color/text/default-text1"
+        },
+        {
+          "figma": "color/text/hover-text1"
+        },
+        {
+          "figma": "color/text/on-notice/default"
+        },
+        {
+          "figma": "color/text/on-notice/hover"
+        },
+        {
+          "figma": "color/text/on-notice/press"
+        },
+        {
+          "figma": "color/text/press-text1"
+        },
+        {
+          "figma": "color/text/secondary/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.neutral.90",
+        "color/light/neutral/90",
+        "--charcoal-color-light-neutral-90",
+        "charcoal-color-light-neutral-90",
+        "color-light-neutral-90",
+        "light/neutral/90",
+        "light-neutral-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.10",
+      "figma": "color/light/orange/10",
+      "css": "--charcoal-color-light-orange-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.10",
+        "color/light/orange/10",
+        "--charcoal-color-light-orange-10",
+        "charcoal-color-light-orange-10",
+        "color-light-orange-10",
+        "light/orange/10",
+        "light-orange-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.20",
+      "figma": "color/light/orange/20",
+      "css": "--charcoal-color-light-orange-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.20",
+        "color/light/orange/20",
+        "--charcoal-color-light-orange-20",
+        "charcoal-color-light-orange-20",
+        "color-light-orange-20",
+        "light/orange/20",
+        "light-orange-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.30",
+      "figma": "color/light/orange/30",
+      "css": "--charcoal-color-light-orange-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.30",
+        "color/light/orange/30",
+        "--charcoal-color-light-orange-30",
+        "charcoal-color-light-orange-30",
+        "color-light-orange-30",
+        "light/orange/30",
+        "light-orange-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.40",
+      "figma": "color/light/orange/40",
+      "css": "--charcoal-color-light-orange-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.40",
+        "color/light/orange/40",
+        "--charcoal-color-light-orange-40",
+        "charcoal-color-light-orange-40",
+        "color-light-orange-40",
+        "light/orange/40",
+        "light-orange-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.5",
+      "figma": "color/light/orange/5",
+      "css": "--charcoal-color-light-orange-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.5",
+        "color/light/orange/5",
+        "--charcoal-color-light-orange-5",
+        "charcoal-color-light-orange-5",
+        "color-light-orange-5",
+        "light/orange/5",
+        "light-orange-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.50",
+      "figma": "color/light/orange/50",
+      "css": "--charcoal-color-light-orange-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.50",
+        "color/light/orange/50",
+        "--charcoal-color-light-orange-50",
+        "charcoal-color-light-orange-50",
+        "color-light-orange-50",
+        "light/orange/50",
+        "light-orange-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.60",
+      "figma": "color/light/orange/60",
+      "css": "--charcoal-color-light-orange-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.60",
+        "color/light/orange/60",
+        "--charcoal-color-light-orange-60",
+        "charcoal-color-light-orange-60",
+        "color-light-orange-60",
+        "light/orange/60",
+        "light-orange-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.70",
+      "figma": "color/light/orange/70",
+      "css": "--charcoal-color-light-orange-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.70",
+        "color/light/orange/70",
+        "--charcoal-color-light-orange-70",
+        "charcoal-color-light-orange-70",
+        "color-light-orange-70",
+        "light/orange/70",
+        "light-orange-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.80",
+      "figma": "color/light/orange/80",
+      "css": "--charcoal-color-light-orange-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.80",
+        "color/light/orange/80",
+        "--charcoal-color-light-orange-80",
+        "charcoal-color-light-orange-80",
+        "color-light-orange-80",
+        "light/orange/80",
+        "light-orange-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.orange.90",
+      "figma": "color/light/orange/90",
+      "css": "--charcoal-color-light-orange-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.orange.90",
+        "color/light/orange/90",
+        "--charcoal-color-light-orange-90",
+        "charcoal-color-light-orange-90",
+        "color-light-orange-90",
+        "light/orange/90",
+        "light-orange-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.10",
+      "figma": "color/light/purple/10",
+      "css": "--charcoal-color-light-purple-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.10",
+        "color/light/purple/10",
+        "--charcoal-color-light-purple-10",
+        "charcoal-color-light-purple-10",
+        "color-light-purple-10",
+        "light/purple/10",
+        "light-purple-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.20",
+      "figma": "color/light/purple/20",
+      "css": "--charcoal-color-light-purple-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.20",
+        "color/light/purple/20",
+        "--charcoal-color-light-purple-20",
+        "charcoal-color-light-purple-20",
+        "color-light-purple-20",
+        "light/purple/20",
+        "light-purple-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.30",
+      "figma": "color/light/purple/30",
+      "css": "--charcoal-color-light-purple-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.30",
+        "color/light/purple/30",
+        "--charcoal-color-light-purple-30",
+        "charcoal-color-light-purple-30",
+        "color-light-purple-30",
+        "light/purple/30",
+        "light-purple-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.40",
+      "figma": "color/light/purple/40",
+      "css": "--charcoal-color-light-purple-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.40",
+        "color/light/purple/40",
+        "--charcoal-color-light-purple-40",
+        "charcoal-color-light-purple-40",
+        "color-light-purple-40",
+        "light/purple/40",
+        "light-purple-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.5",
+      "figma": "color/light/purple/5",
+      "css": "--charcoal-color-light-purple-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.5",
+        "color/light/purple/5",
+        "--charcoal-color-light-purple-5",
+        "charcoal-color-light-purple-5",
+        "color-light-purple-5",
+        "light/purple/5",
+        "light-purple-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.50",
+      "figma": "color/light/purple/50",
+      "css": "--charcoal-color-light-purple-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.50",
+        "color/light/purple/50",
+        "--charcoal-color-light-purple-50",
+        "charcoal-color-light-purple-50",
+        "color-light-purple-50",
+        "light/purple/50",
+        "light-purple-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.60",
+      "figma": "color/light/purple/60",
+      "css": "--charcoal-color-light-purple-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.60",
+        "color/light/purple/60",
+        "--charcoal-color-light-purple-60",
+        "charcoal-color-light-purple-60",
+        "color-light-purple-60",
+        "light/purple/60",
+        "light-purple-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.70",
+      "figma": "color/light/purple/70",
+      "css": "--charcoal-color-light-purple-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.70",
+        "color/light/purple/70",
+        "--charcoal-color-light-purple-70",
+        "charcoal-color-light-purple-70",
+        "color-light-purple-70",
+        "light/purple/70",
+        "light-purple-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.80",
+      "figma": "color/light/purple/80",
+      "css": "--charcoal-color-light-purple-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.80",
+        "color/light/purple/80",
+        "--charcoal-color-light-purple-80",
+        "charcoal-color-light-purple-80",
+        "color-light-purple-80",
+        "light/purple/80",
+        "light-purple-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.purple.90",
+      "figma": "color/light/purple/90",
+      "css": "--charcoal-color-light-purple-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.purple.90",
+        "color/light/purple/90",
+        "--charcoal-color-light-purple-90",
+        "charcoal-color-light-purple-90",
+        "color-light-purple-90",
+        "light/purple/90",
+        "light-purple-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.0",
+      "figma": "color/light/red/0",
+      "css": "--charcoal-color-light-red-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.0",
+        "color/light/red/0",
+        "--charcoal-color-light-red-0",
+        "charcoal-color-light-red-0",
+        "color-light-red-0",
+        "light/red/0",
+        "light-red-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.10",
+      "figma": "color/light/red/10",
+      "css": "--charcoal-color-light-red-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.10",
+        "color/light/red/10",
+        "--charcoal-color-light-red-10",
+        "charcoal-color-light-red-10",
+        "color-light-red-10",
+        "light/red/10",
+        "light-red-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.20",
+      "figma": "color/light/red/20",
+      "css": "--charcoal-color-light-red-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/negative"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.20",
+        "color/light/red/20",
+        "--charcoal-color-light-red-20",
+        "charcoal-color-light-red-20",
+        "color-light-red-20",
+        "light/red/20",
+        "light-red-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.30",
+      "figma": "color/light/red/30",
+      "css": "--charcoal-color-light-red-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.30",
+        "color/light/red/30",
+        "--charcoal-color-light-red-30",
+        "charcoal-color-light-red-30",
+        "color-light-red-30",
+        "light/red/30",
+        "light-red-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.40",
+      "figma": "color/light/red/40",
+      "css": "--charcoal-color-light-red-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.40",
+        "color/light/red/40",
+        "--charcoal-color-light-red-40",
+        "charcoal-color-light-red-40",
+        "color-light-red-40",
+        "light/red/40",
+        "light-red-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.5",
+      "figma": "color/light/red/5",
+      "css": "--charcoal-color-light-red-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.5",
+        "color/light/red/5",
+        "--charcoal-color-light-red-5",
+        "charcoal-color-light-red-5",
+        "color-light-red-5",
+        "light/red/5",
+        "light-red-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.50",
+      "figma": "color/light/red/50",
+      "css": "--charcoal-color-light-red-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/default"
+        },
+        {
+          "figma": "color/container/negative/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.50",
+        "color/light/red/50",
+        "--charcoal-color-light-red-50",
+        "charcoal-color-light-red-50",
+        "color-light-red-50",
+        "light/red/50",
+        "light-red-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.60",
+      "figma": "color/light/red/60",
+      "css": "--charcoal-color-light-red-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/hover"
+        },
+        {
+          "figma": "color/container/negative/hover"
+        },
+        {
+          "figma": "color/text/negative/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.60",
+        "color/light/red/60",
+        "--charcoal-color-light-red-60",
+        "charcoal-color-light-red-60",
+        "color-light-red-60",
+        "light/red/60",
+        "light-red-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.70",
+      "figma": "color/light/red/70",
+      "css": "--charcoal-color-light-red-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/press"
+        },
+        {
+          "figma": "color/container/negative/press"
+        },
+        {
+          "figma": "color/text/negative/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.70",
+        "color/light/red/70",
+        "--charcoal-color-light-red-70",
+        "charcoal-color-light-red-70",
+        "color-light-red-70",
+        "light/red/70",
+        "light-red-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.80",
+      "figma": "color/light/red/80",
+      "css": "--charcoal-color-light-red-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/negative/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.80",
+        "color/light/red/80",
+        "--charcoal-color-light-red-80",
+        "charcoal-color-light-red-80",
+        "color-light-red-80",
+        "light/red/80",
+        "light-red-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.red.90",
+      "figma": "color/light/red/90",
+      "css": "--charcoal-color-light-red-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.red.90",
+        "color/light/red/90",
+        "--charcoal-color-light-red-90",
+        "charcoal-color-light-red-90",
+        "color-light-red-90",
+        "light/red/90",
+        "light-red-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.0",
+      "figma": "color/light/turquoise/0",
+      "css": "--charcoal-color-light-turquoise-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.0",
+        "color/light/turquoise/0",
+        "--charcoal-color-light-turquoise-0",
+        "charcoal-color-light-turquoise-0",
+        "color-light-turquoise-0",
+        "light/turquoise/0",
+        "light-turquoise-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.10",
+      "figma": "color/light/turquoise/10",
+      "css": "--charcoal-color-light-turquoise-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.10",
+        "color/light/turquoise/10",
+        "--charcoal-color-light-turquoise-10",
+        "charcoal-color-light-turquoise-10",
+        "color-light-turquoise-10",
+        "light/turquoise/10",
+        "light-turquoise-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.20",
+      "figma": "color/light/turquoise/20",
+      "css": "--charcoal-color-light-turquoise-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.20",
+        "color/light/turquoise/20",
+        "--charcoal-color-light-turquoise-20",
+        "charcoal-color-light-turquoise-20",
+        "color-light-turquoise-20",
+        "light/turquoise/20",
+        "light-turquoise-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.30",
+      "figma": "color/light/turquoise/30",
+      "css": "--charcoal-color-light-turquoise-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.30",
+        "color/light/turquoise/30",
+        "--charcoal-color-light-turquoise-30",
+        "charcoal-color-light-turquoise-30",
+        "color-light-turquoise-30",
+        "light/turquoise/30",
+        "light-turquoise-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.40",
+      "figma": "color/light/turquoise/40",
+      "css": "--charcoal-color-light-turquoise-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.40",
+        "color/light/turquoise/40",
+        "--charcoal-color-light-turquoise-40",
+        "charcoal-color-light-turquoise-40",
+        "color-light-turquoise-40",
+        "light/turquoise/40",
+        "light-turquoise-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.5",
+      "figma": "color/light/turquoise/5",
+      "css": "--charcoal-color-light-turquoise-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.5",
+        "color/light/turquoise/5",
+        "--charcoal-color-light-turquoise-5",
+        "charcoal-color-light-turquoise-5",
+        "color-light-turquoise-5",
+        "light/turquoise/5",
+        "light-turquoise-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.50",
+      "figma": "color/light/turquoise/50",
+      "css": "--charcoal-color-light-turquoise-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.50",
+        "color/light/turquoise/50",
+        "--charcoal-color-light-turquoise-50",
+        "charcoal-color-light-turquoise-50",
+        "color-light-turquoise-50",
+        "light/turquoise/50",
+        "light-turquoise-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.60",
+      "figma": "color/light/turquoise/60",
+      "css": "--charcoal-color-light-turquoise-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.60",
+        "color/light/turquoise/60",
+        "--charcoal-color-light-turquoise-60",
+        "charcoal-color-light-turquoise-60",
+        "color-light-turquoise-60",
+        "light/turquoise/60",
+        "light-turquoise-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.70",
+      "figma": "color/light/turquoise/70",
+      "css": "--charcoal-color-light-turquoise-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.70",
+        "color/light/turquoise/70",
+        "--charcoal-color-light-turquoise-70",
+        "charcoal-color-light-turquoise-70",
+        "color-light-turquoise-70",
+        "light/turquoise/70",
+        "light-turquoise-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.80",
+      "figma": "color/light/turquoise/80",
+      "css": "--charcoal-color-light-turquoise-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.80",
+        "color/light/turquoise/80",
+        "--charcoal-color-light-turquoise-80",
+        "charcoal-color-light-turquoise-80",
+        "color-light-turquoise-80",
+        "light/turquoise/80",
+        "light-turquoise-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.turquoise.90",
+      "figma": "color/light/turquoise/90",
+      "css": "--charcoal-color-light-turquoise-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.turquoise.90",
+        "color/light/turquoise/90",
+        "--charcoal-color-light-turquoise-90",
+        "charcoal-color-light-turquoise-90",
+        "color-light-turquoise-90",
+        "light/turquoise/90",
+        "light-turquoise-90"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.0",
+      "figma": "color/light/yellow/0",
+      "css": "--charcoal-color-light-yellow-0",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.0",
+        "color/light/yellow/0",
+        "--charcoal-color-light-yellow-0",
+        "charcoal-color-light-yellow-0",
+        "color-light-yellow-0",
+        "light/yellow/0",
+        "light-yellow-0"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.10",
+      "figma": "color/light/yellow/10",
+      "css": "--charcoal-color-light-yellow-10",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.10",
+        "color/light/yellow/10",
+        "--charcoal-color-light-yellow-10",
+        "charcoal-color-light-yellow-10",
+        "color-light-yellow-10",
+        "light/yellow/10",
+        "light-yellow-10"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.20",
+      "figma": "color/light/yellow/20",
+      "css": "--charcoal-color-light-yellow-20",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.20",
+        "color/light/yellow/20",
+        "--charcoal-color-light-yellow-20",
+        "charcoal-color-light-yellow-20",
+        "color-light-yellow-20",
+        "light/yellow/20",
+        "light-yellow-20"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.30",
+      "figma": "color/light/yellow/30",
+      "css": "--charcoal-color-light-yellow-30",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.30",
+        "color/light/yellow/30",
+        "--charcoal-color-light-yellow-30",
+        "charcoal-color-light-yellow-30",
+        "color-light-yellow-30",
+        "light/yellow/30",
+        "light-yellow-30"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.40",
+      "figma": "color/light/yellow/40",
+      "css": "--charcoal-color-light-yellow-40",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.40",
+        "color/light/yellow/40",
+        "--charcoal-color-light-yellow-40",
+        "charcoal-color-light-yellow-40",
+        "color-light-yellow-40",
+        "light/yellow/40",
+        "light-yellow-40"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.5",
+      "figma": "color/light/yellow/5",
+      "css": "--charcoal-color-light-yellow-5",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.5",
+        "color/light/yellow/5",
+        "--charcoal-color-light-yellow-5",
+        "charcoal-color-light-yellow-5",
+        "color-light-yellow-5",
+        "light/yellow/5",
+        "light-yellow-5"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.50",
+      "figma": "color/light/yellow/50",
+      "css": "--charcoal-color-light-yellow-50",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.50",
+        "color/light/yellow/50",
+        "--charcoal-color-light-yellow-50",
+        "charcoal-color-light-yellow-50",
+        "color-light-yellow-50",
+        "light/yellow/50",
+        "light-yellow-50"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.60",
+      "figma": "color/light/yellow/60",
+      "css": "--charcoal-color-light-yellow-60",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/notice/default"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.60",
+        "color/light/yellow/60",
+        "--charcoal-color-light-yellow-60",
+        "charcoal-color-light-yellow-60",
+        "color-light-yellow-60",
+        "light/yellow/60",
+        "light-yellow-60"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.70",
+      "figma": "color/light/yellow/70",
+      "css": "--charcoal-color-light-yellow-70",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/notice/hover"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.70",
+        "color/light/yellow/70",
+        "--charcoal-color-light-yellow-70",
+        "charcoal-color-light-yellow-70",
+        "color-light-yellow-70",
+        "light/yellow/70",
+        "light-yellow-70"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.80",
+      "figma": "color/light/yellow/80",
+      "css": "--charcoal-color-light-yellow-80",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/notice/press"
+        }
+      ],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.80",
+        "color/light/yellow/80",
+        "--charcoal-color-light-yellow-80",
+        "charcoal-color-light-yellow-80",
+        "color-light-yellow-80",
+        "light/yellow/80",
+        "light-yellow-80"
+      ]
+    },
+    {
+      "layer": "primitive",
+      "tokenPath": "color.light.yellow.90",
+      "figma": "color/light/yellow/90",
+      "css": "--charcoal-color-light-yellow-90",
+      "category": "color",
+      "group": "light",
+      "recommendedSemantic": [],
+      "notes": [
+        "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
+      ],
+      "keys": [
+        "color.light.yellow.90",
+        "color/light/yellow/90",
+        "--charcoal-color-light-yellow-90",
+        "charcoal-color-light-yellow-90",
+        "color-light-yellow-90",
+        "light/yellow/90",
+        "light-yellow-90"
+      ]
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       'packages/*/vitest.config.ts',
       'packages/react/vitest.browser.config.ts',
       '.storybook/vitest.config.ts',
+      'misc/charcoal-skill/vitest.config.ts',
     ],
     snapshotFormat: {
       printShadowRoot: false,


### PR DESCRIPTION
## やったこと

- Tailwind mapping を入力として canonical な token index を生成する処理を追加した
- 生成物の順序と provenance hash を固定し、再生成できることをテストした
- Skill 配布物に index.json を追加した

## 動作確認環境

- `CI=true pnpm exec vitest run --config misc/charcoal-skill/vitest.config.ts`（スタック最上段で 10 files / 94 tests 成功）

## チェックリスト

- [x] README やドキュメントに影響があることを確認した