### PR TITLE
fix(react): notificationのheaderOffsetを公開する

### DIFF
--- a/packages/react/src/components/Notification/NotificationRegion.browser.test.tsx
+++ b/packages/react/src/components/Notification/NotificationRegion.browser.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ComponentType } from 'react'
+import { afterEach } from 'vitest'
+import { useSnackbar } from './Snackbar'
+import { useToast } from './Toast'
+
+const HEADER_OFFSET = 64
+const OFFSET = 24
+
+const notificationOptions = {
+  position: 'top',
+  headerOffset: HEADER_OFFSET,
+  offset: OFFSET,
+  duration: 60_000,
+} as const
+
+function ToastApp() {
+  const [toast, showToast] = useToast(notificationOptions)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => showToast('保存しました', { type: 'success' })}
+      >
+        通知を表示
+      </button>
+      <div style={{ height: '200vh' }}>{toast}</div>
+    </>
+  )
+}
+
+function SnackbarApp() {
+  const [snackbar, showSnackbar] = useSnackbar(notificationOptions)
+
+  return (
+    <>
+      <button type="button" onClick={() => showSnackbar('保存しました')}>
+        通知を表示
+      </button>
+      <div style={{ height: '200vh' }}>{snackbar}</div>
+    </>
+  )
+}
+
+function getRegions(regionSelector: string) {
+  const notificationRegion = screen.getByRole('region')
+  const itemRegion = notificationRegion.querySelector(regionSelector)
+
+  if (!(itemRegion instanceof HTMLElement)) {
+    throw new Error('Notification item region not found')
+  }
+
+  return { notificationRegion, itemRegion }
+}
+
+async function scrollTo(top: number) {
+  window.scrollTo(0, top)
+  await vi.waitFor(() => expect(window.scrollY).toBe(top))
+}
+
+afterEach(async () => {
+  await scrollTo(0)
+})
+
+describe.each<{
+  name: string
+  App: ComponentType
+  regionSelector: string
+}>([
+  {
+    name: 'Toast',
+    App: ToastApp,
+    regionSelector: '.charcoal-toast-region',
+  },
+  {
+    name: 'Snackbar',
+    App: SnackbarApp,
+    regionSelector: '.charcoal-snackbar-region',
+  },
+])('$name header offset', ({ App, regionSelector }) => {
+  it('ヘッダーと一緒にスクロールし、画面上端からoffsetの位置で固定される', async () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: '通知を表示' }))
+
+    const { notificationRegion, itemRegion } = getRegions(regionSelector)
+
+    expect(itemRegion.getBoundingClientRect().top).toBe(HEADER_OFFSET)
+
+    await scrollTo(20)
+
+    expect(notificationRegion.getBoundingClientRect().top).toBe(-20)
+    expect(itemRegion.getBoundingClientRect().top).toBe(HEADER_OFFSET - 20)
+
+    await scrollTo(HEADER_OFFSET)
+
+    expect(notificationRegion.getBoundingClientRect().top).toBe(-HEADER_OFFSET)
+    expect(itemRegion.getBoundingClientRect().top).toBe(OFFSET)
+  })
+})

--- a/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
@@ -1,7 +1,3 @@
-.charcoal-snackbar-region {
-  --charcoal-snackbar-offset: 16px;
-}
-
 .charcoal-snackbar-region[data-position='top'] {
   --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
   position: sticky;

--- a/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
@@ -1,3 +1,7 @@
+.charcoal-notification-region {
+  --charcoal-snackbar-offset: 16px;
+}
+
 .charcoal-snackbar-region[data-position='top'] {
   --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
   position: sticky;

--- a/packages/react/src/components/Notification/Snackbar/index.css
+++ b/packages/react/src/components/Notification/Snackbar/index.css
@@ -1,3 +1,7 @@
+.charcoal-notification-region {
+  --charcoal-snackbar-offset: 16px;
+}
+
 .charcoal-snackbar-region {
   &[data-position='top'] {
     --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));

--- a/packages/react/src/components/Notification/Snackbar/index.css
+++ b/packages/react/src/components/Notification/Snackbar/index.css
@@ -1,6 +1,4 @@
 .charcoal-snackbar-region {
-  --charcoal-snackbar-offset: 16px;
-
   &[data-position='top'] {
     --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
 

--- a/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
@@ -1,7 +1,3 @@
-.charcoal-toast-region {
-  --charcoal-toast-offset: 16px;
-}
-
 .charcoal-toast-region[data-position='top'] {
   position: sticky;
   --charcoal-toast-enter-offset: calc(-1 * var(--charcoal-space-30));

--- a/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
@@ -1,3 +1,7 @@
+.charcoal-notification-region {
+  --charcoal-toast-offset: 16px;
+}
+
 .charcoal-toast-region[data-position='top'] {
   position: sticky;
   --charcoal-toast-enter-offset: calc(-1 * var(--charcoal-space-30));

--- a/packages/react/src/components/Notification/Toast/index.css
+++ b/packages/react/src/components/Notification/Toast/index.css
@@ -1,3 +1,7 @@
+.charcoal-notification-region {
+  --charcoal-toast-offset: 16px;
+}
+
 .charcoal-toast-region {
   &[data-position='top'] {
     position: sticky;

--- a/packages/react/src/components/Notification/Toast/index.css
+++ b/packages/react/src/components/Notification/Toast/index.css
@@ -1,6 +1,4 @@
 .charcoal-toast-region {
-  --charcoal-toast-offset: 16px;
-
   &[data-position='top'] {
     position: sticky;
     --charcoal-toast-enter-offset: calc(-1 * var(--charcoal-space-30));

--- a/packages/react/src/components/Notification/types.ts
+++ b/packages/react/src/components/Notification/types.ts
@@ -10,6 +10,11 @@ export type UseNotificationOptions = {
    */
   offset?: number
   /**
+   * スクロールに追従しないヘッダーの高さを指定する
+   * @default 0
+   */
+  headerOffset?: number
+  /**
    * 通知を表示する時間（ミリ秒）。負の値は 0、数値でない値は 5000 として扱う
    * @default 5000
    */


### PR DESCRIPTION
## やったこと

- `headerOffset`を`UseNotificationOptions`から公開
- Toast/Snackbarの内側でCSS変数のデフォルト値が`offset`の指定値を上書きする問題を修正
- Toast/Snackbarが`headerOffset`の位置からスクロールし、`offset`の位置でstickyになることを実ブラウザで検証するテストを追加