### PR TITLE
refactor(tailwind-config): extract token v2 bindings

### DIFF
--- a/packages/tailwind-config/src/token-v2/create-theme.test.ts
+++ b/packages/tailwind-config/src/token-v2/create-theme.test.ts
@@ -36,8 +36,29 @@ describe('createTokenV2TailwindTheme', () => {
         },
       ]),
     ).toMatchObject({
-      colors: { container: { primary: { DEFAULT: 'primary', hover: 'hover' } } },
+      colors: {
+        container: { primary: { DEFAULT: 'primary', hover: 'hover' } },
+      },
       spacing: { 'layout-20': '20px' },
     })
+  })
+
+  test('rejects color bindings with conflicting output paths', () => {
+    expect(() =>
+      createTokenV2TailwindTheme([
+        {
+          canonicalPath: 'color/a/default',
+          themeKey: 'colors',
+          modifier: 'a',
+          value: 'a',
+        },
+        {
+          canonicalPath: 'color/a/default/x',
+          themeKey: 'colors',
+          modifier: 'a-default-x',
+          value: 'x',
+        },
+      ]),
+    ).toThrow('Conflicting color token binding: color/a/default/x')
   })
 })

--- a/packages/tailwind-config/src/token-v2/create-theme.test.ts
+++ b/packages/tailwind-config/src/token-v2/create-theme.test.ts
@@ -1,0 +1,43 @@
+import light from '@charcoal-ui/theme/tokens/css-variables.json' with { type: 'json' }
+import { unstable_createTailwindConfigTokenV2 } from '../tokenV2'
+import { createTokenV2TailwindBindings } from './definition'
+import { createTokenV2TailwindTheme } from './create-theme'
+import type { TokenV2CssVariables } from './types'
+
+describe('createTokenV2TailwindTheme', () => {
+  test('reconstructs the current token v2 theme from bindings', () => {
+    const bindings = createTokenV2TailwindBindings(light as TokenV2CssVariables)
+
+    expect(createTokenV2TailwindTheme(bindings)).toEqual(
+      unstable_createTailwindConfigTokenV2().theme,
+    )
+  })
+
+  test('reconstructs nested colors and DEFAULT keys from canonical paths', () => {
+    expect(
+      createTokenV2TailwindTheme([
+        {
+          canonicalPath: 'color/container/primary/default',
+          themeKey: 'colors',
+          modifier: 'container-primary',
+          value: 'primary',
+        },
+        {
+          canonicalPath: 'color/container/primary/hover',
+          themeKey: 'colors',
+          modifier: 'container-primary-hover',
+          value: 'hover',
+        },
+        {
+          canonicalPath: 'space/layout/20',
+          themeKey: 'spacing',
+          modifier: 'layout-20',
+          value: '20px',
+        },
+      ]),
+    ).toMatchObject({
+      colors: { container: { primary: { DEFAULT: 'primary', hover: 'hover' } } },
+      spacing: { 'layout-20': '20px' },
+    })
+  })
+})

--- a/packages/tailwind-config/src/token-v2/create-theme.ts
+++ b/packages/tailwind-config/src/token-v2/create-theme.ts
@@ -1,0 +1,62 @@
+import type { Config } from 'tailwindcss'
+import { assertUniqueTokenV2TailwindBindings } from './definition'
+import type { TokenV2TailwindBinding, TokenV2TailwindThemeKey } from './types'
+
+type Theme = NonNullable<Config['theme']>
+type ThemeValue = TokenV2TailwindBinding['value']
+
+const themeKeys: readonly TokenV2TailwindThemeKey[] = [
+  'colors',
+  'borderColor',
+  'borderWidth',
+  'borderRadius',
+  'fontSize',
+  'fontWeight',
+  'spacing',
+  'gap',
+  'width',
+]
+
+function createColors(bindings: readonly TokenV2TailwindBinding[]) {
+  const colors: Record<string, unknown> = {}
+  for (const binding of bindings) {
+    const path = binding.canonicalPath.split('/').slice(1)
+    const key = path.pop()
+    if (key === undefined) continue
+
+    const target = path.reduce<Record<string, unknown>>((current, segment) => {
+      const existing = current[segment]
+      if (typeof existing !== 'object' || existing === null) {
+        current[segment] = {}
+      }
+      return current[segment] as Record<string, unknown>
+    }, colors)
+    target[key === 'default' ? 'DEFAULT' : key] = binding.value
+  }
+  return colors
+}
+
+export function createTokenV2TailwindTheme(
+  bindings: readonly TokenV2TailwindBinding[],
+): Theme {
+  assertUniqueTokenV2TailwindBindings(bindings)
+
+  const byThemeKey = new Map<TokenV2TailwindThemeKey, TokenV2TailwindBinding[]>()
+  for (const themeKey of themeKeys) byThemeKey.set(themeKey, [])
+  for (const binding of bindings) byThemeKey.get(binding.themeKey)?.push(binding)
+
+  const theme: Partial<Record<TokenV2TailwindThemeKey, unknown>> = {}
+  for (const themeKey of themeKeys) {
+    const entries = byThemeKey.get(themeKey) ?? []
+    theme[themeKey] =
+      themeKey === 'colors'
+        ? createColors(entries)
+        : Object.fromEntries(
+            entries.map(({ modifier, value }): [string, ThemeValue] => [
+              modifier,
+              value,
+            ]),
+          )
+  }
+  return theme as Theme
+}

