### PR TITLE
feat(charcoal-skill): テーマ別 semantic token 推薦を追加

### DIFF
--- a/misc/charcoal-skill/fixtures/cli-output/invalid/invalid-recommended-semantic-themes.json
+++ b/misc/charcoal-skill/fixtures/cli-output/invalid/invalid-recommended-semantic-themes.json
@@ -7,7 +7,10 @@
   "figma": "color/light/blue/50",
   "css": "--charcoal-color-light-blue-50",
   "recommendedSemantic": [
-    { "figma": "color/container/primary/default", "themes": ["light"] }
+    {
+      "figma": "color/container/primary/default",
+      "themes": ["dark", "light"]
+    }
   ],
   "notes": ["Use a semantic token."]
 }

--- a/misc/charcoal-skill/fixtures/theme-recommendations/both.json
+++ b/misc/charcoal-skill/fixtures/theme-recommendations/both.json
@@ -1,0 +1,20 @@
+{
+  "light": {
+    "color": {
+      "container/primary/default": { "value": "{color.shared/blue/50}" }
+    }
+  },
+  "dark": {
+    "color": {
+      "container/primary/default": { "value": "{color.shared/blue/50}" }
+    }
+  },
+  "expected": {
+    "color.shared.blue.50": [
+      {
+        "figma": "color/container/primary/default",
+        "themes": ["light", "dark"]
+      }
+    ]
+  }
+}

--- a/misc/charcoal-skill/fixtures/theme-recommendations/dark-only.json
+++ b/misc/charcoal-skill/fixtures/theme-recommendations/dark-only.json
@@ -1,0 +1,18 @@
+{
+  "light": {
+    "color": {}
+  },
+  "dark": {
+    "color": {
+      "container/primary/default": { "value": "{color.dark/blue/30}" }
+    }
+  },
+  "expected": {
+    "color.dark.blue.30": [
+      {
+        "figma": "color/container/primary/default",
+        "themes": ["dark"]
+      }
+    ]
+  }
+}

--- a/misc/charcoal-skill/fixtures/theme-recommendations/light-only.json
+++ b/misc/charcoal-skill/fixtures/theme-recommendations/light-only.json
@@ -1,0 +1,18 @@
+{
+  "light": {
+    "color": {
+      "container/primary/default": { "value": "{color.light/blue/50}" }
+    }
+  },
+  "dark": {
+    "color": {}
+  },
+  "expected": {
+    "color.light.blue.50": [
+      {
+        "figma": "color/container/primary/default",
+        "themes": ["light"]
+      }
+    ]
+  }
+}

--- a/misc/charcoal-skill/generate.ts
+++ b/misc/charcoal-skill/generate.ts
@@ -40,17 +40,94 @@ export type IndexRecord = {
   }
   familyKey?: string
   state?: string
-  recommendedSemantic?: { figma: string; reason?: string }[]
+  recommendedSemantic?: {
+    figma: string
+    themes: ('light' | 'dark')[]
+    reason?: string
+  }[]
   notes?: string[]
   keys: string[]
 }
 
 export type TokenIndex = {
   source: {
+    indexSchemaVersion: 1
     mappingPackageVersion: string
     mappingHash: string
+    themePackageVersion: string
+    semanticThemeHashes: {
+      light: string
+      dark: string
+    }
+    primitiveThemeHash: string
   }
   records: IndexRecord[]
+}
+
+export type JsonValue =
+  null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue }
+
+type MappingPayload = ReturnType<typeof getTokenV2TailwindClassMappings>
+
+/** Sort strings by Unicode code point, independent of the host locale. */
+function compareCodePoints(left: string, right: string) {
+  const leftPoints = Array.from(left)
+  const rightPoints = Array.from(right)
+  const length = Math.min(leftPoints.length, rightPoints.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftPoint = leftPoints[index]
+    const rightPoint = rightPoints[index]
+    if (leftPoint === undefined || rightPoint === undefined) break
+    const difference = leftPoint.codePointAt(0)! - rightPoint.codePointAt(0)!
+    if (difference !== 0) return difference
+  }
+  return leftPoints.length - rightPoints.length
+}
+
+function canonicalize(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(canonicalize)
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => compareCodePoints(left, right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    )
+  }
+  return value
+}
+
+/**
+ * Serialize logical JSON content deterministically. Arrays retain their input
+ * order; callers sort only arrays whose members do not carry meaning.
+ */
+export function canonicalJson(value: JsonValue) {
+  return JSON.stringify(canonicalize(value))
+}
+
+export function sha256(value: JsonValue) {
+  return `sha256:${createHash('sha256')
+    .update(canonicalJson(value), 'utf8')
+    .digest('hex')}`
+}
+
+/**
+ * Mapping rows and their candidate/source-token lists are sets in the mapping
+ * contract, so normalize their order before hashing. Nested object keys are
+ * handled by canonicalJson; meaningful arrays such as cssProperties retain
+ * their source order.
+ */
+export function canonicalMappingPayload(mappings: MappingPayload) {
+  return [...mappings]
+    .map((mapping) => ({
+      ...mapping,
+      classCandidates: [...mapping.classCandidates].sort((left, right) =>
+        compareCodePoints(left.className, right.className),
+      ),
+      sourceTokens: [...mapping.sourceTokens].sort((left, right) =>
+        compareCodePoints(left.tokenPath, right.tokenPath),
+      ),
+    }))
+    .sort((left, right) => compareCodePoints(left.tokenPath, right.tokenPath))
 }
 
 function kebabCase(value: string) {
@@ -177,25 +254,51 @@ function semanticRecords() {
   })
 }
 
