### PR TITLE
fix(react): notificationの初期表示位置を修正

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9429,7 +9429,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Default 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9482,7 +9482,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Dim 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9544,7 +9544,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > LongMessage 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9597,7 +9597,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Top 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9650,7 +9650,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithAction 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9712,7 +9712,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithLineBreak 1`] =
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -12526,7 +12526,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Bottom 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
     />
     <div
       class="charcoal-toast-region"
@@ -12578,7 +12578,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Default 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
     />
     <div
       class="charcoal-toast-region"
@@ -12630,7 +12630,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Error 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
     />
     <div
       class="charcoal-toast-region"
@@ -12682,7 +12682,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > LongMessage 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
     />
     <div
       class="charcoal-toast-region"
@@ -12734,7 +12734,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > WithLineBreak 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: 0px;"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
     />
     <div
       class="charcoal-toast-region"

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -9429,7 +9429,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Default 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9482,7 +9482,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Dim 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9544,7 +9544,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > LongMessage 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9597,7 +9597,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > Top 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9650,7 +9650,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithAction 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -9712,7 +9712,7 @@ exports[`Storybook Tests > react/Snackbar > react/Snackbar > WithLineBreak 1`] =
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));"
     />
     <div
       class="charcoal-snackbar-region"
@@ -12526,7 +12526,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Bottom 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));"
     />
     <div
       class="charcoal-toast-region"
@@ -12578,7 +12578,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Default 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));"
     />
     <div
       class="charcoal-toast-region"
@@ -12630,7 +12630,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > Error 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));"
     />
     <div
       class="charcoal-toast-region"
@@ -12682,7 +12682,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > LongMessage 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));"
     />
     <div
       class="charcoal-toast-region"
@@ -12734,7 +12734,7 @@ exports[`Storybook Tests > react/Toast > react/Toast > WithLineBreak 1`] = `
     tabindex="-1"
   >
     <div
-      style="height: calc(0px + env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px));"
+      style="height: calc(0px + env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));"
     />
     <div
       class="charcoal-toast-region"

--- a/packages/react/src/components/Notification/NotificationRegion.browser.test.tsx
+++ b/packages/react/src/components/Notification/NotificationRegion.browser.test.tsx
@@ -6,16 +6,20 @@ import { useToast } from './Toast'
 
 const HEADER_OFFSET = 64
 const OFFSET = 24
+const MINIMUM_OFFSET = 16
 
 const notificationOptions = {
   position: 'top',
   headerOffset: HEADER_OFFSET,
-  offset: OFFSET,
   duration: 60_000,
 } as const
 
