### PR TITLE
fix(react): Androidのスタイラス操作でDropdownSelectorが閉じる問題を修正

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -4151,69 +4151,98 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Ine
       style="display: flex; align-items: flex-start; gap: 64px;"
     >
       <div
-        style="width: 288px;"
+        style="display: flex; flex-direction: column; gap: 16px;"
       >
         <div
-          class="charcoal-dropdown-selector-root"
+          style="position: relative; width: 288px;"
         >
           <div
-            class="charcoal-field-label-root"
-            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+            style="position: relative; z-index: 1;"
           >
-            <label
-              class="charcoal-field-label"
-              id="test-id"
-            >
-              DropdownSelector
-            </label>
             <div
-              class="charcoal-field-label-sub-label"
+              class="charcoal-dropdown-selector-root"
             >
-              <span />
+              <div
+                class="charcoal-field-label-root"
+                style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+              >
+                <label
+                  class="charcoal-field-label"
+                  id="test-id"
+                >
+                  DropdownSelector
+                </label>
+                <div
+                  class="charcoal-field-label-sub-label"
+                >
+                  <span />
+                </div>
+              </div>
+              <div
+                aria-hidden="true"
+                style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+              >
+                <select
+                  tabindex="-1"
+                >
+                  <option
+                    value="1"
+                  >
+                    1
+                  </option>
+                  <option
+                    value="2"
+                  >
+                    2
+                  </option>
+                  <option
+                    value="3"
+                  >
+                    3
+                  </option>
+                </select>
+              </div>
+              <button
+                aria-labelledby="test-id"
+                class="charcoal-dropdown-selector-button"
+                data-active="false"
+                type="button"
+              >
+                <span
+                  class="charcoal-ui-dropdown-selector-text"
+                  data-placeholder="false"
+                >
+                  Option 1
+                </span>
+                <pixiv-icon
+                  class="charcoal-icon charcoal-ui-dropdown-selector-icon"
+                  name="16/Menu"
+                  style="--charcoal-icon-size: 16px;"
+                />
+              </button>
             </div>
           </div>
-          <div
-            aria-hidden="true"
-            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
-          >
-            <select
-              tabindex="-1"
-            >
-              <option
-                value="1"
-              >
-                1
-              </option>
-              <option
-                value="2"
-              >
-                2
-              </option>
-              <option
-                value="3"
-              >
-                3
-              </option>
-            </select>
-          </div>
+        </div>
+        <div>
           <button
-            aria-labelledby="test-id"
-            class="charcoal-dropdown-selector-button"
-            data-active="false"
-            type="button"
+            class="charcoal-button"
+            data-testid="behind-options-button"
+            style="position: relative; top: 0px; left: 0px; width: 100%; height: 120px;"
           >
-            <span
-              class="charcoal-ui-dropdown-selector-text"
-              data-placeholder="false"
-            >
-              Option 1
-            </span>
-            <pixiv-icon
-              class="charcoal-icon charcoal-ui-dropdown-selector-icon"
-              name="16/Menu"
-              style="--charcoal-icon-size: 16px;"
-            />
+            Button behind options
           </button>
+        </div>
+        <div
+          data-testid="selected-option"
+        >
+          Selected option: 
+          1
+        </div>
+        <div
+          data-testid="behind-options-click-count"
+        >
+          Behind options click count: 
+          0
         </div>
       </div>
       <div
@@ -4223,7 +4252,7 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Ine
           class="charcoal-button"
           data-testid="background-button"
         >