-function aliasReverseMap(theme: ThemeJson) {
-  const aliases = new Map<string, { figma: string }[]>()
-  for (const [category, tokens] of Object.entries(theme)) {
-    for (const [key, token] of Object.entries(tokens)) {
-      const match = /^\{([^.]+)\.(.+)\}$/u.exec(token.value)
-      if (match === null) continue
-      const primitivePath = `${match[1]}.${match[2].replaceAll('/', '.')}`
-      const semanticFigma = `${category}/${key}`
-      const current = aliases.get(primitivePath) ?? []
-      current.push({ figma: semanticFigma })
-      aliases.set(primitivePath, current)
+type ThemeName = 'light' | 'dark'
+type RecommendedSemantic = {
+  figma: string
+  themes: ThemeName[]
+}
+
+export function aliasReverseMap(themes: Record<ThemeName, ThemeJson>) {
+  const aliases = new Map<string, Map<string, Set<ThemeName>>>()
+  for (const [themeName, theme] of Object.entries(themes) as [
+    ThemeName,
+    ThemeJson,
+  ][]) {
+    for (const [category, tokens] of Object.entries(theme)) {
+      for (const [key, token] of Object.entries(tokens)) {
+        const match = /^\{([^.]+)\.(.+)\}$/u.exec(token.value)
+        if (match === null) continue
+        const primitivePath = `${match[1]}.${match[2].replaceAll('/', '.')}`
+        const semanticFigma = `${category}/${key}`
+        const semantics = aliases.get(primitivePath) ?? new Map()
+        const semanticThemes = semantics.get(semanticFigma) ?? new Set()
+        semanticThemes.add(themeName)
+        semantics.set(semanticFigma, semanticThemes)
+        aliases.set(primitivePath, semantics)
+      }
     }
   }
-  return aliases
+
+  return new Map<string, RecommendedSemantic[]>(
+    [...aliases].map(([primitivePath, semantics]) => [
+      primitivePath,
+      [...semantics]
+        .map(([figma, semanticThemes]) => ({
+          figma,
+          themes: (['light', 'dark'] as const).filter((theme) =>
+            semanticThemes.has(theme),
+          ),
+        }))
+        .sort((a, b) => a.figma.localeCompare(b.figma)),
+    ]),
+  )
 }
 
 function primitiveRecords(
   base: ThemeJson,
-  aliases: Map<string, { figma: string }[]>,
+  aliases: Map<string, RecommendedSemantic[]>,
 ) {
   const colorTokens = base.color ?? {}
   return Object.keys(colorTokens).flatMap((figmaKey) => {
@@ -224,20 +327,19 @@ export function buildIndex(): TokenIndex {
       'utf8',
     ),
   ).version as string
+  const mappings = getTokenV2TailwindClassMappings({
+    includeCssVariable: true,
+  })
   const semantics = semanticRecords()
-  const mappingHash = createHash('sha256')
-    .update(
-      JSON.stringify(
-        semantics.map((record) => [
-          record.tokenPath,
-          record.tailwind?.recommended,
-        ]),
-      ),
-    )
-    .digest('hex')
   const light = JSON.parse(
     readFileSync(
       path.join(repoRoot, 'packages/theme/src/json/pixiv-light.json'),
+      'utf8',
+    ),
+  ) as ThemeJson
+  const dark = JSON.parse(
+    readFileSync(
+      path.join(repoRoot, 'packages/theme/src/json/pixiv-dark.json'),
       'utf8',
     ),
   ) as ThemeJson
@@ -247,10 +349,28 @@ export function buildIndex(): TokenIndex {
       'utf8',
     ),
   ) as ThemeJson
+  const themePackageVersion = JSON.parse(
+    readFileSync(path.join(repoRoot, 'packages/theme/package.json'), 'utf8'),
+  ).version as string
 
   return {
-    source: { mappingPackageVersion, mappingHash },
-    records: [...semantics, ...primitiveRecords(base, aliasReverseMap(light))],
+    source: {
+      indexSchemaVersion: 1,
+      mappingPackageVersion,
+      mappingHash: sha256(
+        canonicalMappingPayload(mappings) as unknown as JsonValue,
+      ),
+      themePackageVersion,
+      semanticThemeHashes: {
+        light: sha256(light),
+        dark: sha256(dark),
+      },
+      primitiveThemeHash: sha256(base),
+    },
+    records: [
+      ...semantics,
+      ...primitiveRecords(base, aliasReverseMap({ light, dark })),
+    ],
   }
 }
 

--- a/misc/charcoal-skill/lookup/sources.mjs
+++ b/misc/charcoal-skill/lookup/sources.mjs
@@ -12,6 +12,7 @@ export const sources = {
   cssTokenObject: 'packages/theme/src/token-object/index.ts',
   cssTokenObjectFunction: 'createCSSTokenObject',
   semanticThemeJson: 'packages/theme/src/json/pixiv-light.json',
+  semanticDarkThemeJson: 'packages/theme/src/json/pixiv-dark.json',
   primitiveThemeJson: 'packages/theme/src/json/base.json',
   indexOutput: 'skills/charcoal/data/index.json',
   agentEntry: 'skills/charcoal/scripts/resolve.mjs',
@@ -20,10 +21,11 @@ export const sources = {
 /**
  * semantic: mapping API の行。primitive は mapping に足さない。
  * primitive と TW 未収録の CSS 変数は theme JSON から generate が載せる。
- * alias 逆引きは pixiv-light.json の `{color.light/...}` 参照。
+ * alias 逆引きは pixiv-light.json と pixiv-dark.json の `{color.light/...}` /
+ * `{color.dark/...}` 参照を統合する。
  */
 export const indexLayers = {
   semanticFrom: 'mappingApi',
   primitiveFrom: 'primitiveThemeJson',
-  aliasReverseFrom: 'semanticThemeJson',
+  aliasReverseFrom: ['semanticThemeJson', 'semanticDarkThemeJson'],
 }

--- a/misc/charcoal-skill/tests/cli-output-schema.test.mjs
+++ b/misc/charcoal-skill/tests/cli-output-schema.test.mjs
@@ -43,7 +43,7 @@ describe('cli-output.schema.json', () => {
       ...jsonFixtures('valid'),
       ...jsonFixtures('invalid'),
     ]
-    expect(fixtures).toHaveLength(11)
+    expect(fixtures).toHaveLength(12)
 
     for (const [name, fixture] of fixtures) {
       const ajvAccepted = validate(fixture)

--- a/misc/charcoal-skill/tests/generate.test.ts
+++ b/misc/charcoal-skill/tests/generate.test.ts
@@ -1,7 +1,18 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { getTokenV2TailwindClassMappings } from '../../../packages/tailwind-config/src/tokenV2Mappings'
 import { describe, expect, test } from 'vitest'
-import { buildIndex, indexPath, writeIndex } from '../generate.ts'
+import {
+  aliasReverseMap,
+  buildIndex,
+  canonicalJson,
+  canonicalMappingPayload,
+  indexPath,
+  type JsonValue,
+  sha256,
+  writeIndex,
+} from '../generate.ts'
 import { run } from '../../../skills/charcoal/scripts/resolve.mjs'
 
 describe('generate index', () => {
@@ -10,6 +21,82 @@ describe('generate index', () => {
       writeIndex()
     }
     expect(JSON.parse(readFileSync(indexPath, 'utf8'))).toEqual(buildIndex())
+  })
+
+  test('canonical hashes ignore object key order but preserve meaningful array order', () => {
+    const differentKeyOrder = {
+      nested: { z: 'last', a: 'first' },
+      values: ['first', 'second'],
+    }
+    const equivalent = {
+      values: ['first', 'second'],
+      nested: { a: 'first', z: 'last' },
+    }
+    const differentArrayOrder = {
+      nested: { a: 'first', z: 'last' },
+      values: ['second', 'first'],
+    }
+
+    expect(canonicalJson(differentKeyOrder)).toBe(canonicalJson(equivalent))
+    expect(sha256(differentKeyOrder)).toBe(sha256(equivalent))
+    expect(sha256(differentArrayOrder)).not.toBe(sha256(equivalent))
+    expect(canonicalJson({ '\u{10000}': 2, '\uE000': 1 })).toBe('{"":1,"𐀀":2}')
+    expect(sha256(equivalent)).toMatch(/^sha256:[0-9a-f]{64}$/u)
+  })
+
+  test('mapping payload sorts records, candidates, and source tokens', () => {
+    const first = [
+      {
+        tokenPath: 'z',
+        cssVariable: '--z',
+        classCandidates: [
+          { className: 'z-last', cssProperties: ['z', 'a'], utility: 'z' },
+          { className: 'z-first', cssProperties: ['a', 'z'], utility: 'z' },
+        ],
+        sourceTokens: [{ tokenPath: 'z.second' }, { tokenPath: 'z.first' }],
+      },
+      {
+        tokenPath: 'a',
+        cssVariable: '--a',
+        classCandidates: [],
+        sourceTokens: [],
+      },
+    ]
+    const second = [
+      {
+        sourceTokens: [],
+        classCandidates: [],
+        tokenPath: 'a',
+        cssVariable: '--a',
+      },
+      {
+        sourceTokens: [{ tokenPath: 'z.first' }, { tokenPath: 'z.second' }],
+        classCandidates: [
+          { utility: 'z', cssProperties: ['a', 'z'], className: 'z-first' },
+          { utility: 'z', cssProperties: ['z', 'a'], className: 'z-last' },
+        ],
+        cssVariable: '--z',
+        tokenPath: 'z',
+      },
+    ]
+
+    expect(
+      sha256(
+        canonicalMappingPayload(
+          first as unknown as ReturnType<
+            typeof getTokenV2TailwindClassMappings
+          >,
+        ) as unknown as JsonValue,
+      ),
+    ).toBe(
+      sha256(
+        canonicalMappingPayload(
+          second as unknown as ReturnType<
+            typeof getTokenV2TailwindClassMappings
+          >,
+        ) as unknown as JsonValue,
+      ),
+    )
   })
 })
 
@@ -28,5 +115,28 @@ describe('recommended class reverse lookup', () => {
         )
       }
     }
+  })
+})
+
+describe('primitive semantic recommendations by theme', () => {
+  const fixtureDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../fixtures/theme-recommendations',
+  )
+
+  test.each(
+    readdirSync(fixtureDir)
+      .filter((name) => name.endsWith('.json'))
+      .sort(),
+  )('%s merges light/dark aliases into sorted unique themes', (fixtureName) => {
+    const fixture = JSON.parse(
+      readFileSync(path.join(fixtureDir, fixtureName), 'utf8'),
+    )
+    const recommendations = aliasReverseMap({
+      light: fixture.light,
+      dark: fixture.dark,
+    })
+
+    expect(Object.fromEntries(recommendations)).toEqual(fixture.expected)
   })
 })

