### PR TITLE
test(charcoal-skill): 配布物と Codex へのインストールを検証

### DIFF
--- a/misc/charcoal-skill/phase0-baseline.md
+++ b/misc/charcoal-skill/phase0-baseline.md
@@ -1,0 +1,67 @@
+# Charcoal Skill Phase 0 baseline
+
+Recorded 2026-08-27 before the standalone-distribution refactor.
+
+## Inventory
+
+`git ls-files skills/charcoal` reported these 22 tracked files:
+
+```text
+SKILL.md
+data/index.json
+references/css.md
+references/figma.md
+references/tailwind.md
+rules/styling.md
+scripts/generate.test.ts
+scripts/generate.ts
+scripts/lookup/layer.mjs
+scripts/lookup/layer.test.mjs
+scripts/lookup/normalize.mjs
+scripts/lookup/normalize.test.mjs
+scripts/lookup/query.mjs
+scripts/lookup/search.mjs
+scripts/lookup/sources.mjs
+scripts/lookup/sources.test.mjs
+scripts/lookup/validate.mjs
+scripts/resolve.mjs
+scripts/resolve.schema.json
+scripts/resolve.test.mjs
+skill.test.mjs
+vitest.config.ts
+```
+
+The directory's regular-file byte total was **525,117 bytes**.
+
+## Existing test result
+
+On Node.js `v24.18.0`, the following command passed: 6 test files and 63 tests.
+
+```text
+pnpm exec vitest --config skills/charcoal/vitest.config.ts --run
+```
+
+## Discovery and path evidence
+
+With the root dev dependency `skills@1.5.23`, this command discovers one
+skill named `charcoal`:
+
+```text
+pnpm exec skills add <absolute-local-repository> --list
+```
+
+The data path is already independent of the caller's CWD: from an external
+temporary directory, invoking the **absolute** path to `resolve.mjs` succeeds
+and returns the expected JSON. `lookup/query.mjs` derives `data/index.json`
+from `import.meta.url`.
+
+The documented command is instead an agent-visible script-path problem. From
+an external CWD, `node skills/charcoal/scripts/resolve.mjs ...` fails before
+the CLI starts because that relative path is resolved against the consumer
+project, not the selected Skill directory. Phase 0 captures this as an
+expected failure; Phase 1 will change the execution contract.
+
+Launching a symlink to `resolve.mjs` exits 0 with empty stdout. Its current
+main-module comparison compares the unresolved `process.argv[1]` to the real
+module path, so the CLI body does not run. Phase 1 will make that comparison
+symlink-safe.