-          Background button
+          Outside background button
         </button>
         <div
           data-testid="background-click-count"

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -4142,6 +4142,101 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > InM
 </div>
 `;
 
+exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > InertWorkaroundPenOutside 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      style="display: flex; align-items: flex-start; gap: 64px;"
+    >
+      <div
+        style="width: 288px;"
+      >
+        <div
+          class="charcoal-dropdown-selector-root"
+        >
+          <div
+            class="charcoal-field-label-root"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <label
+              class="charcoal-field-label"
+              id="test-id"
+            >
+              DropdownSelector
+            </label>
+            <div
+              class="charcoal-field-label-sub-label"
+            >
+              <span />
+            </div>
+          </div>
+          <div
+            aria-hidden="true"
+            style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+          >
+            <select
+              tabindex="-1"
+            >
+              <option
+                value="1"
+              >
+                1
+              </option>
+              <option
+                value="2"
+              >
+                2
+              </option>
+              <option
+                value="3"
+              >
+                3
+              </option>
+            </select>
+          </div>
+          <button
+            aria-labelledby="test-id"
+            class="charcoal-dropdown-selector-button"
+            data-active="false"
+            type="button"
+          >
+            <span
+              class="charcoal-ui-dropdown-selector-text"
+              data-placeholder="false"
+            >
+              Option 1
+            </span>
+            <pixiv-icon
+              class="charcoal-icon charcoal-ui-dropdown-selector-icon"
+              name="16/Menu"
+              style="--charcoal-icon-size: 16px;"
+            />
+          </button>
+        </div>
+      </div>
+      <div
+        style="display: flex; flex-direction: column; gap: 16px;"
+      >
+        <button
+          class="charcoal-button"
+          data-testid="background-button"
+        >
+          Background button
+        </button>
+        <div
+          data-testid="background-click-count"
+        >
+          Background click count: 
+          0
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Invalid 1`] = `
 <div>
   <div

--- a/lerna.json
+++ b/lerna.json
@@ -85,6 +85,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -85,6 +85,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -85,6 +85,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -85,6 +85,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/foundation",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icon-files/package.json
+++ b/packages/icon-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icon-files",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.cjs",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/icons-cli/package.json
+++ b/packages/icons-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons-cli",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./dist/index.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/icons",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react-sandbox/package.json
+++ b/packages/react-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react-sandbox",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/react",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/components/DropdownSelector/Popover/index.tsx
+++ b/packages/react/src/components/DropdownSelector/Popover/index.tsx
@@ -1,13 +1,6 @@
 import './index.css'
 
-import {
-  RefObject,
-  useContext,
-  useEffect,
-  useRef,
-  ReactNode,
-  type PointerEvent as ReactPointerEvent,
-} from 'react'
+import { RefObject, useContext, useEffect, useRef, ReactNode } from 'react'
 import { ModalBackgroundContext } from '../../Modal/ModalBackgroundContext'
 import { usePreventScroll } from './usePreventScroll'
 import { DismissButton, Overlay } from 'react-aria/Overlay'
@@ -40,9 +33,8 @@ const _empty = () => null
  */
 export default function Popover(props: PopoverProps) {
   const defaultPopoverRef = useRef<HTMLDivElement>(null)
-  const underlayRef = useRef<HTMLDivElement>(null)
   const underlayPointerDownRef = useRef(false)
-  const underlayPointerTypeRef = useRef('')
+  const penPointerDownRef = useRef(false)
   const finalPopoverRef =
     props.popoverRef === undefined ? defaultPopoverRef : props.popoverRef
   const { popoverProps, underlayProps } = usePopover(
@@ -64,22 +56,40 @@ export default function Popover(props: PopoverProps) {
   const modalBackground = useContext(ModalBackgroundContext)
   usePreventScroll(modalBackground, props.isOpen)
 
-  // React の touchstart listener は passive なので、ペン由来の互換 click を
-  // 抑止するため underlay に non-passive listener を直接登録する。
+  // React の touchstart listener は passive なので、Android Chrome が
+  // ペン入力後に生成する互換 click を抑止するため、document に
+  // non-passive listener を直接登録する。Popover 内の選択肢でも
+  // 外側の underlay でも、閉じた後の背景要素へ click を透過させない。
   useEffect(() => {
-    const underlay = underlayRef.current
-    if (!props.isOpen || !props.inertWorkaround || underlay === null) return
+    if (!props.isOpen || !props.inertWorkaround) return
+
+    const handlePointerDown = (e: PointerEvent) => {
+      penPointerDownRef.current = e.pointerType === 'pen'
+    }
+
+    const handlePointerEnd = () => {
+      penPointerDownRef.current = false
+    }
 
     const handleTouchStart = (e: TouchEvent) => {
-      if (underlayPointerTypeRef.current === 'pen') {
+      if (penPointerDownRef.current) {
         e.preventDefault()
       }
     }
-    underlay.addEventListener('touchstart', handleTouchStart, {
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    document.addEventListener('pointerup', handlePointerEnd, true)
+    document.addEventListener('pointercancel', handlePointerEnd, true)
+    document.addEventListener('touchstart', handleTouchStart, {
+      capture: true,
       passive: false,
     })
     return () => {
-      underlay.removeEventListener('touchstart', handleTouchStart)
+      document.removeEventListener('pointerdown', handlePointerDown, true)
+      document.removeEventListener('pointerup', handlePointerEnd, true)
+      document.removeEventListener('pointercancel', handlePointerEnd, true)
+      document.removeEventListener('touchstart', handleTouchStart, true)
+      penPointerDownRef.current = false
     }
   }, [props.isOpen, props.inertWorkaround])
 
@@ -102,20 +112,17 @@ export default function Popover(props: PopoverProps) {
     }
   }, [isOpen, onClose, finalPopoverRef])
 
-  const handleUnderlayPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+  const handleUnderlayPointerDown = () => {
     underlayPointerDownRef.current = true
-    underlayPointerTypeRef.current = e.pointerType
   }
 
   const handleUnderlayPointerCancel = () => {
     underlayPointerDownRef.current = false
-    underlayPointerTypeRef.current = ''
   }
 
   const handleUnderlayClick = () => {
     const startedOnUnderlay = underlayPointerDownRef.current
     underlayPointerDownRef.current = false
-    underlayPointerTypeRef.current = ''
 
     // Android Chrome はペンの pointerup で Popover が開いた後、同じ入力の
     // 互換 click を新しく追加された underlay に送る。この click には
@@ -131,7 +138,6 @@ export default function Popover(props: PopoverProps) {
     <Overlay portalContainer={document.body}>
       <div
         {...underlayProps}
-        ref={underlayRef}
         // https://github.com/adobe/react-spectrum/issues/8784#issuecomment-3234771154
         {...(props.inertWorkaround
           ? {

--- a/packages/react/src/components/DropdownSelector/Popover/index.tsx
+++ b/packages/react/src/components/DropdownSelector/Popover/index.tsx
@@ -1,6 +1,13 @@
 import './index.css'
 
-import { RefObject, useContext, useEffect, useRef, ReactNode } from 'react'
+import {
+  RefObject,
+  useContext,
+  useEffect,
+  useRef,
+  ReactNode,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import { ModalBackgroundContext } from '../../Modal/ModalBackgroundContext'
 import { usePreventScroll } from './usePreventScroll'
 import { DismissButton, Overlay } from 'react-aria/Overlay'
@@ -33,6 +40,9 @@ const _empty = () => null
  */
 export default function Popover(props: PopoverProps) {
   const defaultPopoverRef = useRef<HTMLDivElement>(null)
+  const underlayRef = useRef<HTMLDivElement>(null)
+  const underlayPointerDownRef = useRef(false)
+  const underlayPointerTypeRef = useRef('')
   const finalPopoverRef =
     props.popoverRef === undefined ? defaultPopoverRef : props.popoverRef
   const { popoverProps, underlayProps } = usePopover(
@@ -54,6 +64,25 @@ export default function Popover(props: PopoverProps) {
   const modalBackground = useContext(ModalBackgroundContext)
   usePreventScroll(modalBackground, props.isOpen)
 
+  // React の touchstart listener は passive なので、ペン由来の互換 click を
+  // 抑止するため underlay に non-passive listener を直接登録する。
+  useEffect(() => {
+    const underlay = underlayRef.current
+    if (!props.isOpen || !props.inertWorkaround || underlay === null) return
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (underlayPointerTypeRef.current === 'pen') {
+        e.preventDefault()
+      }
+    }
+    underlay.addEventListener('touchstart', handleTouchStart, {
+      passive: false,
+    })
+    return () => {
+      underlay.removeEventListener('touchstart', handleTouchStart)
+    }
+  }, [props.isOpen, props.inertWorkaround])
+
   // iOS Safari は非インタラクティブな要素へのペン入力で click を合成しないため、
   // click に依存する react-aria の外側判定ではペンで閉じられない。
   // underlay 側では拾えない: react-aria が modal 時に外側を inert にするので
@@ -73,15 +102,44 @@ export default function Popover(props: PopoverProps) {
     }
   }, [isOpen, onClose, finalPopoverRef])
 
+  const handleUnderlayPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    underlayPointerDownRef.current = true
+    underlayPointerTypeRef.current = e.pointerType
+  }
+
+  const handleUnderlayPointerCancel = () => {
+    underlayPointerDownRef.current = false
+    underlayPointerTypeRef.current = ''
+  }
+
+  const handleUnderlayClick = () => {
+    const startedOnUnderlay = underlayPointerDownRef.current
+    underlayPointerDownRef.current = false
+    underlayPointerTypeRef.current = ''
+
+    // Android Chrome はペンの pointerup で Popover が開いた後、同じ入力の
+    // 互換 click を新しく追加された underlay に送る。この click には
+    // underlay 上の pointerdown がないため、外側操作として扱わない。
+    if (startedOnUnderlay) {
+      props.onClose()
+    }
+  }
+
   if (!props.isOpen) return null
 
   return (
     <Overlay portalContainer={document.body}>
       <div
         {...underlayProps}
+        ref={underlayRef}
         // https://github.com/adobe/react-spectrum/issues/8784#issuecomment-3234771154
         {...(props.inertWorkaround
-          ? { 'data-react-aria-top-layer': true, onClick: props.onClose }
+          ? {
+              'data-react-aria-top-layer': true,
+              onPointerDown: handleUnderlayPointerDown,
+              onPointerCancel: handleUnderlayPointerCancel,
+              onClick: handleUnderlayClick,
+            }
           : {})}
         style={{
           position: 'fixed',

--- a/packages/react/src/components/DropdownSelector/index.browser.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.browser.test.tsx
@@ -11,7 +11,7 @@
  * iOS Safari は非インタラクティブな要素へのペン入力で click を合成しないため、
  * click に依存する react-aria の外側判定では overlay を閉じられない。
  */
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import DropdownSelector from '.'
 import DropdownMenuItem from './DropdownMenuItem'
@@ -60,7 +60,7 @@ describe.each([
   ['inertWorkaround が無効', false],
   ['inertWorkaround が有効', true],
 ])('%s なとき', (_, inertWorkaround) => {
-  it('Apple Pencil で overlay の外側をタップすると閉じる', () => {
+  it('Apple Pencil で overlay の外側をタップすると閉じる', async () => {
     renderSelector(inertWorkaround)
 
     penTap(screen.getByRole('button'))
@@ -68,7 +68,9 @@ describe.each([
 
     penTap(hitTestOutsidePopover())
 
-    expect(popover()).toBeNull()
+    await waitFor(() => {
+      expect(popover()).toBeNull()
+    })
   })
 
   // 選択肢のタップは onChange 経由で閉じるのが仕様なので、余白部分を叩く
@@ -83,6 +85,79 @@ describe.each([
 
     expect(popover()).not.toBeNull()
   })
+})
+
+it('inertWorkaround が有効なとき、開いた直後に underlay へ送られる互換 click では閉じない', () => {
+  renderSelector(true)
+
+  penTap(screen.getByRole('button'))
+  expect(popover()).not.toBeNull()
+
+  // Android Chrome はペンの pointerup 後、underlay 上の pointerdown を伴わない
+  // mouse / click イベントを新しく追加された underlay に送る。
+  const underlay = getUnderlay()
+  fireEvent.mouseDown(underlay)
+  fireEvent.mouseUp(underlay)
+  fireEvent.click(underlay)
+
+  expect(popover()).not.toBeNull()
+})
+
+it('ペンで外側をタップしたとき、下にあるクリック可能な要素をクリックせずに閉じる', async () => {
+  const handleBackgroundClick = vi.fn()
+  render(
+    <>
+      <DropdownSelector
+        label="Label"
+        value="1"
+        onChange={vi.fn()}
+        inertWorkaround
+      >
+        <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+        <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+      </DropdownSelector>
+      <button
+        type="button"
+        onClick={handleBackgroundClick}
+        style={{ position: 'fixed', right: 16, bottom: 16 }}
+      >
+        Background button
+      </button>
+    </>,
+  )
+
+  penTap(screen.getByRole('button', { name: 'Label' }))
+  expect(popover()).not.toBeNull()
+
+  const backgroundButton = screen.getByRole('button', {
+    name: 'Background button',
+  })
+  const rect = backgroundButton.getBoundingClientRect()
+  const point = {
+    x: Math.round(rect.left + rect.width / 2),
+    y: Math.round(rect.top + rect.height / 2),
+  }
+  const pointerTarget = document.elementFromPoint(point.x, point.y)
+  if (pointerTarget === null) throw new Error('pointer target not found')
+
+  fireEvent.pointerDown(pointerTarget, {
+    pointerType: 'pen',
+    button: 0,
+    composed: true,
+  })
+  // Android Chrome はこの touchstart がキャンセルされた場合、後続の互換
+  // mouse / click イベントを生成しない。
+  expect(fireEvent.touchStart(pointerTarget)).toBe(false)
+  fireEvent.pointerUp(pointerTarget, {
+    pointerType: 'pen',
+    button: 0,
+    composed: true,
+  })
+
+  await waitFor(() => {
+    expect(popover()).toBeNull()
+  })
+  expect(handleBackgroundClick).not.toHaveBeenCalled()
 })
 
 it('underlay は inertWorkaround が無効なとき inert になる', () => {

--- a/packages/react/src/components/DropdownSelector/index.browser.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.browser.test.tsx
@@ -160,6 +160,70 @@ it('ペンで外側をタップしたとき、下にあるクリック可能な�
   expect(handleBackgroundClick).not.toHaveBeenCalled()
 })
 
+it('ペンで選択肢を選んだとき、選択肢の背後にあるクリック可能な要素をクリックしない', async () => {
+  const handleBackgroundClick = vi.fn()
+  const handleChange = vi.fn()
+  render(
+    <>
+      <DropdownSelector
+        label="Label"
+        value="1"
+        onChange={handleChange}
+        inertWorkaround
+      >
+        <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+        <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+      </DropdownSelector>
+      <button type="button" onClick={handleBackgroundClick}>
+        Button behind options
+      </button>
+    </>,
+  )
+
+  penTap(screen.getByRole('button', { name: 'Label' }))
+  const option = screen.getByRole('option', { name: 'Option 2' })
+  const optionRect = option.getBoundingClientRect()
+  const point = {
+    x: Math.round(optionRect.left + optionRect.width / 2),
+    y: Math.round(optionRect.top + optionRect.height / 2),
+  }
+  const backgroundButton = screen.getByRole('button', {
+    name: 'Button behind options',
+  })
+  Object.assign(backgroundButton.style, {
+    position: 'fixed',
+    left: `${optionRect.left}px`,
+    top: `${optionRect.top}px`,
+    width: `${optionRect.width}px`,
+    height: `${optionRect.height}px`,
+  })
+
+  fireEvent.pointerDown(option, {
+    pointerType: 'pen',
+    button: 0,
+    clientX: point.x,
+    clientY: point.y,
+    composed: true,
+  })
+  // Android Chrome が後続の互換 click を生成しないよう、
+  // 選択肢上のペン由来 touchstart もキャンセルする。
+  expect(fireEvent.touchStart(option)).toBe(false)
+  fireEvent.pointerUp(option, {
+    pointerType: 'pen',
+    button: 0,
+    clientX: point.x,
+    clientY: point.y,
+    composed: true,
+  })
+
+  await waitFor(() => {
+    expect(popover()).toBeNull()
+  })
+  expect(handleChange).toHaveBeenCalledWith('2')
+  expect(document.elementFromPoint(point.x, point.y)).toBe(backgroundButton)
+  expect(handleBackgroundClick).not.toHaveBeenCalled()
+})
+
 it('underlay は inertWorkaround が無効なとき inert になる', () => {
   renderSelector(false)
   penTap(screen.getByRole('button'))

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -548,20 +548,46 @@ export const InertWorkaroundPenOutside: StoryObj<typeof DropdownSelector> = {
   render: function Render() {
     const [selected, setSelected] = useState('1')
     const [backgroundClickCount, setBackgroundClickCount] = useState(0)
+    const [behindOptionsClickCount, setBehindOptionsClickCount] = useState(0)
 
     return (
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 64 }}>
-        <div style={{ width: 288 }}>
-          <DropdownSelector
-            value={selected}
-            onChange={setSelected}
-            label="DropdownSelector"
-            inertWorkaround
-          >
-            <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
-            <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
-            <DropdownMenuItem value="3">Option 3</DropdownMenuItem>
-          </DropdownSelector>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ position: 'relative', width: 288 }}>
+            <div style={{ position: 'relative', zIndex: 1 }}>
+              <DropdownSelector
+                value={selected}
+                onChange={setSelected}
+                label="DropdownSelector"
+                inertWorkaround
+              >
+                <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+                <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+                <DropdownMenuItem value="3">Option 3</DropdownMenuItem>
+              </DropdownSelector>
+            </div>
+          </div>
+          <div>
+            <Button
+              data-testid="behind-options-button"
+              onClick={() => {
+                setBehindOptionsClickCount((count) => count + 1)
+              }}
+              style={{
+                position: 'relative',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: 120,
+              }}
+            >
+              Button behind options
+            </Button>
+          </div>
+          <div data-testid="selected-option">Selected option: {selected}</div>
+          <div data-testid="behind-options-click-count">
+            Behind options click count: {behindOptionsClickCount}
+          </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <Button
@@ -570,7 +596,7 @@ export const InertWorkaroundPenOutside: StoryObj<typeof DropdownSelector> = {
               setBackgroundClickCount((count) => count + 1)
             }}
           >
-            Background button
+            Outside background button
           </Button>
           <div data-testid="background-click-count">
             Background click count: {backgroundClickCount}

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -543,3 +543,40 @@ export const WithRef: StoryObj<typeof DropdownSelector> = {
     )
   },
 }
+
+export const InertWorkaroundPenOutside: StoryObj<typeof DropdownSelector> = {
+  render: function Render() {
+    const [selected, setSelected] = useState('1')
+    const [backgroundClickCount, setBackgroundClickCount] = useState(0)
+
+    return (
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 64 }}>
+        <div style={{ width: 288 }}>
+          <DropdownSelector
+            value={selected}
+            onChange={setSelected}
+            label="DropdownSelector"
+            inertWorkaround
+          >
+            <DropdownMenuItem value="1">Option 1</DropdownMenuItem>
+            <DropdownMenuItem value="2">Option 2</DropdownMenuItem>
+            <DropdownMenuItem value="3">Option 3</DropdownMenuItem>
+          </DropdownSelector>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Button
+            data-testid="background-button"
+            onClick={() => {
+              setBackgroundClickCount((count) => count + 1)
+            }}
+          >
+            Background button
+          </Button>
+          <div data-testid="background-click-count">
+            Background click count: {backgroundClickCount}
+          </div>
+        </div>
+      </div>
+    )
+  },
+}

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/styled/package.json
+++ b/packages/styled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/styled",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-config",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "commonjs",
   "main": "./dist/index.js",

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "type": "commonjs",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "type": "commonjs",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "type": "commonjs",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/tailwind-diff/package.json
+++ b/packages/tailwind-diff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/tailwind-diff",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "type": "commonjs",
   "bin": "bin/tailwind-diff.js",
   "scripts": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/theme",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@charcoal-ui/token-cli",
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsdown",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@charcoal-ui/token-cli",
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsdown",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@charcoal-ui/token-cli",
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsdown",

--- a/packages/token-cli/package.json
+++ b/packages/token-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@charcoal-ui/token-cli",
   "bin": "./dist/index.js",
   "type": "commonjs",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsdown",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "6.1.0",
+  "version": "8.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "6.1.1-beta.1",
+  "version": "6.1.1-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "6.1.1-beta.0",
+  "version": "6.1.1-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@charcoal-ui/utils",
-  "version": "8.1.1-beta.0",
+  "version": "6.1.1-beta.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## やったこと

- `inertWorkaround=true`で、スタイラス操作直後の互換`click`によってDropdownが即座に閉じる問題を修正
  - Underlay上で`pointerdown`から始まった操作だけを外側クリックとして扱い、Dropdownを開いた操作から派生した互換`click`は無視するようにした
- ペンでDropdownの外側をタップした場合は、documentの`pointerup`で確実に閉じるようにした
- ペン由来の`touchstart`をnon-passive listenerでキャンセルし、Dropdownが閉じた後の互換`click`生成を抑止した
- ペン入力の監視範囲をUnderlayだけでなくPopover内の選択肢まで拡張した
- これにより、以下の両方で背後の要素へのクリック透過を防止した
  - Dropdownの外側をペンでタップした場合
  - Dropdownの選択肢をペンで選択した場合
- 通常のマウス・タッチによる外側クリックの挙動は維持

## 動作確認環境

- Android Emulator / Chrome 124
- `adb shell getprop debug.input.simulate_stylus_with_touch true`
  - スタイラスでSelectorをタップしてもDropdownが開いた状態を維持すること
  - スタイラスでOption 2を選択するとDropdownが閉じ、選択値が`2`になること
  - 選択肢リスト背後のButtonのクリックカウントが`0`のままであること
  - スタイラスで外側をタップするとDropdownが閉じること
  - 外側タップの下にあるButtonのクリックカウントが`0`のままであること
- Vitest unit test: 3 tests passed
- Vitest browser test: 8 tests passed
- TypeScript typecheck、ESLint、Prettier、`git diff --check`: passed
- Storybook build: passed

## チェックリスト

- [x] README やドキュメントに影響があることを確認した（更新不要）