--- a/misc/charcoal-skill/tests/lookup/sources.test.mjs
+++ b/misc/charcoal-skill/tests/lookup/sources.test.mjs
@@ -16,6 +16,7 @@ describe('lookup data sources', () => {
       sources.themeEntries,
       sources.cssTokenObject,
       sources.semanticThemeJson,
+      sources.semanticDarkThemeJson,
       sources.primitiveThemeJson,
     ]) {
       expect(existsSync(path.join(repoRoot, relative)), relative).toBe(true)

--- a/skills/charcoal/data/index.json
+++ b/skills/charcoal/data/index.json
@@ -1,7 +1,14 @@
 {
   "source": {
+    "indexSchemaVersion": 1,
     "mappingPackageVersion": "6.1.0-beta.4",
-    "mappingHash": "074180b6b33b9ce954423aa1a2e347919fdff964815fa0137561fc5cbf956b0d"
+    "mappingHash": "sha256:47d70ac3fea52ff4a625c2f0c96fe491680284f13c4d52381f55f895fa23a743",
+    "themePackageVersion": "6.1.0-beta.4",
+    "semanticThemeHashes": {
+      "light": "sha256:b5e262559b24bea652e0446ee4ef9afbcfc1f698357a9298ca42c8707dd4221f",
+      "dark": "sha256:d77df3e1dd6b4ba3fff9b7cd7f51937292605060ad58a71b255f3d11eba6de45"
+    },
+    "primitiveThemeHash": "sha256:d8ca17f99f85181cddd8eb608d878ee6d79d95ca1c1948cab083bf6b80c7f88f"
   },
   "records": [
     {
@@ -10086,7 +10093,14 @@
       "css": "--charcoal-color-dark-blue-20",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/focus/2",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10107,7 +10121,14 @@
       "css": "--charcoal-color-dark-blue-30",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/primary/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10128,7 +10149,14 @@
       "css": "--charcoal-color-dark-blue-40",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/primary/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10170,7 +10198,14 @@
       "css": "--charcoal-color-dark-blue-50",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/primary/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10191,7 +10226,20 @@
       "css": "--charcoal-color-dark-blue-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/focus/1",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/info/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10233,7 +10281,14 @@
       "css": "--charcoal-color-dark-blue-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/info/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10254,7 +10309,14 @@
       "css": "--charcoal-color-dark-blue-90",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/info/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10380,7 +10442,14 @@
       "css": "--charcoal-color-dark-green-30",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10401,7 +10470,14 @@
       "css": "--charcoal-color-dark-green-40",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10443,7 +10519,14 @@
       "css": "--charcoal-color-dark-green-50",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/positive/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10464,7 +10547,14 @@
       "css": "--charcoal-color-dark-green-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/positive/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10506,7 +10596,14 @@
       "css": "--charcoal-color-dark-green-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/positive/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -10527,7 +10624,14 @@
       "css": "--charcoal-color-dark-green-90",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/positive/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11115,7 +11219,14 @@
       "css": "--charcoal-color-dark-neutral-a--5",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/overlay",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11136,7 +11247,14 @@
       "css": "--charcoal-color-dark-neutral-a-0",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/default-a",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11157,7 +11275,32 @@
       "css": "--charcoal-color-dark-neutral-a-10",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/secondary",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/press-a",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/secondary/hover-a",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/default-a",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11178,7 +11321,20 @@
       "css": "--charcoal-color-dark-neutral-a-20",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/secondary/press-a",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/hover-a",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11199,7 +11355,26 @@
       "css": "--charcoal-color-dark-neutral-a-30",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/border/default-text3",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/press-a",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11220,7 +11395,20 @@
       "css": "--charcoal-color-dark-neutral-a-40",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/border/hover-text3",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11241,7 +11429,32 @@
       "css": "--charcoal-color-dark-neutral-a-5",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/disable",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/hover-a",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/secondary/default-a",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/skeleton",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11262,7 +11475,20 @@
       "css": "--charcoal-color-dark-neutral-a-50",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/border/press-text3",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11367,7 +11593,14 @@
       "css": "--charcoal-color-dark-neutral--10",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/tertiary",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11388,7 +11621,14 @@
       "css": "--charcoal-color-dark-neutral--5",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/secondary",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11409,7 +11649,20 @@
       "css": "--charcoal-color-dark-neutral-0",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/background/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11430,7 +11683,32 @@
       "css": "--charcoal-color-dark-neutral-10",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/disable",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/secondary/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11451,7 +11729,20 @@
       "css": "--charcoal-color-dark-neutral-20",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/secondary/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11472,7 +11763,38 @@
       "css": "--charcoal-color-dark-neutral-30",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/neutral/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/tertiary/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/placeholder/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/placeholder/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/placeholder/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11493,7 +11815,26 @@
       "css": "--charcoal-color-dark-neutral-40",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/neutral/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/disable",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/tertiary/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11514,7 +11855,38 @@
       "css": "--charcoal-color-dark-neutral-5",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/secondary/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-notice/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-notice/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-notice/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11535,7 +11907,14 @@
       "css": "--charcoal-color-dark-neutral-50",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/neutral/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11556,7 +11935,20 @@
       "css": "--charcoal-color-dark-neutral-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/secondary/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/tertiary/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11577,7 +11969,32 @@
       "css": "--charcoal-color-dark-neutral-70",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hud/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/secondary/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/tertiary/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11598,7 +12015,26 @@
       "css": "--charcoal-color-dark-neutral-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/hud/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/secondary/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -11621,13 +12057,160 @@
       "group": "dark",
       "recommendedSemantic": [
         {
-          "figma": "color/text/on-hud/default"
+          "figma": "color/container/hud/default",
+          "themes": [
+            "dark"
+          ]
         },
         {
-          "figma": "color/text/on-hud/hover"
+          "figma": "color/icon/on-neutral/default",
+          "themes": [
+            "dark"
+          ]
         },
         {
-          "figma": "color/text/on-hud/press"
+          "figma": "color/icon/on-neutral/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/icon/on-neutral/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/default-text1",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/hover-text1",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-discovery/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-discovery/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-discovery/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-hud/default",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/on-hud/hover",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/on-hud/press",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/on-negative/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-negative/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-negative/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-on-img/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-on-img/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-on-img/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-positive/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-positive/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-positive/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-primary/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-primary/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/on-primary/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/press-text1",
+          "themes": [
+            "dark"
+          ]
         }
       ],
       "notes": [
@@ -12112,7 +12695,14 @@
       "css": "--charcoal-color-dark-purple-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12154,7 +12744,14 @@
       "css": "--charcoal-color-dark-purple-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12175,7 +12772,14 @@
       "css": "--charcoal-color-dark-purple-90",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/visited/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12280,7 +12884,14 @@
       "css": "--charcoal-color-dark-red-20",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/border/negative",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12301,7 +12912,20 @@
       "css": "--charcoal-color-dark-red-30",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/default",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/negative/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12322,7 +12946,20 @@
       "css": "--charcoal-color-dark-red-40",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/negative/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12364,7 +13001,20 @@
       "css": "--charcoal-color-dark-red-50",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/discovery/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/container/negative/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12385,7 +13035,14 @@
       "css": "--charcoal-color-dark-red-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/negative/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12427,7 +13084,14 @@
       "css": "--charcoal-color-dark-red-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/negative/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12448,7 +13112,14 @@
       "css": "--charcoal-color-dark-red-90",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/negative/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12931,7 +13602,14 @@
       "css": "--charcoal-color-dark-yellow-60",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/text/notice/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12952,7 +13630,14 @@
       "css": "--charcoal-color-dark-yellow-70",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/default",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12973,7 +13658,20 @@
       "css": "--charcoal-color-dark-yellow-80",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/hover",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/notice/hover",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -12994,7 +13692,20 @@
       "css": "--charcoal-color-dark-yellow-90",
       "category": "color",
       "group": "dark",
-      "recommendedSemantic": [],
+      "recommendedSemantic": [
+        {
+          "figma": "color/container/notice/press",
+          "themes": [
+            "dark"
+          ]
+        },
+        {
+          "figma": "color/text/notice/press",
+          "themes": [
+            "dark"
+          ]
+        }
+      ],
       "notes": [
         "Color Space プリミティブはプロダクト UI に直接使わない。セマンティックトークンを選べ。"
       ],
@@ -13059,7 +13770,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/focus/2"
+          "figma": "color/border/focus/2",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13147,7 +13861,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/primary/default"
+          "figma": "color/container/primary/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13172,13 +13889,22 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/focus/1"
+          "figma": "color/border/focus/1",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/primary/hover"
+          "figma": "color/container/primary/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/info/default"
+          "figma": "color/text/info/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13203,10 +13929,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/primary/press"
+          "figma": "color/container/primary/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/info/hover"
+          "figma": "color/text/info/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13231,7 +13963,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/info/press"
+          "figma": "color/text/info/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13403,7 +14138,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/positive/default"
+          "figma": "color/container/positive/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13428,10 +14166,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/positive/hover"
+          "figma": "color/container/positive/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/positive/default"
+          "figma": "color/text/positive/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13456,10 +14200,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/positive/press"
+          "figma": "color/container/positive/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/positive/hover"
+          "figma": "color/text/positive/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13484,7 +14234,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/positive/press"
+          "figma": "color/text/positive/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13950,7 +14703,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/default-a"
+          "figma": "color/container/default-a",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -13975,19 +14731,34 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/disable"
+          "figma": "color/border/disable",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/border/secondary"
+          "figma": "color/border/secondary",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/press-a"
+          "figma": "color/container/press-a",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/secondary/hover-a"
+          "figma": "color/container/secondary/hover-a",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/tertiary/default-a"
+          "figma": "color/container/tertiary/default-a",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14012,10 +14783,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/secondary/press-a"
+          "figma": "color/container/secondary/press-a",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/tertiary/hover-a"
+          "figma": "color/container/tertiary/hover-a",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14040,7 +14817,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/tertiary/press-a"
+          "figma": "color/container/tertiary/press-a",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14065,10 +14845,17 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/background/overlay"
+          "figma": "color/background/overlay",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/on-img/default"
+          "figma": "color/container/on-img/default",
+          "themes": [
+            "light",
+            "dark"
+          ]
         }
       ],
       "notes": [
@@ -14093,13 +14880,22 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/hover-a"
+          "figma": "color/container/hover-a",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/secondary/default-a"
+          "figma": "color/container/secondary/default-a",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/skeleton"
+          "figma": "color/container/skeleton",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14124,13 +14920,23 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/default"
+          "figma": "color/border/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/border/default-text3"
+          "figma": "color/border/default-text3",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/on-img/hover"
+          "figma": "color/container/on-img/hover",
+          "themes": [
+            "light",
+            "dark"
+          ]
         }
       ],
       "notes": [
@@ -14155,13 +14961,23 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/hover"
+          "figma": "color/border/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/border/hover-text3"
+          "figma": "color/border/hover-text3",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/on-img/press"
+          "figma": "color/container/on-img/press",
+          "themes": [
+            "light",
+            "dark"
+          ]
         }
       ],
       "notes": [
@@ -14186,10 +15002,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/press"
+          "figma": "color/border/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/border/press-text3"
+          "figma": "color/border/press-text3",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14256,58 +15078,112 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/background/default"
+          "figma": "color/background/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/default"
+          "figma": "color/container/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/icon/on-neutral/default"
+          "figma": "color/icon/on-neutral/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-discovery/default"
+          "figma": "color/text/on-discovery/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-discovery/hover"
+          "figma": "color/text/on-discovery/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-discovery/press"
+          "figma": "color/text/on-discovery/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-negative/default"
+          "figma": "color/text/on-negative/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-negative/hover"
+          "figma": "color/text/on-negative/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-negative/press"
+          "figma": "color/text/on-negative/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-on-img/default"
+          "figma": "color/text/on-on-img/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-on-img/hover"
+          "figma": "color/text/on-on-img/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-on-img/press"
+          "figma": "color/text/on-on-img/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-positive/default"
+          "figma": "color/text/on-positive/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-positive/hover"
+          "figma": "color/text/on-positive/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-positive/press"
+          "figma": "color/text/on-positive/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-primary/default"
+          "figma": "color/text/on-primary/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-primary/hover"
+          "figma": "color/text/on-primary/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-primary/press"
+          "figma": "color/text/on-primary/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14332,22 +15208,40 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/background/tertiary"
+          "figma": "color/background/tertiary",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/disable"
+          "figma": "color/container/disable",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/press"
+          "figma": "color/container/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/secondary/hover"
+          "figma": "color/container/secondary/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/tertiary/default"
+          "figma": "color/container/tertiary/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/icon/on-neutral/press"
+          "figma": "color/icon/on-neutral/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14372,10 +15266,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/secondary/press"
+          "figma": "color/container/secondary/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/tertiary/hover"
+          "figma": "color/container/tertiary/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14400,10 +15300,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/tertiary/press"
+          "figma": "color/container/tertiary/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/disable"
+          "figma": "color/text/disable",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14449,16 +15355,28 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/background/secondary"
+          "figma": "color/background/secondary",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/hover"
+          "figma": "color/container/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/secondary/default"
+          "figma": "color/container/secondary/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/icon/on-neutral/hover"
+          "figma": "color/icon/on-neutral/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14483,16 +15401,28 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/neutral/default"
+          "figma": "color/container/neutral/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/placeholder/default"
+          "figma": "color/text/placeholder/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/placeholder/hover"
+          "figma": "color/text/placeholder/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/placeholder/press"
+          "figma": "color/text/placeholder/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14517,13 +15447,22 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/hud/press"
+          "figma": "color/container/hud/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/neutral/hover"
+          "figma": "color/container/neutral/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/tertiary/default"
+          "figma": "color/text/tertiary/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14548,19 +15487,34 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/hud/hover"
+          "figma": "color/container/hud/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/neutral/press"
+          "figma": "color/container/neutral/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/press"
+          "figma": "color/text/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/secondary/default"
+          "figma": "color/text/secondary/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/tertiary/hover"
+          "figma": "color/text/tertiary/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14585,16 +15539,28 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/hud/default"
+          "figma": "color/container/hud/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/hover"
+          "figma": "color/text/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/secondary/hover"
+          "figma": "color/text/secondary/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/tertiary/press"
+          "figma": "color/text/tertiary/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -14619,28 +15585,70 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/default"
+          "figma": "color/text/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/default-text1"
+          "figma": "color/text/default-text1",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/hover-text1"
+          "figma": "color/text/hover-text1",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/on-notice/default"
+          "figma": "color/text/on-hud/default",
+          "themes": [
+            "dark"
+          ]
         },
         {
-          "figma": "color/text/on-notice/hover"
+          "figma": "color/text/on-hud/hover",
+          "themes": [
+            "dark"
+          ]
         },
         {
-          "figma": "color/text/on-notice/press"
+          "figma": "color/text/on-hud/press",
+          "themes": [
+            "dark"
+          ]
         },
         {
-          "figma": "color/text/press-text1"
+          "figma": "color/text/on-notice/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/secondary/press"
+          "figma": "color/text/on-notice/hover",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/on-notice/press",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/press-text1",
+          "themes": [
+            "light"
+          ]
+        },
+        {
+          "figma": "color/text/secondary/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15022,7 +16030,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/visited/default"
+          "figma": "color/text/visited/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15047,7 +16058,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/visited/hover"
+          "figma": "color/text/visited/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15072,7 +16086,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/visited/press"
+          "figma": "color/text/visited/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15139,7 +16156,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/border/negative"
+          "figma": "color/border/negative",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15227,10 +16247,16 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/discovery/default"
+          "figma": "color/container/discovery/default",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/negative/default"
+          "figma": "color/container/negative/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15255,13 +16281,22 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/discovery/hover"
+          "figma": "color/container/discovery/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/negative/hover"
+          "figma": "color/container/negative/hover",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/negative/default"
+          "figma": "color/text/negative/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15286,13 +16321,22 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/discovery/press"
+          "figma": "color/container/discovery/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/container/negative/press"
+          "figma": "color/container/negative/press",
+          "themes": [
+            "light"
+          ]
         },
         {
-          "figma": "color/text/negative/hover"
+          "figma": "color/text/negative/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15317,7 +16361,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/negative/press"
+          "figma": "color/text/negative/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15636,7 +16683,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/notice/default"
+          "figma": "color/container/notice/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15661,7 +16711,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/notice/hover"
+          "figma": "color/container/notice/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15686,7 +16739,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/container/notice/press"
+          "figma": "color/container/notice/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15753,7 +16809,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/notice/default"
+          "figma": "color/text/notice/default",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15778,7 +16837,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/notice/hover"
+          "figma": "color/text/notice/hover",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [
@@ -15803,7 +16865,10 @@
       "group": "light",
       "recommendedSemantic": [
         {
-          "figma": "color/text/notice/press"
+          "figma": "color/text/notice/press",
+          "themes": [
+            "light"
+          ]
         }
       ],
       "notes": [

--- a/skills/charcoal/scripts/cli-output.schema.json
+++ b/skills/charcoal/scripts/cli-output.schema.json
@@ -44,15 +44,16 @@
     "recommendedSemantic": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["figma"],
+      "required": ["figma", "themes"],
       "properties": {
         "figma": { "type": "string" },
         "reason": { "type": "string" },
         "themes": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": { "type": "string" }
+          "oneOf": [
+            { "const": ["light"] },
+            { "const": ["dark"] },
+            { "const": ["light", "dark"] }
+          ]
         }
       }
     },

--- a/skills/charcoal/scripts/lookup/types.d.ts
+++ b/skills/charcoal/scripts/lookup/types.d.ts
@@ -20,15 +20,26 @@ export type IndexRecord = {
   }
   familyKey?: string
   state?: string
-  recommendedSemantic?: { figma: string; reason?: string }[]
+  recommendedSemantic?: {
+    figma: string
+    themes: ('light' | 'dark')[]
+    reason?: string
+  }[]
   notes?: string[]
   keys: string[]
 }
 
 export type TokenIndex = {
   source: {
+    indexSchemaVersion: 1
     mappingPackageVersion: string
     mappingHash: string
+    themePackageVersion: string
+    semanticThemeHashes: {
+      light: string
+      dark: string
+    }
+    primitiveThemeHash: string
   }
   records: IndexRecord[]
 }

--- a/skills/charcoal/scripts/lookup/validate.mjs
+++ b/skills/charcoal/scripts/lookup/validate.mjs
@@ -151,7 +151,9 @@ function assertRecommendedSemantic(value) {
     value.themes.length === 0 ||
     !value.themes.every((theme) => theme === 'light' || theme === 'dark') ||
     value.themes.join(',') !==
-      ['light', 'dark'].filter((theme) => value.themes.includes(theme)).join(',')
+      ['light', 'dark']
+        .filter((theme) => value.themes.includes(theme))
+        .join(',')
   ) {
     throw new TypeError(
       'recommendedSemantic entry.themes must be a non-empty sorted unique light/dark array',

--- a/skills/charcoal/scripts/lookup/validate.mjs
+++ b/skills/charcoal/scripts/lookup/validate.mjs
@@ -139,23 +139,23 @@ function assertRecommendedSemantic(value) {
   assertShape(
     value,
     ['figma', 'reason', 'themes'],
-    ['figma'],
+    ['figma', 'themes'],
     'recommendedSemantic entry',
   )
   assertString(value.figma, 'recommendedSemantic entry.figma')
   if ('reason' in value) {
     assertString(value.reason, 'recommendedSemantic entry.reason')
   }
-  if ('themes' in value) {
-    assertStringArray(value.themes, 'recommendedSemantic entry.themes')
-    if (
-      value.themes.length === 0 ||
-      new Set(value.themes).size !== value.themes.length
-    ) {
-      throw new TypeError(
-        'recommendedSemantic entry.themes must be a non-empty unique array',
-      )
-    }
+  assertStringArray(value.themes, 'recommendedSemantic entry.themes')
+  if (
+    value.themes.length === 0 ||
+    !value.themes.every((theme) => theme === 'light' || theme === 'dark') ||
+    value.themes.join(',') !==
+      ['light', 'dark'].filter((theme) => value.themes.includes(theme)).join(',')
+  ) {
+    throw new TypeError(
+      'recommendedSemantic entry.themes must be a non-empty sorted unique light/dark array',
+    )
   }
 }
 
@@ -193,6 +193,9 @@ function assertPrimitiveHit(value) {
   }
   if (!Array.isArray(value.recommendedSemantic)) {
     throw new TypeError('recommendedSemantic must be an array')
+  }
+  for (const entry of value.recommendedSemantic) {
+    assertRecommendedSemantic(entry)
   }
   assertStringArray(value.notes, 'notes')
   if (value.notes.length === 0) {


### PR DESCRIPTION
## やったこと

- primitive token から light / dark テーマに応じた semantic token を推薦する機能を追加した
- 推薦内容を CLI schema で検証し、テーマ組み合わせごとの fixture を追加した
- canonical index に生成元の provenance を記録した

## 動作確認環境

- `CI=true pnpm exec vitest run --config misc/charcoal-skill/vitest.config.ts`（10 files / 94 tests 成功）

## チェックリスト

- [x] README やドキュメントに影響があることを確認した