-function ToastApp() {
-  const [toast, showToast] = useToast(notificationOptions)
+type AppProps = {
+  offset?: number
+}
+
+function ToastApp({ offset = OFFSET }: AppProps) {
+  const [toast, showToast] = useToast({ ...notificationOptions, offset })
 
   return (
     <>
@@ -30,8 +34,11 @@ function ToastApp() {
   )
 }
 
-function SnackbarApp() {
-  const [snackbar, showSnackbar] = useSnackbar(notificationOptions)
+function SnackbarApp({ offset = OFFSET }: AppProps) {
+  const [snackbar, showSnackbar] = useSnackbar({
+    ...notificationOptions,
+    offset,
+  })
 
   return (
     <>
@@ -65,7 +72,7 @@ afterEach(async () => {
 
 describe.each<{
   name: string
-  App: ComponentType
+  App: ComponentType<AppProps>
   regionSelector: string
 }>([
   {
@@ -85,16 +92,29 @@ describe.each<{
 
     const { notificationRegion, itemRegion } = getRegions(regionSelector)
 
-    expect(itemRegion.getBoundingClientRect().top).toBe(HEADER_OFFSET)
+    expect(itemRegion.getBoundingClientRect().top).toBe(HEADER_OFFSET + OFFSET)
 
     await scrollTo(20)
 
     expect(notificationRegion.getBoundingClientRect().top).toBe(-20)
-    expect(itemRegion.getBoundingClientRect().top).toBe(HEADER_OFFSET - 20)
+    expect(itemRegion.getBoundingClientRect().top).toBe(
+      HEADER_OFFSET + OFFSET - 20,
+    )
 
     await scrollTo(HEADER_OFFSET)
 
     expect(notificationRegion.getBoundingClientRect().top).toBe(-HEADER_OFFSET)
     expect(itemRegion.getBoundingClientRect().top).toBe(OFFSET)
+  })
+
+  it('offsetが16未満の場合は初期表示位置に16pxの余白を確保する', () => {
+    render(<App offset={8} />)
+    fireEvent.click(screen.getByRole('button', { name: '通知を表示' }))
+
+    const { itemRegion } = getRegions(regionSelector)
+
+    expect(itemRegion.getBoundingClientRect().top).toBe(
+      HEADER_OFFSET + MINIMUM_OFFSET,
+    )
   })
 })

--- a/packages/react/src/components/Notification/NotificationRegion.tsx
+++ b/packages/react/src/components/Notification/NotificationRegion.tsx
@@ -48,6 +48,7 @@ export function NotificationRegion<TContent>({
   }
   const { regionProps } = useToastRegion({}, timerState, regionRef)
   const classNames = useClassNames('charcoal-notification-region', className)
+  const effectiveOffset = Math.max(offset, DEFAULT_OFFSET)
 
   if (state.visibleToasts.length === 0) {
     return null
@@ -62,14 +63,14 @@ export function NotificationRegion<TContent>({
         style={
           {
             zIndex,
-            [`--charcoal-${name}-offset`]: `${offset}px`,
+            [`--charcoal-${name}-offset`]: `${effectiveOffset}px`,
             justifyContent: position === 'top' ? 'flex-start' : 'flex-end',
           } as CSSProperties
         }
       >
         <div
           style={{
-            height: `calc(${headerOffset}px + env(safe-area-inset-top, 0px) + max(var(--charcoal-${name}-offset), ${DEFAULT_OFFSET}px))`,
+            height: `calc(${headerOffset}px + env(safe-area-inset-top, 0px) + var(--charcoal-${name}-offset))`,
           }}
         />
         <div data-position={position} className={`charcoal-${name}-region`}>

--- a/packages/react/src/components/Notification/NotificationRegion.tsx
+++ b/packages/react/src/components/Notification/NotificationRegion.tsx
@@ -69,7 +69,7 @@ export function NotificationRegion<TContent>({
       >
         <div
           style={{
-            height: `${headerOffset}px`,
+            height: `calc(${headerOffset}px + env(safe-area-inset-top, 0px) + max(var(--charcoal-${name}-offset), ${DEFAULT_OFFSET}px))`,
           }}
         />
         <div data-position={position} className={`charcoal-${name}-region`}>

--- a/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Snackbar/__snapshots__/index.css.snap
@@ -5,17 +5,14 @@
 .charcoal-snackbar-region[data-position='top'] {
   --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
   position: sticky;
-  top: calc(
-      env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px)
-    );
+  top: calc(env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));
 }
 
 .charcoal-snackbar-region[data-position='bottom'] {
   --charcoal-snackbar-enter-offset: var(--charcoal-space-30);
   position: fixed;
   bottom: calc(
-      env(safe-area-inset-bottom, 0px) +
-        max(var(--charcoal-snackbar-offset), 16px)
+      env(safe-area-inset-bottom, 0px) + var(--charcoal-snackbar-offset)
     );
 }
 

--- a/packages/react/src/components/Notification/Snackbar/index.css
+++ b/packages/react/src/components/Notification/Snackbar/index.css
@@ -7,9 +7,7 @@
     --charcoal-snackbar-enter-offset: calc(-1 * var(--charcoal-space-30));
 
     position: sticky;
-    top: calc(
-      env(safe-area-inset-top, 0px) + max(var(--charcoal-snackbar-offset), 16px)
-    );
+    top: calc(env(safe-area-inset-top, 0px) + var(--charcoal-snackbar-offset));
   }
 
   &[data-position='bottom'] {
@@ -17,8 +15,7 @@
 
     position: fixed;
     bottom: calc(
-      env(safe-area-inset-bottom, 0px) +
-        max(var(--charcoal-snackbar-offset), 16px)
+      env(safe-area-inset-bottom, 0px) + var(--charcoal-snackbar-offset)
     );
   }
 }

--- a/packages/react/src/components/Notification/Snackbar/index.story.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.story.tsx
@@ -34,7 +34,6 @@ export default {
   args: {
     message: '保存しました',
     position: 'bottom',
-    offset: 16,
     duration: 5000,
     order: 'queue',
     dim: false,

--- a/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
+++ b/packages/react/src/components/Notification/Toast/__snapshots__/index.css.snap
@@ -5,16 +5,14 @@
 .charcoal-toast-region[data-position='top'] {
   position: sticky;
   --charcoal-toast-enter-offset: calc(-1 * var(--charcoal-space-30));
-  top: calc(
-      env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px)
-    );
+  top: calc(env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));
 }
 
 .charcoal-toast-region[data-position='bottom'] {
   position: fixed;
   --charcoal-toast-enter-offset: var(--charcoal-space-30);
   bottom: calc(
-      env(safe-area-inset-bottom, 0px) + max(var(--charcoal-toast-offset), 16px)
+      env(safe-area-inset-bottom, 0px) + var(--charcoal-toast-offset)
     );
 }
 

--- a/packages/react/src/components/Notification/Toast/index.css
+++ b/packages/react/src/components/Notification/Toast/index.css
@@ -7,9 +7,7 @@
     position: sticky;
     --charcoal-toast-enter-offset: calc(-1 * var(--charcoal-space-30));
 
-    top: calc(
-      env(safe-area-inset-top, 0px) + max(var(--charcoal-toast-offset), 16px)
-    );
+    top: calc(env(safe-area-inset-top, 0px) + var(--charcoal-toast-offset));
   }
 
   &[data-position='bottom'] {
@@ -17,7 +15,7 @@
     --charcoal-toast-enter-offset: var(--charcoal-space-30);
 
     bottom: calc(
-      env(safe-area-inset-bottom, 0px) + max(var(--charcoal-toast-offset), 16px)
+      env(safe-area-inset-bottom, 0px) + var(--charcoal-toast-offset)
     );
   }
 }

--- a/packages/react/src/components/Notification/Toast/index.story.tsx
+++ b/packages/react/src/components/Notification/Toast/index.story.tsx
@@ -34,7 +34,6 @@ export default {
   args: {
     message: '保存しました',
     position: 'top',
-    offset: 16,
     duration: 5000,
     order: 'queue',
     zIndex: 20,


### PR DESCRIPTION
## 概要

- 上部Notificationの初期表示位置を `headerOffset + max(offset, 16px)` に修正
- `headerOffset` 分スクロールした後は、従来どおり画面上端から `offset` の位置で固定
- `offset` が16未満の場合を含むToast/Snackbarのブラウザテストを追加
- Storybookでは `offset` の初期値を明示せず、コンポーネントのデフォルト値を使用
- Storybookスナップショットを更新

## 確認

- `pnpm test`（1470 tests passed）
- `pnpm test:browser`（47 tests passed）
- `pnpm lint`
- `pnpm typecheck`