### PR TITLE
feat(design-token-resolver): add resolver CLI

### DIFF
--- a/packages/design-token-resolver/README.md
+++ b/packages/design-token-resolver/README.md
@@ -1,0 +1,3 @@
+# @charcoal-ui/design-token-resolver
+
+CLI for resolving Figma applied token names to Charcoal CSS custom properties and Tailwind candidates.

--- a/packages/design-token-resolver/README.md
+++ b/packages/design-token-resolver/README.md
@@ -1,3 +1,121 @@
 # @charcoal-ui/design-token-resolver
 
-CLI for resolving Figma applied token names to Charcoal CSS custom properties and Tailwind candidates.
+`charcoal-token-resolver` converts Figma applied token names into Charcoal CSS
+custom properties and, when a CSS property is supplied, Tailwind class
+candidates. It does not connect to Figma or require credentials.
+
+## Commands
+
+Resolve one token with an optional collection and CSS property:
+
+```sh
+charcoal-token-resolver resolve container/primary/default \
+  --collection color \
+  --property background-color
+```
+
+```json
+{
+  "schemaVersion": 1,
+  "query": {
+    "name": "container/primary/default",
+    "collection": "color",
+    "property": "background-color"
+  },
+  "status": "resolved",
+  "token": { "canonicalPath": "color/container/primary/default" },
+  "css": {
+    "variable": "--charcoal-color-container-primary-default",
+    "reference": "var(--charcoal-color-container-primary-default)"
+  },
+  "tailwind": {
+    "candidates": [
+      {
+        "property": "background-color",
+        "className": "bg-container-primary",
+        "themeKey": "colors"
+      }
+    ]
+  },
+  "diagnostics": []
+}
+```
+
+For batch input, use a JSON object file or stdin. `--input` is exclusive with a
+positional name, `--collection`, and `--property`.
+
+```sh
+charcoal-token-resolver resolve --input variables.json
+charcoal-token-resolver resolve --input -
+```
+
+```json
+{
+  "queries": [
+    { "name": "container/primary/default", "collection": "color" },
+    { "name": "unknown" }
+  ]
+}
+```
+
+Each query object accepts exactly `name` (required string), `collection`
+(optional string), and `property` (optional string). A malformed batch is not
+partially processed.
+
+The batch output preserves input order. Its results use the single-query result
+shape without `schemaVersion`:
+
+```json
+{
+  "schemaVersion": 1,
+  "results": [
+    {
+      "query": {
+        "name": "container/primary/default",
+        "collection": "color"
+      },
+      "status": "resolved",
+      "token": { "canonicalPath": "color/container/primary/default" },
+      "css": {
+        "variable": "--charcoal-color-container-primary-default",
+        "reference": "var(--charcoal-color-container-primary-default)"
+      },
+      "tailwind": { "candidates": [] },
+      "diagnostics": []
+    },
+    {
+      "query": { "name": "unknown" },
+      "status": "not_found",
+      "diagnostics": []
+    }
+  ]
+}
+```
+
+## Result contract
+
+Every result has `query`, `status`, and `diagnostics`. `status` is one of:
+
+- `resolved`: includes `token`, `css`, and `tailwind.candidates`.
+- `ambiguous`: includes `candidates`, an ordered list of canonical paths.
+- `not_found`: has no token, CSS, or Tailwind fields.
+- `unsupported_property` or `incompatible_property`: includes the uniquely
+  resolved `token`, but intentionally has no CSS or Tailwind fields.
+
+Diagnostics are code-only objects: `{ "code": "case_normalized" }` signals a
+unique case-insensitive name match, and
+`{ "code": "tailwind_binding_not_found" }` signals that a uniquely resolved
+CSS token has no Tailwind binding. In the latter case the result remains
+`resolved`, `tailwind.candidates` is empty, and `css` is the fallback.
+
+Without `--property`, the resolver returns the CSS result but does not select a
+Tailwind class. It never uses fuzzy matching or resolved values to choose a
+token.
+
+## Process contract
+
+Valid single and batch requests always write JSON only to stdout and exit `0`,
+including domain results such as `ambiguous` and `not_found`. Argument errors,
+file or stdin errors, invalid JSON, and invalid batch schema write an explanation
+to stderr, leave stdout empty, and exit `2`. Unexpected internal errors write to
+stderr, leave stdout empty, and exit `1`.

--- a/packages/design-token-resolver/package.json
+++ b/packages/design-token-resolver/package.json
@@ -24,11 +24,7 @@
   },
   "dependencies": {
     "@charcoal-ui/tailwind-config": "workspace:*",
-    "@charcoal-ui/theme": "workspace:*",
-    "yargs": "^17.7.2"
-  },
-  "devDependencies": {
-    "@types/yargs": "^17.0.32"
+    "@charcoal-ui/theme": "workspace:*"
   },
   "files": [
     "dist",

--- a/packages/design-token-resolver/package.json
+++ b/packages/design-token-resolver/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@charcoal-ui/tailwind-config": "workspace:*",
     "@charcoal-ui/theme": "workspace:*"
   },
   "files": [

--- a/packages/design-token-resolver/package.json
+++ b/packages/design-token-resolver/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@charcoal-ui/design-token-resolver",
+  "version": "6.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --pretty --noEmit",
+    "clean": "rimraf dist .tsbuildinfo",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@charcoal-ui/theme": "workspace:*"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixiv/charcoal.git",
+    "directory": "packages/design-token-resolver"
+  }
+}

--- a/packages/design-token-resolver/package.json
+++ b/packages/design-token-resolver/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "charcoal-token-resolver": "./dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -17,11 +20,15 @@
     "build": "tsdown",
     "typecheck": "tsc --pretty --noEmit",
     "clean": "rimraf dist .tsbuildinfo",