--- a/packages/tailwind-config/src/token-v2/create-theme.ts
+++ b/packages/tailwind-config/src/token-v2/create-theme.ts
@@ -20,18 +20,34 @@ const themeKeys: readonly TokenV2TailwindThemeKey[] = [
 function createColors(bindings: readonly TokenV2TailwindBinding[]) {
   const colors: Record<string, unknown> = {}
   for (const binding of bindings) {
-    const path = binding.canonicalPath.split('/').slice(1)
+    const path = binding.canonicalPath
+      .split('/')
+      .slice(1)
+      .map((segment) => (segment === 'default' ? 'DEFAULT' : segment))
     const key = path.pop()
     if (key === undefined) continue
 
     const target = path.reduce<Record<string, unknown>>((current, segment) => {
       const existing = current[segment]
+      if (
+        existing !== undefined &&
+        (typeof existing !== 'object' || existing === null)
+      ) {
+        throw new Error(
+          `Conflicting color token binding: ${binding.canonicalPath}`,
+        )
+      }
       if (typeof existing !== 'object' || existing === null) {
         current[segment] = {}
       }
       return current[segment] as Record<string, unknown>
     }, colors)
-    target[key === 'default' ? 'DEFAULT' : key] = binding.value
+    if (target[key] !== undefined) {
+      throw new Error(
+        `Conflicting color token binding: ${binding.canonicalPath}`,
+      )
+    }
+    target[key] = binding.value
   }
   return colors
 }
@@ -41,9 +57,13 @@ export function createTokenV2TailwindTheme(
 ): Theme {
   assertUniqueTokenV2TailwindBindings(bindings)
 
-  const byThemeKey = new Map<TokenV2TailwindThemeKey, TokenV2TailwindBinding[]>()
+  const byThemeKey = new Map<
+    TokenV2TailwindThemeKey,
+    TokenV2TailwindBinding[]
+  >()
   for (const themeKey of themeKeys) byThemeKey.set(themeKey, [])
-  for (const binding of bindings) byThemeKey.get(binding.themeKey)?.push(binding)
+  for (const binding of bindings)
+    byThemeKey.get(binding.themeKey)?.push(binding)
 
   const theme: Partial<Record<TokenV2TailwindThemeKey, unknown>> = {}
   for (const themeKey of themeKeys) {

--- a/packages/tailwind-config/src/token-v2/definition.test.ts
+++ b/packages/tailwind-config/src/token-v2/definition.test.ts
@@ -1,0 +1,59 @@
+import light from '@charcoal-ui/theme/tokens/css-variables.json' with { type: 'json' }
+import {
+  assertUniqueTokenV2TailwindBindings,
+  createTokenV2TailwindBindings,
+} from './definition'
+import type { TokenV2CssVariables } from './types'
+
+const bindings = createTokenV2TailwindBindings(light as TokenV2CssVariables)
+
+describe('createTokenV2TailwindBindings', () => {
+  test.each([
+    ['color/container/primary/default', 'colors', 'container-primary'],
+    ['color/border/default', 'colors', 'border'],
+    ['color/border/default', 'borderColor', 'ch'],
+    ['color/border/selected', 'borderColor', 'ch-selected'],
+    ['border-width/focus/1', 'borderWidth', 'width-ch-focus-1'],
+    ['space/layout/20', 'spacing', 'layout-20'],
+    ['space/layout/20', 'gap', 'layout-20'],
+    ['space/padding/padding-card', 'spacing', 'padding-card'],
+    ['text/font-size/heading/xs', 'fontSize', 'heading-xs'],
+    ['text/font-weight/bold', 'fontWeight', 'ch-bold'],
+    ['radius/oval', 'borderRadius', 'oval'],
+    ['paragraph-width/s-cozy', 'width', 's-cozy'],
+  ])('%s creates a %s binding with modifier %s', (canonicalPath, themeKey, modifier) => {
+    expect(bindings).toContainEqual(
+      expect.objectContaining({ canonicalPath, themeKey, modifier }),
+    )
+  })
+
+  test('combines font size with its line height', () => {
+    expect(bindings).toContainEqual({
+      canonicalPath: 'text/font-size/heading/xs',
+      themeKey: 'fontSize',
+      modifier: 'heading-xs',
+      value: [
+        'var(--charcoal-text-font-size-heading-xs)',
+        { lineHeight: 'var(--charcoal-text-line-height-heading-xs)' },
+      ],
+    })
+  })
+
+  test('rejects duplicate theme keys and modifiers', () => {
+    expect(() =>
+      createTokenV2TailwindBindings({
+        ...light,
+        space: { foo: 'a', gap: { foo: 'b' } },
+      } as TokenV2CssVariables),
+    ).toThrow('Duplicate Tailwind token binding: spacing:foo')
+  })
+
+  test('can validate bindings independently', () => {
+    expect(() =>
+      assertUniqueTokenV2TailwindBindings([
+        { canonicalPath: 'a', themeKey: 'spacing', modifier: 'a', value: 'a' },
+        { canonicalPath: 'b', themeKey: 'spacing', modifier: 'a', value: 'b' },
+      ]),
+    ).toThrow('Duplicate Tailwind token binding: spacing:a')
+  })
+})

--- a/packages/tailwind-config/src/token-v2/definition.test.ts
+++ b/packages/tailwind-config/src/token-v2/definition.test.ts
@@ -21,11 +21,14 @@ describe('createTokenV2TailwindBindings', () => {
     ['text/font-weight/bold', 'fontWeight', 'ch-bold'],
     ['radius/oval', 'borderRadius', 'oval'],
     ['paragraph-width/s-cozy', 'width', 's-cozy'],
-  ])('%s creates a %s binding with modifier %s', (canonicalPath, themeKey, modifier) => {
-    expect(bindings).toContainEqual(
-      expect.objectContaining({ canonicalPath, themeKey, modifier }),
-    )
-  })
+  ])(
+    '%s creates a %s binding with modifier %s',
+    (canonicalPath, themeKey, modifier) => {
+      expect(bindings).toContainEqual(
+        expect.objectContaining({ canonicalPath, themeKey, modifier }),
+      )
+    },
+  )
 
   test('combines font size with its line height', () => {
     expect(bindings).toContainEqual({
@@ -44,12 +47,18 @@ describe('createTokenV2TailwindBindings', () => {
       ...light,
       color: {
         ...light.color,
-        border: { default: { hover: 'nested-default' }, 'default-a': 'default-a' },
+        border: {
+          default: { hover: 'nested-default' },
+          'default-a': 'default-a',
+        },
       },
       'border-width': { default: { hover: 'nested-default' } },
       text: {
         ...light.text,
-        'font-weight': { default: 'weight-default', 'default-a': 'weight-default-a' },
+        'font-weight': {
+          default: 'weight-default',
+          'default-a': 'weight-default-a',
+        },
       },
     } as TokenV2CssVariables)
 

--- a/packages/tailwind-config/src/token-v2/definition.test.ts
+++ b/packages/tailwind-config/src/token-v2/definition.test.ts
@@ -39,6 +39,51 @@ describe('createTokenV2TailwindBindings', () => {
     })
   })
 
+  test('only removes a trailing default segment from prefixed modifiers', () => {
+    const prefixedBindings = createTokenV2TailwindBindings({
+      ...light,
+      color: {
+        ...light.color,
+        border: { default: { hover: 'nested-default' }, 'default-a': 'default-a' },
+      },
+      'border-width': { default: { hover: 'nested-default' } },
+      text: {
+        ...light.text,
+        'font-weight': { default: 'weight-default', 'default-a': 'weight-default-a' },
+      },
+    } as TokenV2CssVariables)
+
+    expect(prefixedBindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          canonicalPath: 'color/border/default/hover',
+          themeKey: 'borderColor',
+          modifier: 'ch-default-hover',
+        }),
+        expect.objectContaining({
+          canonicalPath: 'color/border/default-a',
+          themeKey: 'borderColor',
+          modifier: 'ch-default-a',
+        }),
+        expect.objectContaining({
+          canonicalPath: 'border-width/default/hover',
+          themeKey: 'borderWidth',
+          modifier: 'width-ch-default-hover',
+        }),
+        expect.objectContaining({
+          canonicalPath: 'text/font-weight/default',
+          themeKey: 'fontWeight',
+          modifier: 'ch',
+        }),
+        expect.objectContaining({
+          canonicalPath: 'text/font-weight/default-a',
+          themeKey: 'fontWeight',
+          modifier: 'ch-default-a',
+        }),
+      ]),
+    )
+  })
+
   test('rejects duplicate theme keys and modifiers', () => {
     expect(() =>
       createTokenV2TailwindBindings({

--- a/packages/tailwind-config/src/token-v2/definition.ts
+++ b/packages/tailwind-config/src/token-v2/definition.ts
@@ -64,7 +64,11 @@ export function createTokenV2TailwindBindings(
     'borderWidth',
     (path) => ['width-ch', modifier(path)].filter(Boolean).join('-'),
   )
-  const borderRadiusBindings = bindingsFor(tokens.radius, ['radius'], 'borderRadius')
+  const borderRadiusBindings = bindingsFor(
+    tokens.radius,
+    ['radius'],
+    'borderRadius',
+  )
   const fontWeightBindings = bindingsFor(
     tokens.text['font-weight'],
     ['text', 'font-weight'],
@@ -95,7 +99,9 @@ export function createTokenV2TailwindBindings(
         tokens.text['line-height'],
       )
       if (typeof lineHeight !== 'string') {
-        throw new Error(`Missing line-height token for text/font-size/${path.join('/')}`)
+        throw new Error(
+          `Missing line-height token for text/font-size/${path.join('/')}`,
+        )
       }
       return {
         canonicalPath: ['text', 'font-size', ...path].join('/'),

--- a/packages/tailwind-config/src/token-v2/definition.ts
+++ b/packages/tailwind-config/src/token-v2/definition.ts
@@ -1,0 +1,121 @@
+import type {
+  TokenV2CssVariables,
+  TokenV2TailwindBinding,
+  TokenV2TailwindThemeKey,
+  TokenV2TokenTree,
+} from './types'
+
+type LeafEntry = { path: string[]; value: string }
+
+function leafEntries(tree: TokenV2TokenTree, path: string[] = []): LeafEntry[] {
+  return Object.entries(tree).flatMap(([key, value]) => {
+    const nextPath = [...path, key]
+    return typeof value === 'string'
+      ? [{ path: nextPath, value }]
+      : leafEntries(value, nextPath)
+  })
+}
+
+function modifier(path: string[]) {
+  const parts = path.at(-1) === 'default' ? path.slice(0, -1) : path
+  return parts.join('-')
+}
+
+function bindingsFor(
+  tree: TokenV2TokenTree,
+  canonicalPrefix: string[],
+  themeKey: TokenV2TailwindThemeKey,
+  modifierForPath: (path: string[]) => string = modifier,
+): TokenV2TailwindBinding[] {
+  return leafEntries(tree).map(({ path, value }) => ({
+    canonicalPath: [...canonicalPrefix, ...path].join('/'),
+    themeKey,
+    modifier: modifierForPath(path),
+    value,
+  }))
+}
+
+export function assertUniqueTokenV2TailwindBindings(
+  bindings: readonly TokenV2TailwindBinding[],
+) {
+  const seen = new Set<string>()
+  for (const binding of bindings) {
+    const key = `${binding.themeKey}:${binding.modifier}`
+    if (seen.has(key)) {
+      throw new Error(`Duplicate Tailwind token binding: ${key}`)
+    }
+    seen.add(key)
+  }
+}
+
+export function createTokenV2TailwindBindings(
+  tokens: TokenV2CssVariables,
+): TokenV2TailwindBinding[] {
+  const colorBindings = bindingsFor(tokens.color, ['color'], 'colors')
+  const borderColorBindings = bindingsFor(
+    tokens.color.border as TokenV2TokenTree,
+    ['color', 'border'],
+    'borderColor',
+    (path) => ['ch', ...path.filter((part) => part !== 'default')].join('-'),
+  )
+  const borderWidthBindings = bindingsFor(
+    tokens['border-width'],
+    ['border-width'],
+    'borderWidth',
+    (path) => ['width-ch', ...path.filter((part) => part !== 'default')].join('-'),
+  )
+  const borderRadiusBindings = bindingsFor(tokens.radius, ['radius'], 'borderRadius')
+  const fontWeightBindings = bindingsFor(
+    tokens.text['font-weight'],
+    ['text', 'font-weight'],
+    'fontWeight',
+    (path) => ['ch', ...path].join('-'),
+  )
+  const spaceBindings = leafEntries(tokens.space).flatMap(({ path, value }) => {
+    const spaceModifier = modifier(
+      /^(gap|padding)$/u.test(path[0]) ? path.slice(1) : path,
+    )
+    const canonicalPath = ['space', ...path].join('/')
+    return (['spacing', 'gap'] as const).map((themeKey) => ({
+      canonicalPath,
+      themeKey,
+      modifier: spaceModifier,
+      value,
+    }))
+  })
+  const widthBindings = bindingsFor(
+    tokens['paragraph-width'],
+    ['paragraph-width'],
+    'width',
+  )
+  const fontSizeBindings = leafEntries(tokens.text['font-size']).map(
+    ({ path, value }) => {
+      const lineHeight = path.reduce<unknown>(
+        (current, key) => (current as TokenV2TokenTree)[key],
+        tokens.text['line-height'],
+      )
+      if (typeof lineHeight !== 'string') {
+        throw new Error(`Missing line-height token for text/font-size/${path.join('/')}`)
+      }
+      return {
+        canonicalPath: ['text', 'font-size', ...path].join('/'),
+        themeKey: 'fontSize' as const,
+        modifier: modifier(path),
+        value: [value, { lineHeight }] as [string, { lineHeight: string }],
+      }
+    },
+  )
+
+  const bindings = [
+    ...colorBindings,
+    ...borderColorBindings,
+    ...borderWidthBindings,
+    ...borderRadiusBindings,
+    ...fontSizeBindings,
+    ...fontWeightBindings,
+    ...spaceBindings,
+    ...widthBindings,
+  ]
+  assertUniqueTokenV2TailwindBindings(bindings)
+  return bindings
+}

--- a/packages/tailwind-config/src/token-v2/definition.ts
+++ b/packages/tailwind-config/src/token-v2/definition.ts
@@ -56,20 +56,20 @@ export function createTokenV2TailwindBindings(
     tokens.color.border as TokenV2TokenTree,
     ['color', 'border'],
     'borderColor',
-    (path) => ['ch', ...path.filter((part) => part !== 'default')].join('-'),
+    (path) => ['ch', modifier(path)].filter(Boolean).join('-'),
   )
   const borderWidthBindings = bindingsFor(
     tokens['border-width'],
     ['border-width'],
     'borderWidth',
-    (path) => ['width-ch', ...path.filter((part) => part !== 'default')].join('-'),
+    (path) => ['width-ch', modifier(path)].filter(Boolean).join('-'),
   )
   const borderRadiusBindings = bindingsFor(tokens.radius, ['radius'], 'borderRadius')
   const fontWeightBindings = bindingsFor(
     tokens.text['font-weight'],
     ['text', 'font-weight'],
     'fontWeight',
-    (path) => ['ch', ...path].join('-'),
+    (path) => ['ch', modifier(path)].filter(Boolean).join('-'),
   )
   const spaceBindings = leafEntries(tokens.space).flatMap(({ path, value }) => {
     const spaceModifier = modifier(

--- a/packages/tailwind-config/src/token-v2/types.ts
+++ b/packages/tailwind-config/src/token-v2/types.ts
@@ -1,0 +1,34 @@
+export type TokenV2TailwindThemeKey =
+  | 'colors'
+  | 'borderColor'
+  | 'borderWidth'
+  | 'borderRadius'
+  | 'fontSize'
+  | 'fontWeight'
+  | 'spacing'
+  | 'gap'
+  | 'width'
+
+export type TokenV2TailwindBinding = {
+  canonicalPath: string
+  themeKey: TokenV2TailwindThemeKey
+  modifier: string
+  value: string | [string, { lineHeight: string }]
+}
+
+export type TokenV2TokenTree = {
+  [key: string]: string | TokenV2TokenTree
+}
+
+export type TokenV2CssVariables = {
+  color: TokenV2TokenTree
+  space: TokenV2TokenTree
+  'border-width': TokenV2TokenTree
+  radius: TokenV2TokenTree
+  'paragraph-width': TokenV2TokenTree
+  text: {
+    'font-size': TokenV2TokenTree
+    'line-height': TokenV2TokenTree
+    'font-weight': TokenV2TokenTree
+  }
+}

--- a/packages/tailwind-config/src/tokenV2.ts
+++ b/packages/tailwind-config/src/tokenV2.ts
@@ -1,73 +1,17 @@
 import light from '@charcoal-ui/theme/tokens/css-variables.json' with { type: 'json' }
 import type { Config } from 'tailwindcss'
-import {
-  flattenKey as flattenKeys,
-  flattenKeyWithoutDefault,
-  mapDefaultKey as mapDefaultKeys,
-} from './util'
+import { createTokenV2TailwindTheme } from './token-v2/create-theme'
+import { createTokenV2TailwindBindings } from './token-v2/definition'
+import type { TokenV2CssVariables } from './token-v2/types'
 
 export function unstable_createTailwindConfigTokenV2(): Omit<
   Config,
   'content'
 > {
-  const fontSize = Object.fromEntries(
-    Object.entries(light.text['font-size']).flatMap(([k, v]) => {
-      // text.fontSize.paragraph + text.lineHeight.paragraph -> text-paragraph
-      if (typeof v === 'string') {
-        return [
-          [
-            k,
-            [
-              v,
-              // @ts-expect-error k is keyof line-height
-              { lineHeight: light.text['line-height'][k] },
-            ],
-          ],
-        ]
-      }
-
-      // text.fontSize.heading.s + text.lineHeight.heading.s -> text-heading-s
-      return Object.entries(v as Record<string, string>).map(([kk, vv]) => {
-        return [
-          [k, kk].join('-'),
-          [
-            vv,
-            // @ts-expect-error k is keyof line-height
-            { lineHeight: light.text['line-height'][k][kk] },
-          ],
-        ]
-      })
-    }),
-  ) as NonNullable<Config['theme']>['fontSize']
-
-  // space.target.s -> p-target-s
-  // space.gap.gapButtons -> p-gap-buttons
-  const spacing = flattenKeys(light.space, (key) => !/(gap|padding)/.test(key))
-  // color.container.default -> bg-container
-  // color.container.hover -> bg-container-hover
-  const colors = mapDefaultKeys(light.color)
-
-  const config: Omit<Config, 'content'> = {
+  return {
     darkMode: 'media',
-    theme: {
-      // borderWidth.m -> border-m
-      // borderWidth.focus.1 -> border-focus-1
-      borderWidth: flattenKeyWithoutDefault({
-        'width-ch': flattenKeys(light['border-width']), // unstable border width token
-      }),
-      borderRadius: light.radius,
-      borderColor: flattenKeyWithoutDefault({ ch: flattenKeys(colors.border) }),
-
-      colors,
-
-      fontSize,
-      fontWeight: flattenKeys({ ch: light.text['font-weight'] }),
-
-      spacing,
-      gap: spacing,
-      width: light['paragraph-width'],
-    },
+    theme: createTokenV2TailwindTheme(
+      createTokenV2TailwindBindings(light as TokenV2CssVariables),
+    ),
   }
-
-  return config
 }


### PR DESCRIPTION
## やったこと

- Design Token 2.0のtoken pathからTailwind theme entryを生成する内部bindingを追加しました。
- bindingからTailwind themeを再構築し、`unstable_createTailwindConfigTokenV2()`をbindingベースの薄い入口へ移行しました。
- canonical path、末尾の`default`のみの除外、font-sizeとline-heightの結合、space・border系のmodifier変換、bindingおよびcolor出力pathの衝突検証を追加しました。
- binding生成・theme再構築の単体テストを追加し、既存のconfig/class list snapshotを更新せずに回帰を確認しました。

## 動作確認環境

- macOS
- Node.js v24.18.0
- `pnpm --filter @charcoal-ui/tailwind-config test`（39件成功）
- `pnpm --filter @charcoal-ui/tailwind-config typecheck`
- `pnpm --filter @charcoal-ui/tailwind-config build`

## チェックリスト

- [x] 破壊的変更はありません
- [x] 追加したコンポーネントはありません
- [x] READMEやドキュメントへの影響を確認しました（公開APIの変更はありません）