--- a/misc/charcoal-skill/tests/distribution.test.mjs
+++ b/misc/charcoal-skill/tests/distribution.test.mjs
@@ -1,4 +1,5 @@
-import { execFileSync, spawnSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
@@ -24,6 +25,9 @@ const runtimeFiles = new Set([
   'scripts/lookup/validate.mjs',
 ])
 
+const monorepoOnlyPattern =
+  /@charcoal-ui\/|generate\.ts|misc\/charcoal-skill|sources\.mjs/u
+
 function trackedRuntimeFiles() {
   return execFileSync('git', ['ls-files', '--', 'skills/charcoal'], {
     cwd: repoRoot,
@@ -35,22 +39,25 @@ function trackedRuntimeFiles() {
     .map((file) => file.replace(/^skills\/charcoal\//u, ''))
 }
 
+function collectFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name)
+    return entry.isDirectory() ? collectFiles(fullPath) : [fullPath]
+  })
+}
+
 describe('charcoal skill distribution tree', () => {
   test('contains only runtime files', () => {
     expect(new Set(trackedRuntimeFiles())).toEqual(runtimeFiles)
   })
 
   test('runtime does not reference monorepo-only code', () => {
-    const result = spawnSync(
-      'rg',
-      [
-        '-n',
-        '@charcoal-ui/|generate\\.ts|misc/charcoal-skill|sources\\.mjs',
-        'skills/charcoal/scripts',
-      ],
-      { cwd: repoRoot, encoding: 'utf8' },
+    const scriptsDir = path.join(repoRoot, 'skills/charcoal/scripts')
+    const hits = collectFiles(scriptsDir).flatMap((file) =>
+      monorepoOnlyPattern.test(readFileSync(file, 'utf8'))
+        ? [path.relative(repoRoot, file)]
+        : [],
     )
-    expect(result.status).toBe(1)
-    expect(result.stdout).toBe('')
+    expect(hits).toEqual([])
   })
 })

--- a/misc/charcoal-skill/tests/distribution.test.mjs
+++ b/misc/charcoal-skill/tests/distribution.test.mjs
@@ -1,0 +1,56 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+)
+
+const runtimeFiles = new Set([
+  'SKILL.md',
+  'data/index.json',
+  'references/css.md',
+  'references/figma.md',
+  'references/tailwind.md',
+  'rules/styling.md',
+  'scripts/resolve.mjs',
+  'scripts/cli-output.schema.json',
+  'scripts/lookup/normalize.mjs',
+  'scripts/lookup/query.mjs',
+  'scripts/lookup/search.mjs',
+  'scripts/lookup/types.d.ts',
+  'scripts/lookup/validate.mjs',
+])
+
+function trackedRuntimeFiles() {
+  return execFileSync('git', ['ls-files', '--', 'skills/charcoal'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((file) => file.replace(/^skills\/charcoal\//u, ''))
+}
+
+describe('charcoal skill distribution tree', () => {
+  test('contains only runtime files', () => {
+    expect(new Set(trackedRuntimeFiles())).toEqual(runtimeFiles)
+  })
+
+  test('runtime does not reference monorepo-only code', () => {
+    const result = spawnSync(
+      'rg',
+      [
+        '-n',
+        '@charcoal-ui/|generate\\.ts|misc/charcoal-skill|sources\\.mjs',
+        'skills/charcoal/scripts',
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    )
+    expect(result.status).toBe(1)
+    expect(result.stdout).toBe('')
+  })
+})

--- a/misc/charcoal-skill/tests/install.test.mjs
+++ b/misc/charcoal-skill/tests/install.test.mjs
@@ -1,0 +1,248 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import {
+  cpSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Ajv2020 from 'ajv/dist/2020.js'
+import { afterEach, describe, expect, test } from 'vitest'
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+)
+const skillRoot = path.join(repoRoot, 'skills', 'charcoal')
+const runtimeFiles = new Set([
+  'SKILL.md',
+  'data/index.json',
+  'references/css.md',
+  'references/figma.md',
+  'references/tailwind.md',
+  'rules/styling.md',
+  'scripts/resolve.mjs',
+  'scripts/cli-output.schema.json',
+  'scripts/lookup/normalize.mjs',
+  'scripts/lookup/query.mjs',
+  'scripts/lookup/search.mjs',
+  'scripts/lookup/types.d.ts',
+  'scripts/lookup/validate.mjs',
+])
+const temporaryDirectories = []
+
+function temporaryDirectory() {
+  const directory = mkdtempSync(path.join(tmpdir(), 'charcoal-install-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function git(directory, ...args) {
+  return execFileSync('git', args, { cwd: directory, encoding: 'utf8' })
+}
+
+function installedFiles(directory) {
+  return execFileSync('find', ['.', '-type', 'f'], {
+    cwd: directory,
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((file) => file.replace(/^\.\//u, ''))
+}
+
+function invoke(cwd, script, ...args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd,
+    encoding: 'utf8',
+  })
+}
+
+function jsonResult(result, validate) {
+  expect(result.status).toBe(0)
+  expect(result.stderr).toBe('')
+  expect(result.stdout).not.toBe('')
+  const output = JSON.parse(result.stdout)
+  expect(validate(output), JSON.stringify(validate.errors)).toBe(true)
+  return output
+}
+
+function expectMinimumContracts(consumer, installedSkill, validate) {
+  expect(
+    jsonResult(
+      invoke(
+        consumer,
+        path.join(installedSkill, 'scripts', 'resolve.mjs'),
+        'resolve',
+        'color/container/primary/default',
+      ),
+      validate,
+    ),
+  ).toMatchObject({
+    ok: true,
+    figma: 'color/container/primary/default',
+    css: '--charcoal-color-container-primary-default',
+  })
+
+  const search = jsonResult(
+    invoke(
+      consumer,
+      path.join(installedSkill, 'scripts', 'resolve.mjs'),
+      'search',
+      'プライマリボタンの背景',
+    ),
+    validate,
+  )
+  expect(search).toMatchObject({ ok: true })
+  expect(search.results[0]).toMatchObject({
+    figma: 'color/container/primary/default',
+    css: '--charcoal-color-container-primary-default',
+  })
+
+  expect(
+    jsonResult(
+      invoke(
+        consumer,
+        path.join(installedSkill, 'scripts', 'resolve.mjs'),
+        'family',
+        'color/container/primary/default',
+      ),
+      validate,
+    ),
+  ).toMatchObject({
+    ok: true,
+    figma: 'color/container/primary/default',
+    members: {
+      default: { css: '--charcoal-color-container-primary-default' },
+      hover: { css: '--charcoal-color-container-primary-hover' },
+      press: { css: '--charcoal-color-container-primary-press' },
+    },
+  })
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('Codex copy install', () => {
+  test('installs a self-contained runtime-only Skill into an isolated consumer', () => {
+    const directory = temporaryDirectory()
+    const source = path.join(directory, 'source')
+    const consumer = path.join(directory, 'consumer')
+    const unavailableSource = path.join(directory, 'source-unavailable')
+
+    const sourceSkill = path.join(source, 'skills', 'charcoal')
+    for (const file of runtimeFiles) {
+      const destination = path.join(sourceSkill, file)
+      mkdirSync(path.dirname(destination), { recursive: true })
+      cpSync(path.join(skillRoot, file), destination)
+    }
+    git(source, 'init')
+    git(source, 'add', '.')
+    git(
+      source,
+      '-c',
+      'user.name=Charcoal Skill Test',
+      '-c',
+      'user.email=charcoal-skill-test@example.invalid',
+      'commit',
+      '-m',
+      'add charcoal skill',
+    )
+
+    mkdirSync(consumer)
+    git(consumer, 'init')
+    writeFileSync(
+      path.join(consumer, 'package.json'),
+      '{"name":"charcoal-install-consumer","private":true}\n',
+    )
+    // Make the consumer's pnpm invocation use this repository's pinned CLI.
+    symlinkSync(
+      path.join(repoRoot, 'node_modules'),
+      path.join(consumer, 'node_modules'),
+    )
+
+    const install = spawnSync(
+      'pnpm',
+      [
+        'exec',
+        'skills',
+        'add',
+        source,
+        '--skill',
+        'charcoal',
+        '--agent',
+        'codex',
+        '--copy',
+        '--yes',
+      ],
+      { cwd: consumer, encoding: 'utf8' },
+    )
+    expect(
+      install.status,
+      `skills add failed:\nstdout:\n${install.stdout}\nstderr:\n${install.stderr}`,
+    ).toBe(0)
+
+    const installedSkill = path.join(consumer, '.agents', 'skills', 'charcoal')
+    expect(path.join(installedSkill, 'SKILL.md')).toSatisfy((file) => {
+      try {
+        return lstatSync(file).isFile()
+      } catch {
+        return false
+      }
+    })
+    expect(lstatSync(installedSkill).isSymbolicLink()).toBe(false)
+    expect(lstatSync(installedSkill).isDirectory()).toBe(true)
+    expect(new Set(installedFiles(installedSkill))).toEqual(runtimeFiles)
+
+    const schema = JSON.parse(
+      readFileSync(
+        path.join(installedSkill, 'scripts', 'cli-output.schema.json'),
+        'utf8',
+      ),
+    )
+    const validate = new Ajv2020({ strict: true }).compile(schema)
+
+    // The install must remain runnable after its local source disappears.
+    renameSync(source, unavailableSource)
+    expectMinimumContracts(consumer, installedSkill, validate)
+
+    // An unreadable installed index produces stderr-only internal errors.
+    writeFileSync(path.join(installedSkill, 'data', 'index.json'), '{')
+    const internalFixture = JSON.parse(
+      readFileSync(
+        path.join(
+          repoRoot,
+          'misc',
+          'charcoal-skill',
+          'fixtures',
+          'cli-output',
+          'errors',
+          'internal-error.json',
+        ),
+        'utf8',
+      ),
+    )
+    const internal = invoke(
+      consumer,
+      path.join(installedSkill, 'scripts', 'resolve.mjs'),
+      internalFixture.command,
+      internalFixture.query,
+    )
+    expect(internal).toMatchObject({
+      status: internalFixture.exitCode,
+      stdout: internalFixture.stdout,
+    })
+    expect(internal.stderr.startsWith(internalFixture.stderrPrefix)).toBe(true)
+  })
+})

--- a/misc/charcoal-skill/tests/phase0.test.mjs
+++ b/misc/charcoal-skill/tests/phase0.test.mjs
@@ -1,0 +1,221 @@
+import { cpSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, test } from 'vitest'
+
+const skillRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../skills/charcoal',
+)
+const script = path.join(skillRoot, 'scripts', 'resolve.mjs')
+const temporaryDirectories = []
+
+function temporaryDirectory() {
+  const directory = mkdtempSync(path.join(tmpdir(), 'charcoal-phase0-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+function invoke(cwd, scriptPath, ...args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+  })
+}
+
+function jsonResult(result) {
+  expect(result.status).toBe(0)
+  expect(result.stderr).toBe('')
+  return JSON.parse(result.stdout)
+}
+
+function expectPrimaryResult(result) {
+  expect(jsonResult(result)).toMatchObject({
+    figma: 'color/container/primary/default',
+    css: '--charcoal-color-container-primary-default',
+  })
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('CLI path portability', () => {
+  test('an external CWD and absolute script path work, proving data is not CWD-relative', () => {
+    const externalCwd = temporaryDirectory()
+
+    expect(
+      jsonResult(
+        invoke(
+          externalCwd,
+          script,
+          'resolve',
+          'color/container/primary/default',
+        ),
+      ),
+    ).toMatchObject({
+      ok: true,
+      figma: 'color/container/primary/default',
+      css: '--charcoal-color-container-primary-default',
+    })
+  })
+
+  test('pins the representative successful CLI results', () => {
+    const cwd = temporaryDirectory()
+
+    expect(
+      jsonResult(
+        invoke(cwd, script, 'resolve', 'color/container/primary/default'),
+      ),
+    ).toMatchObject({
+      ok: true,
+      figma: 'color/container/primary/default',
+      tailwind: { recommended: ['bg-container-primary'] },
+    })
+    expect(
+      jsonResult(
+        invoke(cwd, script, 'resolve', '--charcoal-color-text-default'),
+      ),
+    ).toMatchObject({
+      ok: true,
+      figma: 'color/text/default',
+      css: '--charcoal-color-text-default',
+    })
+    const japaneseSearch = jsonResult(
+      invoke(cwd, script, 'search', 'プライマリボタンの背景'),
+    )
+    expect(japaneseSearch.ok).toBe(true)
+    expect(japaneseSearch.results[0]).toMatchObject({
+      figma: 'color/container/primary/default',
+      css: '--charcoal-color-container-primary-default',
+    })
+    expect(
+      jsonResult(
+        invoke(cwd, script, 'family', 'color/container/primary/default'),
+      ),
+    ).toMatchObject({
+      ok: true,
+      figma: 'color/container/primary/default',
+      members: {
+        default: { css: '--charcoal-color-container-primary-default' },
+        hover: { css: '--charcoal-color-container-primary-hover' },
+        press: { css: '--charcoal-color-container-primary-press' },
+      },
+    })
+  })
+
+  test('the documented skill-root-relative command works', () => {
+    expectPrimaryResult(
+      invoke(
+        skillRoot,
+        'scripts/resolve.mjs',
+        'resolve',
+        'color/container/primary/default',
+      ),
+    )
+  })
+
+  test('a direct symlink to the CLI executes and writes JSON', () => {
+    const directory = temporaryDirectory()
+    const symlink = path.join(directory, 'resolve.mjs')
+    symlinkSync(script, symlink)
+
+    expectPrimaryResult(
+      invoke(directory, symlink, 'resolve', 'color/container/primary/default'),
+    )
+  })
+
+  test('a symlinked Skill directory resolves bundled data and imports', () => {
+    const directory = temporaryDirectory()
+    const linkedSkill = path.join(directory, 'charcoal')
+    symlinkSync(skillRoot, linkedSkill)
+
+    expectPrimaryResult(
+      invoke(
+        directory,
+        path.join(linkedSkill, 'scripts', 'resolve.mjs'),
+        'resolve',
+        'color/container/primary/default',
+      ),
+    )
+  })
+
+  test('a symlinked Skill parent directory resolves bundled data and imports', () => {
+    const directory = temporaryDirectory()
+    const linkedParent = path.join(directory, 'skills')
+    symlinkSync(path.dirname(skillRoot), linkedParent)
+
+    expectPrimaryResult(
+      invoke(
+        directory,
+        path.join(linkedParent, 'charcoal', 'scripts', 'resolve.mjs'),
+        'resolve',
+        'color/container/primary/default',
+      ),
+    )
+  })
+
+  test('an independently copied Skill directory needs no repository context', () => {
+    const directory = temporaryDirectory()
+    const copiedSkill = path.join(directory, 'copied-charcoal')
+    cpSync(skillRoot, copiedSkill, { recursive: true })
+
+    expectPrimaryResult(
+      invoke(
+        temporaryDirectory(),
+        path.join(copiedSkill, 'scripts', 'resolve.mjs'),
+        'resolve',
+        'color/container/primary/default',
+      ),
+    )
+  })
+
+  test('a Skill path containing spaces executes', () => {
+    const directory = temporaryDirectory()
+    const copiedSkill = path.join(directory, 'charcoal skill with spaces')
+    cpSync(skillRoot, copiedSkill, { recursive: true })
+
+    expectPrimaryResult(
+      invoke(
+        temporaryDirectory(),
+        path.join(copiedSkill, 'scripts', 'resolve.mjs'),
+        'resolve',
+        'color/container/primary/default',
+      ),
+    )
+  })
+
+  test('importing resolve.mjs does not execute the CLI', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['--input-type=module', '--eval', `import ${JSON.stringify(script)}`],
+      { cwd: temporaryDirectory(), encoding: 'utf8' },
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('')
+  })
+
+  test(
+    'English primary-button search should rank the same first result as Japanese',
+    () => {
+      const result = jsonResult(
+        invoke(
+          temporaryDirectory(),
+          script,
+          'search',
+          'primary button background',
+        ),
+      )
+
+      expect(result.results[0]).toMatchObject({
+        figma: 'color/container/primary/default',
+      })
+    },
+  )
+})

--- a/misc/charcoal-skill/tests/phase0.test.mjs
+++ b/misc/charcoal-skill/tests/phase0.test.mjs
@@ -201,21 +201,18 @@ describe('CLI path portability', () => {
     expect(result.stderr).toBe('')
   })
 
-  test(
-    'English primary-button search should rank the same first result as Japanese',
-    () => {
-      const result = jsonResult(
-        invoke(
-          temporaryDirectory(),
-          script,
-          'search',
-          'primary button background',
-        ),
-      )
+  test('English primary-button search should rank the same first result as Japanese', () => {
+    const result = jsonResult(
+      invoke(
+        temporaryDirectory(),
+        script,
+        'search',
+        'primary button background',
+      ),
+    )
 
-      expect(result.results[0]).toMatchObject({
-        figma: 'color/container/primary/default',
-      })
-    },
-  )
+    expect(result.results[0]).toMatchObject({
+      figma: 'color/container/primary/default',
+    })
+  })
 })

--- a/misc/charcoal-skill/tests/skill.test.mjs
+++ b/misc/charcoal-skill/tests/skill.test.mjs
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { help } from '../../../skills/charcoal/scripts/resolve.mjs'
+
+const root = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../skills/charcoal',
+)
+
+function read(relative) {
+  return readFileSync(path.join(root, relative), 'utf8')
+}
+
+describe('charcoal skill docs', () => {
+  const skill = read('SKILL.md')
+
+  test('SKILL.md documents the resolve commands from help', () => {
+    for (const command of [
+      'node scripts/resolve.mjs resolve <query>',
+      'node scripts/resolve.mjs search <intent>',
+      'node scripts/resolve.mjs family <token>',
+    ]) {
+      expect(skill).toContain(command)
+      expect(help).toContain(command)
+    }
+  })
+
+  test('linked markdown files exist and do not embed token tables', () => {
+    const linked = [...skill.matchAll(/\(([^)]+\.md)\)/g)].map(
+      ([, href]) => href,
+    )
+    expect(linked.length).toBeGreaterThan(0)
+    for (const href of linked) {
+      const body = read(href)
+      expect(body.length).toBeGreaterThan(0)
+      expect(body).not.toMatch(/\|[^|\n]*--charcoal-[^|\n]*\|/)
+    }
+  })
+})


### PR DESCRIPTION
## やったこと

- Skill の runtime 配布内容を固定するテストを追加した
- Codex へのコピーとインストール後の CLI 実行を検証した
- 配布前の baseline を記録した

## 動作確認環境

- `CI=true pnpm exec vitest run --config misc/charcoal-skill/vitest.config.ts`（10 files / 94 tests 成功）

## チェックリスト

- [x] README やドキュメントに影響があることを確認した