-    "test": "vitest run --passWithNoTests"
+    "test": "pnpm run build && vitest run --passWithNoTests"
   },
   "dependencies": {
     "@charcoal-ui/tailwind-config": "workspace:*",
-    "@charcoal-ui/theme": "workspace:*"
+    "@charcoal-ui/theme": "workspace:*",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/yargs": "^17.0.32"
   },
   "files": [
     "dist",

--- a/packages/design-token-resolver/src/cli-core.test.ts
+++ b/packages/design-token-resolver/src/cli-core.test.ts
@@ -47,6 +47,12 @@ describe('CLI input and output', () => {
       results: [{ status: 'not_found' }, { status: 'ambiguous' }],
     })
     expect(batch.output().stderr).toBe('')
+
+    const equalsInput = createIo('{"queries":[{"name":"unknown"}]}')
+    expect(await runCli(['resolve', '--input=-'], equalsInput.io)).toBe(0)
+    expect(JSON.parse(equalsInput.output().stdout)).toMatchObject({
+      results: [{ status: 'not_found' }],
+    })
   })
 
   it('rejects invalid batch input without partial execution', async () => {
@@ -93,6 +99,24 @@ describe('CLI input and output', () => {
       stdout: '',
       stderr: expect.stringContaining('unexpected failure'),
     })
+  })
+
+  it.each([
+    ['unknown command', ['search']],
+    ['unknown option', ['resolve', '--format', 'json']],
+    ['extra positional', ['resolve', 'unknown', 'extra']],
+    ['missing option value', ['resolve', '--input']],
+    ['input combined with name', ['resolve', 'unknown', '--input', '-']],
+    [
+      'input combined with property',
+      ['resolve', '--input', '-', '--property', 'color'],
+    ],
+  ])('treats %s as an input error', async (_description, args) => {
+    const io = createIo()
+
+    expect(await runCli(args, io.io)).toBe(2)
+    expect(io.output().stdout).toBe('')
+    expect(io.output().stderr).not.toBe('')
   })
 
   it('runs the built binary without workspace source imports', async () => {

--- a/packages/design-token-resolver/src/cli-core.test.ts
+++ b/packages/design-token-resolver/src/cli-core.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { parseBatchInput, runCli } from './cli-core'
+
+const execFileAsync = promisify(execFile)
+
+function createIo(stdin = '') {
+  let stdout = ''
+  let stderr = ''
+  return {
+    io: {
+      async readStdin() {
+        return stdin
+      },
+      writeStdout(value: string) {
+        stdout += value
+      },
+      writeStderr(value: string) {
+        stderr += value
+      },
+    },
+    output() {
+      return { stdout, stderr }
+    },
+  }
+}
+
+describe('CLI input and output', () => {
+  it('writes only JSON to stdout for valid single and batch requests', async () => {
+    const single = createIo()
+    expect(
+      await runCli(
+        ['resolve', 'container/primary/default', '--collection', 'color'],
+        single.io,
+      ),
+    ).toBe(0)
+    expect(JSON.parse(single.output().stdout)).toMatchObject({
+      schemaVersion: 1,
+      status: 'resolved',
+    })
+    expect(single.output().stderr).toBe('')
+
+    const batch = createIo('{"queries":[{"name":"unknown"},{"name":"m"}]}')
+    expect(await runCli(['resolve', '--input', '-'], batch.io)).toBe(0)
+    expect(JSON.parse(batch.output().stdout)).toMatchObject({
+      schemaVersion: 1,
+      results: [{ status: 'not_found' }, { status: 'ambiguous' }],
+    })
+    expect(batch.output().stderr).toBe('')
+  })
+
+  it('rejects invalid batch input without partial execution', async () => {
+    expect(() => parseBatchInput('[]')).toThrow('object with a queries array')
+    expect(() => parseBatchInput('{"queries":[{"name":""}]}')).toThrow(
+      'Token name must not contain empty path segments.',
+    )
+    expect(() =>
+      parseBatchInput('{"queries":[{"name":"valid","extra":true}]}'),
+    ).toThrow('unsupported field')
+    expect(() =>
+      parseBatchInput('{"queries":[{"name":"valid"},{"name":42}]}'),
+    ).toThrow('Each query must be an object with a string name.')
+
+    const io = createIo('{"queries":[{"name":"valid"},{"name":42}]}')
+    expect(await runCli(['resolve', '--input', '-'], io.io)).toBe(2)
+    expect(io.output()).toEqual({
+      stdout: '',
+      stderr: expect.stringContaining('Each query must be an object'),
+    })
+  })
+
+  it('separates domain, input, and internal failures by exit code', async () => {
+    const domainFailure = createIo()
+    expect(await runCli(['resolve', 'unknown'], domainFailure.io)).toBe(0)
+    expect(JSON.parse(domainFailure.output().stdout)).toMatchObject({
+      status: 'not_found',
+    })
+
+    const invalid = createIo()
+    expect(await runCli(['resolve'], invalid.io)).toBe(2)
+    expect(invalid.output()).toEqual({
+      stdout: '',
+      stderr: expect.stringContaining('token name or --input'),
+    })
+
+    const internal = createIo()
+    expect(
+      await runCli(['resolve', 'unknown'], internal.io, () => {
+        throw new Error('unexpected failure')
+      }),
+    ).toBe(1)
+    expect(internal.output()).toEqual({
+      stdout: '',
+      stderr: expect.stringContaining('unexpected failure'),
+    })
+  })
+
+  it('runs the built binary without workspace source imports', async () => {
+    const binary = new URL('../dist/cli.js', import.meta.url)
+    const { stdout, stderr } = await execFileAsync(process.execPath, [
+      binary.pathname,
+      'resolve',
+      'unknown',
+    ])
+
+    expect(JSON.parse(stdout)).toMatchObject({ status: 'not_found' })
+    expect(stderr).toBe('')
+  })
+})

--- a/packages/design-token-resolver/src/cli-core.ts
+++ b/packages/design-token-resolver/src/cli-core.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import yargs from 'yargs/yargs'
+import { parseArgs } from 'node:util'
 import { normalizeQueryName } from './resolver/normalize-query'
 import { resolveBatchQueries, resolveSingleQuery } from './resolver/resolve'
 import type { TokenQuery, TokenResolutionResult } from './resolver/types'
@@ -83,72 +83,48 @@ type ParsedArguments = Readonly<{
 
 function parseArguments(args: readonly string[]): ParsedArguments {
   try {
-    const parserArgs = args.flatMap((argument, index) =>
-      argument === '--input' && args[index + 1] === '-'
-        ? ['--input=-']
-        : argument === '-' && args[index - 1] === '--input'
-          ? []
-          : [argument],
-    )
-    const parsed = yargs(parserArgs)
-      .scriptName('charcoal-token-resolver')
-      .strict()
-      .exitProcess(false)
-      .fail((message, error) => {
-        throw new CliInputError(
-          message ?? error?.message ?? 'Invalid arguments.',
-        )
-      })
-      .command(
-        'resolve [name]',
-        'Resolve a Figma applied token name.',
-        (command) =>
-          command
-            .positional('name', { type: 'string' })
-            .option('input', { type: 'string' })
-            .option('collection', { type: 'string' })
-            .option('property', { type: 'string' }),
-      )
-      .demandCommand(1)
-      .parseSync()
-
-    if (parsed._[0] !== 'resolve') {
+    const [command, ...commandArgs] = args
+    if (command !== 'resolve') {
       throw new CliInputError('The resolve command is required.')
     }
-    if (parsed.input !== undefined) {
-      if (typeof parsed.input !== 'string') {
-        throw new CliInputError('--input must be a string.')
-      }
+
+    const { values, positionals } = parseArgs({
+      args: commandArgs,
+      options: {
+        input: { type: 'string' },
+        collection: { type: 'string' },
+        property: { type: 'string' },
+      },
+      allowPositionals: true,
+      strict: true,
+    })
+    if (positionals.length > 1) {
+      throw new CliInputError('Only one token name can be provided.')
+    }
+
+    const [name] = positionals
+    if (values.input !== undefined) {
       if (
-        parsed.name !== undefined ||
-        parsed.collection !== undefined ||
-        parsed.property !== undefined
+        name !== undefined ||
+        values.collection !== undefined ||
+        values.property !== undefined
       ) {
         throw new CliInputError(
           '--input cannot be combined with name, --collection, or --property.',
         )
       }
-      return { input: parsed.input }
+      return { input: values.input }
     }
-    if (parsed.name === undefined) {
+    if (name === undefined) {
       throw new CliInputError('A token name or --input is required.')
     }
-    if (typeof parsed.name !== 'string') {
-      throw new CliInputError('Token name must be a string.')
-    }
-    if (
-      (parsed.collection !== undefined &&
-        typeof parsed.collection !== 'string') ||
-      (parsed.property !== undefined && typeof parsed.property !== 'string')
-    ) {
-      throw new CliInputError('--collection and --property must be strings.')
-    }
+
     return {
-      name: parsed.name,
-      ...(parsed.collection === undefined
+      name,
+      ...(values.collection === undefined
         ? {}
-        : { collection: parsed.collection }),
-      ...(parsed.property === undefined ? {} : { property: parsed.property }),
+        : { collection: values.collection }),
+      ...(values.property === undefined ? {} : { property: values.property }),
     }
   } catch (error) {
     if (error instanceof CliInputError) {

--- a/packages/design-token-resolver/src/cli-core.ts
+++ b/packages/design-token-resolver/src/cli-core.ts
@@ -1,0 +1,200 @@
+import { readFile } from 'node:fs/promises'
+import yargs from 'yargs/yargs'
+import { normalizeQueryName } from './resolver/normalize-query'
+import { resolveBatchQueries, resolveSingleQuery } from './resolver/resolve'
+import type { TokenQuery, TokenResolutionResult } from './resolver/types'
+
+export class CliInputError extends Error {}
+
+export type CliIo = Readonly<{
+  readStdin(): Promise<string>
+  writeStdout(value: string): void
+  writeStderr(value: string): void
+}>
+
+function asPlainObject(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function validateQuery(value: unknown): TokenQuery {
+  const query = asPlainObject(value)
+  if (query === undefined || typeof query.name !== 'string') {
+    throw new CliInputError('Each query must be an object with a string name.')
+  }
+  if (
+    (query.collection !== undefined && typeof query.collection !== 'string') ||
+    (query.property !== undefined && typeof query.property !== 'string')
+  ) {
+    throw new CliInputError('Query collection and property must be strings.')
+  }
+  if (
+    Object.keys(query).some(
+      (key) => key !== 'name' && key !== 'collection' && key !== 'property',
+    )
+  ) {
+    throw new CliInputError('Each query contains an unsupported field.')
+  }
+
+  try {
+    normalizeQueryName(query.name)
+  } catch (error) {
+    throw new CliInputError(
+      error instanceof Error ? error.message : 'Invalid token name.',
+    )
+  }
+
+  return {
+    name: query.name,
+    ...(query.collection === undefined ? {} : { collection: query.collection }),
+    ...(query.property === undefined ? {} : { property: query.property }),
+  }
+}
+
+export function parseBatchInput(input: string): readonly TokenQuery[] {
+  let value: unknown
+  try {
+    value = JSON.parse(input)
+  } catch {
+    throw new CliInputError('Batch input must be valid JSON.')
+  }
+
+  const batch = asPlainObject(value)
+  if (
+    batch === undefined ||
+    !Array.isArray(batch.queries) ||
+    Object.keys(batch).some((key) => key !== 'queries')
+  ) {
+    throw new CliInputError(
+      'Batch input must be an object with a queries array.',
+    )
+  }
+
+  return batch.queries.map(validateQuery)
+}
+
+type ParsedArguments = Readonly<{
+  name?: string
+  input?: string
+  collection?: string
+  property?: string
+}>
+
+function parseArguments(args: readonly string[]): ParsedArguments {
+  try {
+    const parserArgs = args.flatMap((argument, index) =>
+      argument === '--input' && args[index + 1] === '-'
+        ? ['--input=-']
+        : argument === '-' && args[index - 1] === '--input'
+          ? []
+          : [argument],
+    )
+    const parsed = yargs(parserArgs)
+      .scriptName('charcoal-token-resolver')
+      .strict()
+      .exitProcess(false)
+      .fail((message, error) => {
+        throw new CliInputError(
+          message ?? error?.message ?? 'Invalid arguments.',
+        )
+      })
+      .command(
+        'resolve [name]',
+        'Resolve a Figma applied token name.',
+        (command) =>
+          command
+            .positional('name', { type: 'string' })
+            .option('input', { type: 'string' })
+            .option('collection', { type: 'string' })
+            .option('property', { type: 'string' }),
+      )
+      .demandCommand(1)
+      .parseSync()
+
+    if (parsed._[0] !== 'resolve') {
+      throw new CliInputError('The resolve command is required.')
+    }
+    if (parsed.input !== undefined) {
+      if (typeof parsed.input !== 'string') {
+        throw new CliInputError('--input must be a string.')
+      }
+      if (
+        parsed.name !== undefined ||
+        parsed.collection !== undefined ||
+        parsed.property !== undefined
+      ) {
+        throw new CliInputError(
+          '--input cannot be combined with name, --collection, or --property.',
+        )
+      }
+      return { input: parsed.input }
+    }
+    if (parsed.name === undefined) {
+      throw new CliInputError('A token name or --input is required.')
+    }
+    if (typeof parsed.name !== 'string') {
+      throw new CliInputError('Token name must be a string.')
+    }
+    if (
+      (parsed.collection !== undefined &&
+        typeof parsed.collection !== 'string') ||
+      (parsed.property !== undefined && typeof parsed.property !== 'string')
+    ) {
+      throw new CliInputError('--collection and --property must be strings.')
+    }
+    return {
+      name: parsed.name,
+      ...(parsed.collection === undefined
+        ? {}
+        : { collection: parsed.collection }),
+      ...(parsed.property === undefined ? {} : { property: parsed.property }),
+    }
+  } catch (error) {
+    if (error instanceof CliInputError) {
+      throw error
+    }
+    throw new CliInputError(
+      error instanceof Error ? error.message : 'Invalid arguments.',
+    )
+  }
+}
+
+async function readBatchInput(input: string, io: CliIo): Promise<string> {
+  try {
+    return input === '-' ? await io.readStdin() : await readFile(input, 'utf8')
+  } catch (error) {
+    throw new CliInputError(
+      error instanceof Error
+        ? `Unable to read input: ${error.message}`
+        : 'Unable to read input.',
+    )
+  }
+}
+
+export async function runCli(
+  args: readonly string[],
+  io: CliIo,
+  resolve: (query: TokenQuery) => TokenResolutionResult = resolveSingleQuery,
+): Promise<number> {
+  try {
+    const parsed = parseArguments(args)
+    const result =
+      parsed.input === undefined
+        ? resolve(validateQuery(parsed))
+        : resolveBatchQueries(
+            parseBatchInput(await readBatchInput(parsed.input, io)),
+          )
+    io.writeStdout(`${JSON.stringify(result)}\n`)
+    return 0
+  } catch (error) {
+    if (error instanceof CliInputError) {
+      io.writeStderr(`charcoal-token-resolver: ${error.message}\n`)
+      return 2
+    }
+    io.writeStderr(
+      `charcoal-token-resolver: ${error instanceof Error ? error.message : 'Internal error.'}\n`,
+    )
+    return 1
+  }
+}

--- a/packages/design-token-resolver/src/cli.ts
+++ b/packages/design-token-resolver/src/cli.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { runCli } from './cli-core'
+
+const exitCode = await runCli(process.argv.slice(2), {
+  async readStdin() {
+    let input = ''
+    for await (const chunk of process.stdin) {
+      input += chunk
+    }
+    return input
+  },
+  writeStdout(value) {
+    process.stdout.write(value)
+  },
+  writeStderr(value) {
+    process.stderr.write(value)
+  },
+})
+
+process.exitCode = exitCode

--- a/packages/design-token-resolver/src/index.ts
+++ b/packages/design-token-resolver/src/index.ts
@@ -1,0 +1,2 @@
+// The package intentionally exposes only its CLI contract.
+export {}

--- a/packages/design-token-resolver/src/resolver/applied-token-index.ts
+++ b/packages/design-token-resolver/src/resolver/applied-token-index.ts
@@ -1,0 +1,4 @@
+import cssVariables from '@charcoal-ui/theme/tokens/css-variables.json' with { type: 'json' }
+import { createAppliedTokenIndex } from './flatten-css-variables'
+
+export const appliedTokenIndex = createAppliedTokenIndex(cssVariables)

--- a/packages/design-token-resolver/src/resolver/flatten-css-variables.test.ts
+++ b/packages/design-token-resolver/src/resolver/flatten-css-variables.test.ts
@@ -1,0 +1,85 @@
+import { createAppliedTokenIndex } from './flatten-css-variables'
+import { appliedTokenIndex } from './applied-token-index'
+import cssVariables from '@charcoal-ui/theme/tokens/css-variables.json' with { type: 'json' }
+
+function cssVariableLeafReferences(tree: unknown): string[] {
+  if (typeof tree === 'string') {
+    return tree.startsWith('var(--') ? [tree] : []
+  }
+  if (tree === null || typeof tree !== 'object') {
+    return []
+  }
+  return Object.values(tree).flatMap(cssVariableLeafReferences)
+}
+
+describe('createAppliedTokenIndex', () => {
+  it('flattens nested CSS variable definitions without dropping path segments', () => {
+    const index = createAppliedTokenIndex({
+      color: {
+        container: {
+          primary: {
+            default: 'var(--charcoal-color-container-primary-default)',
+          },
+        },
+      },
+    })
+
+    expect(index.entries).toEqual([
+      {
+        canonicalPath: 'color/container/primary/default',
+        figmaName: 'container/primary/default',
+        cssVariable: '--charcoal-color-container-primary-default',
+        cssReference: 'var(--charcoal-color-container-primary-default)',
+      },
+    ])
+  })
+
+  it('preserves duplicate Figma names in JSON traversal order', () => {
+    const index = createAppliedTokenIndex({
+      color: { s: 'var(--charcoal-color-s)' },
+      space: { s: 'var(--charcoal-space-s)' },
+    })
+
+    expect(index.byFigmaName.get('s')).toEqual([
+      expect.objectContaining({ canonicalPath: 'color/s' }),
+      expect.objectContaining({ canonicalPath: 'space/s' }),
+    ])
+  })
+
+  it('uses the leaf reference and ignores non-CSS-variable leaves', () => {
+    const index = createAppliedTokenIndex({
+      color: {
+        applied: 'var(--custom-name)',
+        primitive: '#ffffff',
+      },
+    })
+
+    expect(index.entries).toEqual([
+      {
+        canonicalPath: 'color/applied',
+        figmaName: 'applied',
+        cssVariable: '--custom-name',
+        cssReference: 'var(--custom-name)',
+      },
+    ])
+  })
+
+  it('indexes the theme package CSS variable definitions', () => {
+    expect(
+      appliedTokenIndex.byCanonicalPath.get('color/container/primary/default'),
+    ).toEqual([
+      {
+        canonicalPath: 'color/container/primary/default',
+        figmaName: 'container/primary/default',
+        cssVariable: '--charcoal-color-container-primary-default',
+        cssReference: 'var(--charcoal-color-container-primary-default)',
+      },
+    ])
+  })
+
+  it('indexes every CSS variable leaf in the theme manifest', () => {
+    expect(
+      appliedTokenIndex.entries.map((entry) => entry.cssReference),
+    ).toEqual(cssVariableLeafReferences(cssVariables))
+  })
+})

--- a/packages/design-token-resolver/src/resolver/flatten-css-variables.ts
+++ b/packages/design-token-resolver/src/resolver/flatten-css-variables.ts
@@ -54,7 +54,9 @@ function createLookup(
   return lookup
 }
 
-export function createAppliedTokenIndex(tree: CssVariableTree): AppliedTokenIndex {
+export function createAppliedTokenIndex(
+  tree: CssVariableTree,
+): AppliedTokenIndex {
   const entries = flattenTree(tree)
 
   return {

--- a/packages/design-token-resolver/src/resolver/flatten-css-variables.ts
+++ b/packages/design-token-resolver/src/resolver/flatten-css-variables.ts
@@ -1,0 +1,65 @@
+import type { AppliedTokenEntry, AppliedTokenIndex } from './types'
+
+type CssVariableTree = { readonly [key: string]: string | CssVariableTree }
+
+const cssVariableReferencePattern = /^var\((--[^)]+)\)$/
+
+function flattenTree(
+  tree: CssVariableTree,
+  path: readonly string[] = [],
+): AppliedTokenEntry[] {
+  return Object.entries(tree).flatMap(([key, value]) => {
+    const nextPath = [...path, key]
+
+    if (typeof value !== 'string') {
+      return flattenTree(value, nextPath)
+    }
+
+    const match = cssVariableReferencePattern.exec(value)
+    if (match === null) {
+      return []
+    }
+
+    const [collection, ...figmaPath] = nextPath
+    if (collection === undefined || figmaPath.length === 0) {
+      return []
+    }
+
+    return [
+      {
+        canonicalPath: nextPath.join('/'),
+        figmaName: figmaPath.join('/'),
+        cssVariable: match[1],
+        cssReference: value,
+      },
+    ]
+  })
+}
+
+function createLookup(
+  entries: readonly AppliedTokenEntry[],
+  key: (entry: AppliedTokenEntry) => string,
+): ReadonlyMap<string, readonly AppliedTokenEntry[]> {
+  const lookup = new Map<string, AppliedTokenEntry[]>()
+
+  for (const entry of entries) {
+    const entriesForKey = lookup.get(key(entry))
+    if (entriesForKey === undefined) {
+      lookup.set(key(entry), [entry])
+    } else {
+      entriesForKey.push(entry)
+    }
+  }
+
+  return lookup
+}
+
+export function createAppliedTokenIndex(tree: CssVariableTree): AppliedTokenIndex {
+  const entries = flattenTree(tree)
+
+  return {
+    entries,
+    byCanonicalPath: createLookup(entries, (entry) => entry.canonicalPath),
+    byFigmaName: createLookup(entries, (entry) => entry.figmaName),
+  }
+}

--- a/packages/design-token-resolver/src/resolver/normalize-query.test.ts
+++ b/packages/design-token-resolver/src/resolver/normalize-query.test.ts
@@ -1,0 +1,19 @@
+import { normalizeQueryName } from './normalize-query'
+
+describe('normalizeQueryName', () => {
+  it('trims only outer whitespace and slashes', () => {
+    expect(normalizeQueryName(' /container/primary/default/ ')).toEqual({
+      name: 'container/primary/default',
+      segments: ['container', 'primary', 'default'],
+    })
+  })
+
+  it.each(['', '///', 'foo//bar'])(
+    'rejects empty path segments: %s',
+    (name) => {
+      expect(() => normalizeQueryName(name)).toThrow(
+        'Token name must not contain empty path segments.',
+      )
+    },
+  )
+})

--- a/packages/design-token-resolver/src/resolver/normalize-query.ts
+++ b/packages/design-token-resolver/src/resolver/normalize-query.ts
@@ -1,0 +1,18 @@
+export type NormalizedQueryName = Readonly<{
+  name: string
+  segments: readonly string[]
+}>
+
+export function normalizeQueryName(name: string): NormalizedQueryName {
+  const normalizedName = name.trim().replace(/^\/+|\/+$/g, '')
+  const segments = normalizedName.split('/')
+
+  if (
+    normalizedName.length === 0 ||
+    segments.some((segment) => segment.length === 0)
+  ) {
+    throw new Error('Token name must not contain empty path segments.')
+  }
+
+  return { name: normalizedName, segments }
+}

--- a/packages/design-token-resolver/src/resolver/resolve-name.test.ts
+++ b/packages/design-token-resolver/src/resolver/resolve-name.test.ts
@@ -1,0 +1,77 @@
+import { createAppliedTokenIndex } from './flatten-css-variables'
+import { resolveTokenName } from './resolve-name'
+
+const index = createAppliedTokenIndex({
+  color: {
+    s: 'var(--charcoal-color-s)',
+    typography: { paragraph: 'var(--charcoal-color-paragraph)' },
+  },
+  space: { s: 'var(--charcoal-space-s)' },
+})
+
+describe('resolveTokenName', () => {
+  it('resolves canonical paths and collection-less Figma names exactly', () => {
+    expect(
+      resolveTokenName(index, { name: 'color/typography/paragraph' }),
+    ).toMatchObject({
+      status: 'resolved',
+      entry: { canonicalPath: 'color/typography/paragraph' },
+    })
+    expect(
+      resolveTokenName(index, { name: 'typography/paragraph' }),
+    ).toMatchObject({
+      status: 'resolved',
+      entry: { canonicalPath: 'color/typography/paragraph' },
+    })
+  })
+
+  it('retains ambiguous Figma names and supports collection filtering', () => {
+    expect(resolveTokenName(index, { name: 's' })).toMatchObject({
+      status: 'ambiguous',
+      candidates: [{ canonicalPath: 'color/s' }, { canonicalPath: 'space/s' }],
+    })
+    expect(
+      resolveTokenName(index, { name: 's', collection: 'space' }),
+    ).toMatchObject({
+      status: 'resolved',
+      entry: { canonicalPath: 'space/s' },
+    })
+  })
+
+  it('accepts a unique case-insensitive exact match with a diagnostic', () => {
+    expect(
+      resolveTokenName(index, { name: 'TYPOGRAPHY/PARAGRAPH' }),
+    ).toMatchObject({
+      status: 'resolved',
+      entry: { canonicalPath: 'color/typography/paragraph' },
+      diagnostics: [{ code: 'case_normalized' }],
+    })
+  })
+
+  it('normalizes the collection segment case for canonical queries', () => {
+    expect(
+      resolveTokenName(index, { name: 'Color/Typography/Paragraph' }),
+    ).toMatchObject({
+      status: 'resolved',
+      entry: { canonicalPath: 'color/typography/paragraph' },
+      diagnostics: [{ code: 'case_normalized' }],
+    })
+  })
+
+  it('does not resolve an ambiguous case-insensitive match', () => {
+    expect(resolveTokenName(index, { name: 'S' })).toMatchObject({
+      status: 'ambiguous',
+      candidates: [{ canonicalPath: 'color/s' }, { canonicalPath: 'space/s' }],
+      diagnostics: [],
+    })
+  })
+
+  it('does not use partial matches or normalize invalid paths', () => {
+    expect(resolveTokenName(index, { name: 'paragraph' })).toMatchObject({
+      status: 'not_found',
+    })
+    expect(() =>
+      resolveTokenName(index, { name: 'typography//paragraph' }),
+    ).toThrow()
+  })
+})

--- a/packages/design-token-resolver/src/resolver/resolve-name.ts
+++ b/packages/design-token-resolver/src/resolver/resolve-name.ts
@@ -1,0 +1,82 @@
+import { normalizeQueryName } from './normalize-query'
+import type {
+  AppliedTokenEntry,
+  AppliedTokenIndex,
+  NameResolution,
+  TokenQuery,
+} from './types'
+
+function collectionOf(entry: AppliedTokenEntry): string {
+  return entry.canonicalPath.split('/')[0] ?? ''
+}
+
+function filterByCollection(
+  entries: readonly AppliedTokenEntry[],
+  collection: string | undefined,
+): readonly AppliedTokenEntry[] {
+  return collection === undefined
+    ? entries
+    : entries.filter((entry) => collectionOf(entry) === collection)
+}
+
+function completeResolution(
+  candidates: readonly AppliedTokenEntry[],
+  caseNormalized: boolean,
+): NameResolution {
+  const diagnostics = caseNormalized
+    ? [{ code: 'case_normalized' } as const]
+    : []
+
+  if (candidates.length === 0) {
+    return { status: 'not_found', diagnostics }
+  }
+  if (candidates.length === 1) {
+    const [entry] = candidates
+    if (entry === undefined) {
+      throw new Error('A single token candidate was expected.')
+    }
+    return { status: 'resolved', entry, diagnostics }
+  }
+  return { status: 'ambiguous', candidates, diagnostics }
+}
+
+export function resolveTokenName(
+  index: AppliedTokenIndex,
+  query: TokenQuery,
+): NameResolution {
+  const normalized = normalizeQueryName(query.name)
+  const [firstSegment] = normalized.segments
+  if (firstSegment === undefined) {
+    throw new Error('Normalized token name must contain a path segment.')
+  }
+  const collections = new Set(index.entries.map(collectionOf))
+  const hasCollection = [...collections].some(
+    (collection) => collection.toLowerCase() === firstSegment.toLowerCase(),
+  )
+  const exactCandidates = filterByCollection(
+    hasCollection
+      ? (index.byCanonicalPath.get(normalized.name) ?? [])
+      : (index.byFigmaName.get(normalized.name) ?? []),
+    query.collection,
+  )
+
+  if (exactCandidates.length > 0) {
+    return completeResolution(exactCandidates, false)
+  }
+
+  const caseInsensitiveCandidates = filterByCollection(
+    index.entries.filter(
+      (entry) =>
+        (hasCollection
+          ? entry.canonicalPath
+          : entry.figmaName
+        ).toLowerCase() === normalized.name.toLowerCase(),
+    ),
+    query.collection,
+  )
+
+  return completeResolution(
+    caseInsensitiveCandidates,
+    caseInsensitiveCandidates.length === 1,
+  )
+}

--- a/packages/design-token-resolver/src/resolver/resolve.test.ts
+++ b/packages/design-token-resolver/src/resolver/resolve.test.ts
@@ -1,0 +1,105 @@
+import {
+  resolveBatchQueries,
+  resolveSingleQuery,
+  resolveToken,
+} from './resolve'
+
+describe('resolveToken', () => {
+  it('returns CSS and Tailwind candidates from their respective sources', () => {
+    expect(
+      resolveSingleQuery({
+        name: 'container/primary/default',
+        collection: 'color',
+        property: 'background-color',
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      query: {
+        name: 'container/primary/default',
+        collection: 'color',
+        property: 'background-color',
+      },
+      status: 'resolved',
+      token: { canonicalPath: 'color/container/primary/default' },
+      css: {
+        variable: '--charcoal-color-container-primary-default',
+        reference: 'var(--charcoal-color-container-primary-default)',
+      },
+      tailwind: {
+        candidates: [
+          {
+            property: 'background-color',
+            className: 'bg-container-primary',
+            themeKey: 'colors',
+          },
+        ],
+      },
+      diagnostics: [],
+    })
+  })
+
+  it('does not pick a Tailwind class without property context', () => {
+    expect(
+      resolveToken({ name: 'container/primary/default', collection: 'color' }),
+    ).toMatchObject({
+      status: 'resolved',
+      tailwind: { candidates: [] },
+    })
+  })
+
+  it('keeps CSS resolution when no Tailwind binding exists', () => {
+    expect(
+      resolveToken({
+        name: 'container/primary/default',
+        collection: 'color',
+        property: 'opacity',
+      }),
+    ).toMatchObject({
+      status: 'unsupported_property',
+      token: { canonicalPath: 'color/container/primary/default' },
+    })
+    expect(
+      resolveToken({
+        name: 'line-height/body',
+        collection: 'text',
+        property: 'line-height',
+      }),
+    ).toMatchObject({
+      status: 'resolved',
+      diagnostics: [{ code: 'tailwind_binding_not_found' }],
+    })
+  })
+
+  it('distinguishes incompatible properties from unsupported properties', () => {
+    expect(
+      resolveToken({
+        name: 'container/primary/default',
+        collection: 'color',
+        property: 'border-radius',
+      }),
+    ).toMatchObject({ status: 'incompatible_property' })
+  })
+
+  it('uses property context to narrow an ambiguous name only when unique', () => {
+    expect(resolveToken({ name: 'm', property: 'width' })).toMatchObject({
+      status: 'resolved',
+      token: { canonicalPath: 'paragraph-width/m' },
+    })
+    expect(resolveToken({ name: 'm', property: 'opacity' })).toMatchObject({
+      status: 'ambiguous',
+      candidates: ['border-width/m', 'paragraph-width/m', 'radius/m'],
+    })
+  })
+
+  it('wraps batch results in a stable envelope without dropping domain failures', () => {
+    expect(
+      resolveBatchQueries([
+        { name: 'container/primary/default', collection: 'color' },
+        { name: 'unknown' },
+      ]),
+    ).toMatchObject({
+      schemaVersion: 1,
+      results: [{ status: 'resolved' }, { status: 'not_found' }],
+    })
+  })
+})

--- a/packages/design-token-resolver/src/resolver/resolve.ts
+++ b/packages/design-token-resolver/src/resolver/resolve.ts
@@ -1,0 +1,135 @@
+import { _resolveTokenV2ClassNames } from '@charcoal-ui/tailwind-config/token-v2'
+import { appliedTokenIndex } from './applied-token-index'
+import { resolveTokenName } from './resolve-name'
+import type {
+  AppliedTokenEntry,
+  BatchResolutionResponse,
+  ResolutionDiagnostic,
+  SingleResolutionResponse,
+  TailwindCandidate,
+  TokenQuery,
+  TokenResolutionResult,
+} from './types'
+
+function token(entry: AppliedTokenEntry) {
+  return { canonicalPath: entry.canonicalPath }
+}
+
+function resolvedResult(
+  query: TokenQuery,
+  entry: AppliedTokenEntry,
+  candidates: readonly TailwindCandidate[],
+  diagnostics: readonly ResolutionDiagnostic[],
+): TokenResolutionResult {
+  return {
+    query,
+    status: 'resolved',
+    token: token(entry),
+    css: { variable: entry.cssVariable, reference: entry.cssReference },
+    tailwind: { candidates },
+    diagnostics,
+  }
+}
+
+function resolveUniqueToken(
+  query: TokenQuery,
+  entry: AppliedTokenEntry,
+  diagnostics: readonly ResolutionDiagnostic[],
+): TokenResolutionResult {
+  if (query.property === undefined) {
+    return resolvedResult(query, entry, [], diagnostics)
+  }
+
+  const tailwind = _resolveTokenV2ClassNames({
+    canonicalPath: entry.canonicalPath,
+    property: query.property,
+  })
+
+  if (tailwind.status === 'resolved') {
+    return resolvedResult(query, entry, tailwind.candidates, diagnostics)
+  }
+  if (tailwind.status === 'binding_not_found') {
+    return resolvedResult(
+      query,
+      entry,
+      [],
+      [...diagnostics, { code: 'tailwind_binding_not_found' }],
+    )
+  }
+
+  return {
+    query,
+    status: tailwind.status,
+    token: token(entry),
+    diagnostics,
+  }
+}
+
+function propertyCompatibleEntries(
+  entries: readonly AppliedTokenEntry[],
+  property: string,
+): readonly AppliedTokenEntry[] {
+  return entries.filter(
+    (entry) =>
+      _resolveTokenV2ClassNames({
+        canonicalPath: entry.canonicalPath,
+        property,
+      }).status === 'resolved',
+  )
+}
+
+export function resolveToken(query: TokenQuery): TokenResolutionResult {
+  const nameResolution = resolveTokenName(appliedTokenIndex, query)
+
+  if (nameResolution.status === 'not_found') {
+    return {
+      query,
+      status: 'not_found',
+      diagnostics: nameResolution.diagnostics,
+    }
+  }
+
+  if (nameResolution.status === 'resolved') {
+    return resolveUniqueToken(
+      query,
+      nameResolution.entry,
+      nameResolution.diagnostics,
+    )
+  }
+
+  const compatibleEntries =
+    query.property === undefined
+      ? nameResolution.candidates
+      : propertyCompatibleEntries(nameResolution.candidates, query.property)
+  const candidates =
+    compatibleEntries.length === 0
+      ? nameResolution.candidates
+      : compatibleEntries
+
+  if (compatibleEntries.length === 1) {
+    const [entry] = compatibleEntries
+    if (entry === undefined) {
+      throw new Error('A single compatible token entry was expected.')
+    }
+    return resolveUniqueToken(query, entry, nameResolution.diagnostics)
+  }
+
+  return {
+    query,
+    status: 'ambiguous',
+    candidates: candidates.map((entry) => entry.canonicalPath),
+    diagnostics: nameResolution.diagnostics,
+  }
+}
+
+export function resolveSingleQuery(
+  query: TokenQuery,
+): SingleResolutionResponse {
+  return { schemaVersion: 1, ...resolveToken(query) }
+}
+
+export function resolveBatchQueries(
+  queries: readonly TokenQuery[],
+): BatchResolutionResponse {
+  return { schemaVersion: 1, results: queries.map(resolveToken) }
+}

--- a/packages/design-token-resolver/src/resolver/types.ts
+++ b/packages/design-token-resolver/src/resolver/types.ts
@@ -10,3 +10,28 @@ export type AppliedTokenIndex = Readonly<{
   byCanonicalPath: ReadonlyMap<string, readonly AppliedTokenEntry[]>
   byFigmaName: ReadonlyMap<string, readonly AppliedTokenEntry[]>
 }>
+
+export type TokenQuery = Readonly<{
+  name: string
+  collection?: string
+}>
+
+export type ResolutionDiagnostic = Readonly<{
+  code: 'case_normalized'
+}>
+
+export type NameResolution =
+  | Readonly<{
+      status: 'resolved'
+      entry: AppliedTokenEntry
+      diagnostics: readonly ResolutionDiagnostic[]
+    }>
+  | Readonly<{
+      status: 'ambiguous'
+      candidates: readonly AppliedTokenEntry[]
+      diagnostics: readonly ResolutionDiagnostic[]
+    }>
+  | Readonly<{
+      status: 'not_found'
+      diagnostics: readonly ResolutionDiagnostic[]
+    }>

--- a/packages/design-token-resolver/src/resolver/types.ts
+++ b/packages/design-token-resolver/src/resolver/types.ts
@@ -14,10 +14,11 @@ export type AppliedTokenIndex = Readonly<{
 export type TokenQuery = Readonly<{
   name: string
   collection?: string
+  property?: string
 }>
 
 export type ResolutionDiagnostic = Readonly<{
-  code: 'case_normalized'
+  code: 'case_normalized' | 'tailwind_binding_not_found'
 }>
 
 export type NameResolution =
@@ -35,3 +36,56 @@ export type NameResolution =
       status: 'not_found'
       diagnostics: readonly ResolutionDiagnostic[]
     }>
+
+export type TailwindCandidate = Readonly<{
+  property: string
+  className: string
+  themeKey: string
+}>
+
+type ResolutionResultBase = Readonly<{
+  query: TokenQuery
+  diagnostics: readonly ResolutionDiagnostic[]
+}>
+
+type ResolvedToken = Readonly<{
+  canonicalPath: string
+}>
+
+export type TokenResolutionResult =
+  | (ResolutionResultBase &
+      Readonly<{
+        status: 'resolved'
+        token: ResolvedToken
+        css: Readonly<{
+          variable: string
+          reference: string
+        }>
+        tailwind: Readonly<{
+          candidates: readonly TailwindCandidate[]
+        }>
+      }>)
+  | (ResolutionResultBase &
+      Readonly<{
+        status: 'ambiguous'
+        candidates: readonly string[]
+      }>)
+  | (ResolutionResultBase &
+      Readonly<{
+        status: 'not_found'
+      }>)
+  | (ResolutionResultBase &
+      Readonly<{
+        status: 'unsupported_property' | 'incompatible_property'
+        token: ResolvedToken
+      }>)
+
+export type SingleResolutionResponse = TokenResolutionResult &
+  Readonly<{
+    schemaVersion: 1
+  }>
+
+export type BatchResolutionResponse = Readonly<{
+  schemaVersion: 1
+  results: readonly TokenResolutionResult[]
+}>

--- a/packages/design-token-resolver/src/resolver/types.ts
+++ b/packages/design-token-resolver/src/resolver/types.ts
@@ -1,0 +1,12 @@
+export type AppliedTokenEntry = Readonly<{
+  canonicalPath: string
+  figmaName: string
+  cssVariable: string
+  cssReference: string
+}>
+
+export type AppliedTokenIndex = Readonly<{
+  entries: readonly AppliedTokenEntry[]
+  byCanonicalPath: ReadonlyMap<string, readonly AppliedTokenEntry[]>
+  byFigmaName: ReadonlyMap<string, readonly AppliedTokenEntry[]>
+}>

--- a/packages/design-token-resolver/tsconfig.json
+++ b/packages/design-token-resolver/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"],
+    "incremental": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./.tsbuildinfo"
+  }
+}

--- a/packages/design-token-resolver/tsdown.config.mts
+++ b/packages/design-token-resolver/tsdown.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/cli.ts'],
   dts: {
     generator: 'tsc',
     compilerOptions: { isolatedDeclarations: false },

--- a/packages/design-token-resolver/tsdown.config.mts
+++ b/packages/design-token-resolver/tsdown.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  dts: {
+    generator: 'tsc',
+    compilerOptions: { isolatedDeclarations: false },
+  },
+  format: 'esm',
+  target: 'node22',
+  sourcemap: true,
+  fixedExtension: false,
+})

--- a/packages/design-token-resolver/vitest.config.ts
+++ b/packages/design-token-resolver/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    alias: [
+      {
+        find: /^@charcoal-ui\/(?!theme\/tokens)(.*)/,
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '..'),
+          '$1',
+          'src',
+        ),
+      },
+    ],
+  },
+})

--- a/packages/design-token-resolver/vitest.config.ts
+++ b/packages/design-token-resolver/vitest.config.ts
@@ -7,6 +7,16 @@ export default defineConfig({
     environment: 'node',
     alias: [
       {
+        find: '@charcoal-ui/tailwind-config/token-v2',
+        replacement: path.join(
+          path.resolve(import.meta.dirname, '..'),
+          'tailwind-config',
+          'src',
+          'token-v2',
+          'index.ts',
+        ),
+      },
+      {
         find: /^@charcoal-ui\/(?!theme\/tokens)(.*)/,
         replacement: path.join(
           path.resolve(import.meta.dirname, '..'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,13 @@ importers:
       '@charcoal-ui/theme':
         specifier: workspace:*
         version: link:../theme
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@types/yargs':
+        specifier: ^17.0.32
+        version: 17.0.35
 
   packages/foundation: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,13 +263,6 @@ importers:
       '@charcoal-ui/theme':
         specifier: workspace:*
         version: link:../theme
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
-    devDependencies:
-      '@types/yargs':
-        specifier: ^17.0.32
-        version: 17.0.35
 
   packages/foundation: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
 
   packages/design-token-resolver:
     dependencies:
+      '@charcoal-ui/tailwind-config':
+        specifier: workspace:*
+        version: link:../tailwind-config
       '@charcoal-ui/theme':
         specifier: workspace:*
         version: link:../theme

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,12 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
 
+  packages/design-token-resolver:
+    dependencies:
+      '@charcoal-ui/theme':
+        specifier: workspace:*
+        version: link:../theme
+
   packages/foundation: {}
 
   packages/icon-files: {}


### PR DESCRIPTION
## やったこと

- #1075 の上に、`@charcoal-ui/design-token-resolver` packageを追加した
- Figma MCP由来のapplied token名を、theme packageのCSS custom propertyとtailwind-config packageのclass candidateへ解決する処理を追加した
- single query、file/stdin batch、schema version 1のJSON contract、domain statusとdiagnosticを実装した
- Node.js 22 targetの`charcoal-token-resolver` binary、README、build後binaryのsmoke testを追加した
- #1082と同様にNode.js組み込みの`parseArgs()`を利用し、`yargs`への依存を持たないCLIにした

## 動作確認環境

- Node.js v24.18.0
- pnpm 11.1.3
- `pnpm exec prettier packages/design-token-resolver --check`
- `pnpm exec eslint packages/design-token-resolver --max-warnings=0`
- `pnpm --filter @charcoal-ui/design-token-resolver typecheck`
- `pnpm --filter @charcoal-ui/design-token-resolver test`（31 tests passed）
- `pnpm --filter @charcoal-ui/design-token-resolver build`
- build後binaryのsingle query、file batch、stdin batchを確認した

## チェックリスト

- [x] README やドキュメントに影響があることを確認した
