### PR TITLE
fix(react): keep notification show functions referentially stable

### DIFF
--- a/packages/react/src/components/Notification/Snackbar/index.test.tsx
+++ b/packages/react/src/components/Notification/Snackbar/index.test.tsx
@@ -147,6 +147,33 @@ describe('Snackbar', () => {
     ).toHaveAttribute('data-exiting', 'true')
   })
 
+  it('keeps the show function referentially stable across re-renders', () => {
+    // show を useEffect の依存に入れる利用側で、表示 → 再レンダー → show の参照が変わる →
+    // effect 再実行 → 再表示、という無限ループにならないことを保証する
+    const identities = new Set<unknown>()
+
+    function SnackbarApp() {
+      const [snackbar, show] = useSnackbar()
+      useEffect(() => {
+        identities.add(show)
+      }, [show])
+      return snackbar
+    }
+
+    render(<SnackbarApp />)
+    const [firstShow] = identities
+    act(() => {
+      ;(firstShow as (message: ReactNode) => void)('メッセージ')
+    })
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(screen.getByText('メッセージ')).toBeInTheDocument()
+    // 表示に伴う再レンダー後も show は同じ参照のまま
+    expect(identities.size).toBe(1)
+  })
+
   it('queues the next snackbar until the previous one closes', async () => {
     const { show } = renderSnackbar()
 

--- a/packages/react/src/components/Notification/Toast/index.test.tsx
+++ b/packages/react/src/components/Notification/Toast/index.test.tsx
@@ -1,4 +1,4 @@
-import { createRef, type ComponentProps } from 'react'
+import { createRef, useEffect, type ComponentProps } from 'react'
 import { render, fireEvent, act, cleanup, screen } from '@testing-library/react'
 import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest'
 import Toast, { useToast, type ToastHandler } from '.'
@@ -98,6 +98,32 @@ describe('Toast', () => {
     expect(
       screen.getByText('保存しました').closest('.charcoal-toast'),
     ).toHaveAttribute('data-exiting', 'true')
+  })
+
+  it('keeps the show function referentially stable across re-renders', () => {
+    // Snackbar 側の同名テストと同じ保証。show を useEffect の依存に入れても
+    // 表示のたびに effect が再実行されないことを担保する
+    const identities = new Set<unknown>()
+
+    function ToastApp() {
+      const [toast, show] = useToast()
+      useEffect(() => {
+        identities.add(show)
+      }, [show])
+      return toast
+    }
+
+    render(<ToastApp />)
+    const [firstShow] = identities
+    act(() => {
+      ;(firstShow as ToastHandler['show'])('メッセージ', { type: 'success' })
+    })
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(screen.getByText('メッセージ')).toBeInTheDocument()
+    expect(identities.size).toBe(1)
   })
 
   it('queues the next toast until the previous one closes', async () => {

--- a/packages/react/src/components/Notification/useNotificationQueue.ts
+++ b/packages/react/src/components/Notification/useNotificationQueue.ts
@@ -116,6 +116,11 @@ export function useNotificationQueue<
     maxVisibleToasts: 1,
     wrapUpdate,
   })
+  // state は表示のたびに参照が変わる。enqueue / close が state を直接 close over すると
+  // それらを包む利用側の show も表示のたびに作り直され、show を useEffect の依存に入れた
+  // 利用側で「表示 → 再レンダー → effect 再実行 → 再表示」の無限ループになるため、ref 経由で参照する
+  const stateRef = useRef(state)
+  stateRef.current = state
 
   useEffect(() => {
     return () => {
@@ -130,7 +135,11 @@ export function useNotificationQueue<
     }
   }, [])
 
-  function playNext() {
+  // enqueue から返る show を useEffect の依存に入れる利用側で「表示 → 再レンダー →
+  // show の参照が変わる → effect 再実行 → 再表示」の無限ループにならないよう、
+  // 以下の公開関数は useCallback で参照を固定する (render ごとに変わる state へは
+  // stateRef 経由でアクセスする)
+  const playNext = useCallback(() => {
     const next = queueRef.current.shift()
     if (next === undefined) {
       isShowingRef.current = false
@@ -143,47 +152,47 @@ export function useNotificationQueue<
       .matches
       ? 0
       : ANIMATION_DURATION_MS
-    const key = state.add(content, {
+    const key = stateRef.current.add(content, {
       // react-stately は 0 を「タイマーなし」と扱うため、最小の正数を渡す
       timeout: Math.max(1, duration + enterMs),
     })
     activeRef.current = { key, onClose, notified: false }
-  }
+  }, [])
   playNextRef.current = playNext
 
-  function enqueue(
-    content: TContent,
-    onClose?: (reason?: TCloseReason) => void,
-  ) {
-    const duration =
-      typeof durationOption === 'number' && Number.isFinite(durationOption)
-        ? Math.max(0, durationOption)
-        : DEFAULT_DURATION_MS
+  const enqueue = useCallback(
+    (content: TContent, onClose?: (reason?: TCloseReason) => void) => {
+      const duration =
+        typeof durationOption === 'number' && Number.isFinite(durationOption)
+          ? Math.max(0, durationOption)
+          : DEFAULT_DURATION_MS
 
-    queueRef.current.push({
-      content,
-      onClose,
-      duration,
-    })
-    if (!isShowingRef.current) {
-      playNext()
-    } else if (order === 'replace') {
-      const active = activeRef.current
-      if (active === undefined) return
+      queueRef.current.push({
+        content,
+        onClose,
+        duration,
+      })
+      if (!isShowingRef.current) {
+        playNext()
+      } else if (order === 'replace') {
+        const active = activeRef.current
+        if (active === undefined) return
 
-      replaceRef.current = !animateReplace
-      hoverRef.current.active = false
-      const pending = hoverRef.current.pending
-      hoverRef.current.pending = undefined
-      if (pending !== undefined) {
-        pending()
-      } else {
-        state.close(active.key)
+        replaceRef.current = !animateReplace
+        hoverRef.current.active = false
+        const pending = hoverRef.current.pending
+        hoverRef.current.pending = undefined
+        if (pending !== undefined) {
+          pending()
+        } else {
+          stateRef.current.close(active.key)
+        }
       }
-    }
-  }
+    },
+    [animateReplace, durationOption, order, playNext],
+  )
 
-  function close(key: string, reason: TCloseReason) {
+  const close = useCallback((key: string, reason: TCloseReason) => {
     const active = activeRef.current
     if (active?.key !== key) return
     active.reason = reason
@@ -193,25 +202,25 @@ export function useNotificationQueue<
     if (pending !== undefined) {
       pending()
     } else {
-      state.close(key)
+      stateRef.current.close(key)
     }
-  }
+  }, [])
 
-  function onHoverStart() {
+  const onHoverStart = useCallback(() => {
     hoverRef.current.active = true
-  }
+  }, [])
 
-  function onHoverEnd() {
+  const onHoverEnd = useCallback(() => {
     hoverRef.current.active = false
     const pending = hoverRef.current.pending
     hoverRef.current.pending = undefined
     pending?.()
-  }
+  }, [])
 
-  function clearHover() {
+  const clearHover = useCallback(() => {
     hoverRef.current.active = false
     hoverRef.current.pending = undefined
-  }
+  }, [])
 
   return {
     state,


### PR DESCRIPTION
## やったこと

useSnackbar の show (が包む useNotificationQueue の enqueue) は
render ごとに参照が変わる state を close over していたため、表示のたびに
作り直されていた。show を useEffect の依存に入れた利用側では
「表示 → 再レンダー → show の参照が変わる → effect 再実行 → 再表示」
という無限ループになる (pixiv-web の傍点/ルビ置換トーストで実際に発生)。

公開関数 (enqueue / close / onHoverStart / onHoverEnd / clearHover) を
useCallback で固定し、state へは stateRef 経由でアクセスするようにした。
useToast の show は元から ref ベースで安定していたが、同じ保証を
ロックインする回帰テストを両方に追加した。


## 動作確認環境

## チェックリスト

不要なチェック項目は消して構いません

- [ ] 破壊的変更がある場合には、対象のパッケージのメジャーバージョンが上がっていることを確認した
- [ ] 追加したコンポーネントが index.ts から再 export されている
- [ ] README やドキュメントに影響があることを確認した
