### PR TITLE
feat: add charcoal design token v2 agent skill

### DIFF
--- a/skills/charcoal-design-token-v2/SKILL.md
+++ b/skills/charcoal-design-token-v2/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: charcoal-design-token-v2
+description: Resolve Charcoal Design Token 2.0 applied variables from Figma MCP into @charcoal-ui/theme CSS custom properties or @charcoal-ui/tailwind-config utility classes when implementing Charcoal-based web UI. Do not use for v1 tokens or primitive-token authoring.
+license: Apache-2.0
+compatibility: Requires Node.js 22+, a runnable charcoal-token-resolver CLI, and Figma variable definition access (MCP or equivalent).
+---
+
+# Charcoal Design Token 2.0
+
+## Use this skill
+
+Use this skill only when implementing Charcoal Design Token 2.0 in web UI.
+Do not use it for v1 tokens, primitive-token authoring, updating Figma, or
+guessing tokens.
+
+Stop if any precondition is unmet:
+
+- Node.js 22 or newer is available.
+- The `charcoal-token-resolver` CLI can be run.
+- Figma variable definitions are accessible through MCP or an equivalent
+  operation.
+
+If the resolver cannot run, report the blocker and stop. Never guess a token.
+
+## Workflow
+
+1. Confirm that the target is a Charcoal Design Token 2.0 web implementation.
+2. Confirm Node.js 22+, a runnable resolver CLI, and Figma variable-definition
+   access. Stop if any check fails.
+3. Before applying results, inspect the target file/component's existing styling
+   approach, verify a theme import such as
+   `@charcoal-ui/theme/css/v2/light.css` or
+   `@charcoal-ui/theme/css/v2/dark.css`, and verify `.ch-token-v2` on `html`
+   or an ancestor. If considering Tailwind classes, verify Tailwind CSS v3 and
+   that `unstableTokenV2: true` in `@charcoal-ui/tailwind-config` actually
+   generates the needed classes.
+4. Get variable definitions and design context through Figma MCP. Prefer
+   `get_variable_defs` and `get_design_context`; use equivalent operations when
+   those tool names are unavailable.
+5. Record every usage site as `node/layer + variable name + collection? + CSS
+   property + component state?`. Prefer applied tokens over primitive aliases.
+   Determine the destination CSS property from the design context.
+6. Deduplicate queries by `(name, collection?, property?)`, never by variable
+   name alone, and send the batch JSON to the resolver CLI.
+7. Read stdout as JSON and require `schemaVersion === 1`. An unknown schema or
+   exit code `1` or `2` is not an implementation source: report it and stop.
+8. Apply the status decision table below and map each result back to its
+   original usage sites.
+9. Choose a unique Tailwind class or the existing CSS notation from
+   `css.reference`, according to the notation rules below.
+10. Add interaction variants only when the component state is explicit.
+11. Check typography density only when handling typography or when density is
+    specified by Figma or the project.
+12. Run lint, typecheck, tests, and any needed visual checks.
+
+Read [resolver-cli.md](references/resolver-cli.md) when executing the CLI or
+when you need its JSON contract, statuses, or schema rules. Read
+[figma-variable-resolution.md](references/figma-variable-resolution.md) when
+interpreting applied versus primitive variables, property context, states, or
+composites.
+
+## Notation selection
+
+Use a Tailwind class only when all of these are true:
+
+1. Follow the user's explicit notation instruction when one was given:
+   explicit classes passes; explicit CSS variables or other non-class notation
+   fails. With no explicit notation instruction, the target file/component
+   must already use utility classes.
+2. Tailwind CSS v3 is in use and token v2 is actually enabled
+   (`unstableTokenV2: true` actually generates the classes).
+3. The resolver candidate is unique for that usage site.
+
+Otherwise use the existing CSS approach (CSS Modules, styled-components, or a
+plain stylesheet) with `css.reference`. A `resolved` result with empty
+`tailwind.candidates` (`tailwind_binding_not_found`) also falls back to the CSS
+variable.
+
+## Status decisions
+
+Domain statuses are `resolved`, `ambiguous`, `not_found`,
+`unsupported_property`, and `incompatible_property`. The
+`case_normalized` and `tailwind_binding_not_found` codes are diagnostics on a
+uniquely `resolved` result, not status values.
+
+| Result | Action |
+| --- | --- |
+| `resolved` + 1 candidate | Use the class if notation rules pass; otherwise use `css.reference`. |
+| `resolved` + 0 or multiple candidates | Use the existing CSS notation with `css.reference`. |
+| `ambiguous` | Re-run with collection and/or property; if still unresolved, leave unapplied. |
+| `not_found` | Do not guess; report it as unapplied. |
+| `unsupported_property` | Do not remove the property to work around it; leave unapplied. |
+| `incompatible_property` | Leave unapplied and check for a token/property mix-up. |
+| Unknown schema or exit `1`/`2` | Do not use it as an implementation source; report the error. |
+
+For a `resolved` result with `case_normalized`, use it because it resolved
+uniquely and report the normalization if useful. For a `resolved` result with
+`tailwind_binding_not_found`, use the CSS variable because its candidate list
+is empty.
+
+`unsupported_property` and `incompatible_property` intentionally have no CSS
+or Tailwind fields. Do not re-query without the property to obtain CSS.
+Treat primitive-only payloads as unsupported; do not infer applied tokens from
+values. Do not expand composite names such as `paragraph/regular` into atomic
+tokens. Only explicitly listed atomic variables with CSS properties are
+individual queries.
+
+Never propose v1 tokens. Do not auto-add variants because a token name ends in
+`hover` or `press`. For explicit component state only, map `hover` to
+`hover:` and `press` to `active:`; no other mappings are defined in v1 of this
+skill.

--- a/skills/charcoal-design-token-v2/SKILL.md
+++ b/skills/charcoal-design-token-v2/SKILL.md
@@ -38,7 +38,7 @@ If the resolver cannot run, report the blocker and stop. Never guess a token.
    `get_variable_defs` and `get_design_context`; use equivalent operations when
    those tool names are unavailable.
 5. Record every usage site as `node/layer + variable name + collection? + CSS
-   property + component state?`. Prefer applied tokens over primitive aliases.
+property + component state?`. Prefer applied tokens over primitive aliases.
    Determine the destination CSS property from the design context.
 6. Deduplicate queries by `(name, collection?, property?)`, never by variable
    name alone, and send the batch JSON to the resolver CLI.
@@ -83,15 +83,15 @@ Domain statuses are `resolved`, `ambiguous`, `not_found`,
 `case_normalized` and `tailwind_binding_not_found` codes are diagnostics on a
 uniquely `resolved` result, not status values.
 
-| Result | Action |
-| --- | --- |
-| `resolved` + 1 candidate | Use the class if notation rules pass; otherwise use `css.reference`. |
-| `resolved` + 0 or multiple candidates | Use the existing CSS notation with `css.reference`. |
-| `ambiguous` | Re-run with collection and/or property; if still unresolved, leave unapplied. |
-| `not_found` | Do not guess; report it as unapplied. |
-| `unsupported_property` | Do not remove the property to work around it; leave unapplied. |
-| `incompatible_property` | Leave unapplied and check for a token/property mix-up. |
-| Unknown schema or exit `1`/`2` | Do not use it as an implementation source; report the error. |
+| Result                                | Action                                                                        |
+| ------------------------------------- | ----------------------------------------------------------------------------- |
+| `resolved` + 1 candidate              | Use the class if notation rules pass; otherwise use `css.reference`.          |
+| `resolved` + 0 or multiple candidates | Use the existing CSS notation with `css.reference`.                           |
+| `ambiguous`                           | Re-run with collection and/or property; if still unresolved, leave unapplied. |
+| `not_found`                           | Do not guess; report it as unapplied.                                         |
+| `unsupported_property`                | Do not remove the property to work around it; leave unapplied.                |
+| `incompatible_property`               | Leave unapplied and check for a token/property mix-up.                        |
+| Unknown schema or exit `1`/`2`        | Do not use it as an implementation source; report the error.                  |
 
 For a `resolved` result with `case_normalized`, use it because it resolved
 uniquely and report the normalization if useful. For a `resolved` result with

--- a/skills/charcoal-design-token-v2/references/figma-variable-resolution.md
+++ b/skills/charcoal-design-token-v2/references/figma-variable-resolution.md
@@ -1,0 +1,71 @@
+# Figma Variable Resolution
+
+Read this reference when translating Figma variable definitions and design
+context into resolver queries. This skill resolves applied variables; it does
+not author or update Figma variables.
+
+## Applied and primitive variables
+
+Prefer applied tokens: variables attached to a layer or node with a semantic
+role and destination CSS property. A primitive-only payload is unsupported.
+Never infer an applied token by matching a resolved color, number, or other
+value.
+
+Figma MCP names may omit the collection. For example,
+`container/primary/default` may need collection `color` to identify
+`color/container/primary/default`. Do not assume the omitted collection when
+the name is ambiguous. Short names such as `s` require a property and/or
+collection; never auto-pick one.
+
+The following are observed name forms, not a token list or an authorization
+to guess:
+
+- `container/primary/default`
+- `text/default`
+- `component/30`
+- `font-size/Paragraph`
+- `font-weight/regular`
+- `s`
+- `paragraph/regular`
+- `light/blue/50` (primitive; do not treat as applied)
+
+## Property context
+
+Keep each usage-site identity as:
+
+`node/layer + variable name + collection? + CSS property + component state?`
+
+The destination CSS property comes from design context, not from the variable
+value alone. Practical examples include fills mapping to `background-color` or
+`color`, strokes to a border color property, corner radius to `border-radius`,
+spacing to the relevant margin/padding/gap property, and typography atomics to
+their corresponding font properties. Preserve the exact property needed by the
+usage site when querying.
+
+Do not expand a composite name such as `paragraph/regular` into atomic tokens.
+Only atomic variables that the MCP payload explicitly lists together with CSS
+properties become normal individual queries.
+
+## Query identity and matching
+
+Deduplicate only by `(name, collection?, property?)`, then map each resolver
+result back to every original usage site using that key. Deduplicating by
+variable name alone can incorrectly reuse a result across properties or
+collections.
+
+A unique complete match that differs only in case is allowed and is reported
+as `case_normalized`. Non-unique case folding is still ambiguous; it is not a
+license to guess. When a name is ambiguous, re-run with collection and/or
+property. If it remains unresolved, leave the usage unapplied.
+
+## Interaction state
+
+Add a variant only when component state is explicit in the Figma design
+context or implementation requirement. Map explicit `hover` to `hover:` and
+explicit `press` to `active:`. No other state mappings are defined in v1 of
+this skill.
+
+The suffixes `hover` and `press` in a token name are not interaction-state
+signals. Do not auto-add variants from those suffixes.
+
+Design Token v1 tokens are out of scope and must never be proposed.

--- a/skills/charcoal-design-token-v2/references/figma-variable-resolution.md
+++ b/skills/charcoal-design-token-v2/references/figma-variable-resolution.md
@@ -29,6 +29,16 @@ to guess:
 - `paragraph/regular`
 - `light/blue/50` (primitive; do not treat as applied)
 
+For a short-name usage, do not auto-confirm `s` without property or
+collection context. If the usage site's CSS property is `border-radius`,
+re-run with `property: border-radius`; `s` then uniquely resolves to
+`radius/s`, with class `rounded-s` and CSS reference
+`var(--charcoal-radius-s)`. Do not assume that `s` is a space token:
+`collection: space` returns `not_found` because there is no applied
+`space/s` match. `light/blue/50` is primitive and returns `not_found`; never
+recover an applied token by matching its value. `paragraph/regular` returns
+`not_found` and must not be expanded into atomic tokens.
+
 ## Property context
 
 Keep each usage-site identity as:

--- a/skills/charcoal-design-token-v2/references/resolver-cli.md
+++ b/skills/charcoal-design-token-v2/references/resolver-cli.md
@@ -1,0 +1,131 @@
+# Resolver CLI
+
+Read this reference when executing `charcoal-token-resolver`, constructing
+batch input, or interpreting its schema and statuses. The resolver is the
+source of truth for conversion; do not reproduce its token lists or
+conversion logic.
+
+## Invocation
+
+The package is `@charcoal-ui/design-token-resolver` and its binary is
+`charcoal-token-resolver`. Supported commands are:
+
+```sh
+charcoal-token-resolver resolve <name>
+charcoal-token-resolver resolve --input <file>
+charcoal-token-resolver resolve --input -
+```
+
+Use this execution priority, without automatically downloading unpublished
+packages:
+
+1. Run the project's dependency with its package-manager exec command, for
+   example `pnpm exec charcoal-token-resolver`.
+2. Use this monorepo's built binary at
+   `packages/design-token-resolver/dist/cli.js`, or that package's
+   `pnpm exec`.
+3. Use `charcoal-token-resolver` already on `PATH`.
+
+Use `pnpm dlx` or `npx` only when the user explicitly requests it. The
+package's SemVer is Charcoal's overall version (currently 6.x); it is
+independent of JSON `schemaVersion`, which must be `1`.
+
+`--input` is exclusive with a positional name, `--collection`, and
+`--property`. A single query requires `name`; `collection` and `property` are
+optional. The resolver does not reconstruct collection or property context
+from a name alone.
+
+## JSON contract
+
+A valid single response has `schemaVersion: 1`, the original `query`, a
+domain `status`, and `diagnostics`. A batch request is an envelope:
+
+```json
+{
+  "queries": [
+    {
+      "name": "container/primary/default",
+      "collection": "color",
+      "property": "background-color"
+    }
+  ]
+}
+```
+
+Batch output has `schemaVersion: 1` and `results`. Results preserve input
+order and each result has the single-result shape without `schemaVersion`.
+Each query object contains exactly `name` (required string), and optional
+string `collection` and `property`. A malformed batch is never partially
+processed: invalid JSON or an invalid batch schema produces no partial
+results.
+
+For example, a single resolution is:
+
+```sh
+charcoal-token-resolver resolve container/primary/default \
+  --collection color \
+  --property background-color
+```
+
+Its relevant shape is:
+
+```json
+{
+  "schemaVersion": 1,
+  "query": {
+    "name": "container/primary/default",
+    "collection": "color",
+    "property": "background-color"
+  },
+  "status": "resolved",
+  "token": {
+    "canonicalPath": "color/container/primary/default"
+  },
+  "css": {
+    "variable": "--charcoal-color-container-primary-default",
+    "reference": "var(--charcoal-color-container-primary-default)"
+  },
+  "tailwind": {
+    "candidates": [
+      {
+        "property": "background-color",
+        "className": "bg-container-primary",
+        "themeKey": "colors"
+      }
+    ]
+  },
+  "diagnostics": []
+}
+```
+
+Without `--property`, CSS is returned but no Tailwind class is selected.
+
+## Statuses and diagnostics
+
+Domain statuses are `resolved`, `ambiguous`, `not_found`,
+`unsupported_property`, and `incompatible_property`.
+
+- `resolved` includes `token`, `css`, and `tailwind.candidates`.
+- `ambiguous` includes `candidates`, an ordered list of canonical paths.
+- `not_found` has no `token`, `css`, or `tailwind`.
+- `unsupported_property` and `incompatible_property` include the unique
+  `token` only; they intentionally have no CSS or Tailwind fields.
+
+Diagnostics are code-only objects. `case_normalized` means a unique
+case-insensitive name match. `tailwind_binding_not_found` means the token
+resolved uniquely but has no Tailwind binding; the result remains `resolved`
+with an empty candidate list and CSS as the fallback.
+
+## Process behavior
+
+Valid single and batch requests write JSON only to stdout and exit `0`,
+including domain results such as `ambiguous` and `not_found`. Argument errors,
+file or stdin errors, invalid JSON, and invalid batch schemas write an
+explanation to stderr, leave stdout empty, and exit `2`; malformed batches
+therefore produce no partial results. Unexpected internal errors write to
+stderr, leave stdout empty, and exit `1`.
+
+Require `schemaVersion === 1` and the expected response shape before using
+any result. Missing or unknown schema is a stop condition. In particular,
+`unsupported_property` and `incompatible_property` must not be re-queried
+without `property` to obtain CSS.


### PR DESCRIPTION
## やったこと

- #1083 の上に、Charcoal Design Token 2.0向けのAgent Skill `charcoal-design-token-v2` を追加した
- Figma MCPのvariable definitionsからresolver CLIへbatch queryし、status決定表と記法選択に従ってWeb UIへ適用するworkflowを定義した
- resolverを正本にし、Skillへ変換ロジックやtoken一覧を複製していない
- `references/resolver-cli.md` にPR 3のCLI契約（実行優先順位、JSON schema、status、exit code）を記載した
- `references/figma-variable-resolution.md` にapplied/primitive、曖昧な短名、interaction state、composite非展開の判断を記載した

## 動作確認環境

- Node.js v24.18.0
- pnpm 11.1.3
- build後binary `packages/design-token-resolver/dist/cli.js` でfocused scenarioを確認した
  - `resolved` + unique class（`bg-container-primary`）
  - CSS記法への `css.reference` fallback、`tailwind_binding_not_found`
  - `s` はcontextなしで `ambiguous`、`border-radius` で `radius/s` に一意解決。`collection: space` は `not_found`
  - primitive / 未知名 / `paragraph/regular` は `not_found`（値一致やcomposite展開をしない）
  - `unsupported_property` / `incompatible_property` はpropertyを外して迂回しない
- `pnpm dlx skills@1.5.23 add . --list` で `charcoal-design-token-v2` を検出した
- 一時directoryへ `--agent codex --copy --yes` でinstallし、referencesの相対linkが到達することを確認した
- `skills-ref validate`（agentskills@`f130f348f502d9804278a617f86929846896d2e9`）が成功した

## チェックリスト

- [x] README やドキュメントに影響があることを確認した