### PR TITLE
feat(react): DropdownSelectorの選択を解除できるようにする

### DIFF
--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -5088,6 +5088,76 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Wit
 </div>
 `;
 
+exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > WithValueLessMenuItem 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      style="width: 288px;"
+    >
+      <div
+        class="charcoal-dropdown-selector-root"
+      >
+        <div
+          class="charcoal-field-label-root"
+          style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        >
+          <label
+            class="charcoal-field-label"
+            id="test-id"
+          >
+            Focus regression
+          </label>
+          <div
+            class="charcoal-field-label-sub-label"
+          >
+            <span />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        >
+          <select
+            tabindex="-1"
+          >
+            <option
+              value="selected"
+            >
+              selected
+            </option>
+            <option
+              value="other"
+            >
+              other
+            </option>
+          </select>
+        </div>
+        <button
+          aria-labelledby="test-id"
+          class="charcoal-dropdown-selector-button"
+          data-active="false"
+          type="button"
+        >
+          <span
+            class="charcoal-ui-dropdown-selector-text"
+            data-placeholder="false"
+          >
+            Selected option
+          </span>
+          <pixiv-icon
+            class="charcoal-icon charcoal-ui-dropdown-selector-icon"
+            name="16/Menu"
+            style="--charcoal-icon-size: 16px;"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/FocusRing > react/FocusRing > Default 1`] = `
 <div>
   <div

--- a/.storybook/__snapshots__/storybook.test.ts.snap
+++ b/.storybook/__snapshots__/storybook.test.ts.snap
@@ -4857,6 +4857,79 @@ exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > Tok
 </div>
 `;
 
+exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > WithNoSelection 1`] = `
+<div>
+  <div
+    data-dark="false"
+  >
+    <div
+      style="width: 288px;"
+    >
+      <div
+        class="charcoal-dropdown-selector-root"
+      >
+        <div
+          class="charcoal-field-label-root"
+          style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        >
+          <label
+            class="charcoal-field-label"
+            id="test-id"
+          >
+            Sort
+          </label>
+          <div
+            class="charcoal-field-label-sub-label"
+          >
+            <span />
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          style="border: 0px; clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+        >
+          <select
+            tabindex="-1"
+          >
+            <option
+              value=""
+            />
+            <option
+              value="popular"
+            >
+              popular
+            </option>
+            <option
+              value="new"
+            >
+              new
+            </option>
+          </select>
+        </div>
+        <button
+          aria-labelledby="test-id"
+          class="charcoal-dropdown-selector-button"
+          data-active="false"
+          type="button"
+        >
+          <span
+            class="charcoal-ui-dropdown-selector-text"
+            data-placeholder="true"
+          >
+            Select an option
+          </span>
+          <pixiv-icon
+            class="charcoal-icon charcoal-ui-dropdown-selector-icon"
+            name="16/Menu"
+            style="--charcoal-icon-size: 16px;"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests > react/DropdownSelector > react/DropdownSelector > WithRef 1`] = `
 <div>
   <div

--- a/packages/react/src/components/DropdownSelector/DropdownMenuItem/index.tsx
+++ b/packages/react/src/components/DropdownSelector/DropdownMenuItem/index.tsx
@@ -15,7 +15,7 @@ export type DropdownMenuItemProps = Omit<MenuItemProps, 'as'> & {
  */
 export default function DropdownMenuItem(props: DropdownMenuItemProps) {
   const { value: ctxValue } = useContext(MenuListContext)
-  const isSelected = props.value === ctxValue
+  const isSelected = props.noSelection !== true && props.value === ctxValue
   const { children, secondary, ...rest } = props
 
   const fullWidthClassName = props.contentFullWidth

--- a/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
+++ b/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
@@ -1,8 +1,10 @@
 import { Key, useEffect, useRef } from 'react'
 import Popover, { PopoverProps } from './Popover'
+import { MenuItemDescriptor } from './MenuList/internals/getValuesRecursive'
 
 type DropdownPopoverProps = PopoverProps & {
   value?: Key
+  items: MenuItemDescriptor[]
 }
 
 /**
@@ -20,23 +22,34 @@ export function DropdownPopover({ children, ...props }: DropdownPopoverProps) {
 
   useEffect(() => {
     if (props.isOpen) {
-      if (props.value !== undefined && props.value !== '') {
+      const popover = ref.current
+      if (popover === null) return
+      const options = Array.from(
+        popover.querySelectorAll<HTMLElement>('[role="option"]'),
+      )
+      const selectedIndex = props.items.findIndex(
+        (item) =>
+          !item.disabled &&
+          (props.value === ''
+            ? item.noSelection === true
+            : item.noSelection !== true && item.value === props.value),
+      )
+      const selectedElement = options[selectedIndex]
+      const firstEnabledElement = options.find(
+        (element) => element.ariaDisabled !== 'true',
+      )
+
+      if (selectedElement instanceof HTMLElement) {
         // windowのスクロールを維持したまま選択肢をPopoverの中心に表示する
         const windowScrollY = window.scrollY
         const windowScrollX = window.scrollX
-        const selectedElement = document.querySelector(
-          `[data-key="${props.value.toString()}"]`,
-        ) as HTMLElement | undefined
-        selectedElement?.focus()
+        selectedElement.focus()
         window.scrollTo(windowScrollX, windowScrollY)
-      } else {
-        const el = ref.current?.querySelector("[role='option']")
-        if (el instanceof HTMLElement) {
-          el.focus()
-        }
+      } else if (firstEnabledElement instanceof HTMLElement) {
+        firstEnabledElement.focus()
       }
     }
-  }, [props.value, props.isOpen])
+  }, [props.value, props.items, props.isOpen])
 
   return (
     <Popover

--- a/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
+++ b/packages/react/src/components/DropdownSelector/DropdownPopover.tsx
@@ -1,10 +1,8 @@
 import { Key, useEffect, useRef } from 'react'
 import Popover, { PopoverProps } from './Popover'
-import { MenuItemDescriptor } from './MenuList/internals/getValuesRecursive'
 
 type DropdownPopoverProps = PopoverProps & {
   value?: Key
-  items: MenuItemDescriptor[]
 }
 
 /**
@@ -27,14 +25,14 @@ export function DropdownPopover({ children, ...props }: DropdownPopoverProps) {
       const options = Array.from(
         popover.querySelectorAll<HTMLElement>('[role="option"]'),
       )
-      const selectedIndex = props.items.findIndex(
-        (item) =>
-          !item.disabled &&
+      const selectedElement = options.find(
+        (option) =>
+          option.ariaDisabled !== 'true' &&
           (props.value === ''
-            ? item.noSelection === true
-            : item.noSelection !== true && item.value === props.value),
+            ? option.dataset.noSelection === 'true'
+            : option.dataset.noSelection !== 'true' &&
+              option.dataset.key === props.value),
       )
-      const selectedElement = options[selectedIndex]
       const firstEnabledElement = options.find(
         (element) => element.ariaDisabled !== 'true',
       )
@@ -49,7 +47,7 @@ export function DropdownPopover({ children, ...props }: DropdownPopoverProps) {
         firstEnabledElement.focus()
       }
     }
-  }, [props.value, props.items, props.isOpen])
+  }, [props.value, props.isOpen])
 
   return (
     <Popover

--- a/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuItem/index.tsx
@@ -4,6 +4,8 @@ import { useMenuItemHandleKeyDown } from './internals/useMenuItemHandleKeyDown'
 
 export type MenuItemProps<T extends React.ElementType = 'li'> = {
   value?: string
+  /** Selects the DropdownSelector's unselected state. */
+  noSelection?: boolean
   disabled?: boolean
 } & ListItemProps<T>
 
@@ -14,10 +16,14 @@ export type MenuItemProps<T extends React.ElementType = 'li'> = {
 const MenuItem = forwardRef(function MenuItem<
   T extends React.ElementType = 'li',
 >(
-  { className: _, value, disabled, ...props }: MenuItemProps<T>,
+  { className: _, value, noSelection, disabled, ...props }: MenuItemProps<T>,
   ref: ForwardedRef<HTMLLIElement>,
 ) {
-  const [handleKeyDown, setContextValue] = useMenuItemHandleKeyDown(value)
+  const [handleKeyDown, setContextValue] = useMenuItemHandleKeyDown(
+    value,
+    noSelection,
+    disabled,
+  )
   const penHandledRef = useRef(false)
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null)
 
@@ -60,6 +66,7 @@ const MenuItem = forwardRef(function MenuItem<
       {...props}
       ref={ref}
       data-key={value}
+      data-no-selection={noSelection || undefined}
       onKeyDown={handleKeyDown}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}

--- a/packages/react/src/components/DropdownSelector/MenuItem/internals/useMenuItemHandleKeyDown.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuItem/internals/useMenuItemHandleKeyDown.tsx
@@ -11,44 +11,40 @@ import { MenuListContext } from '../../MenuList/MenuListContext'
  */
 export function useMenuItemHandleKeyDown(
   value?: string,
+  noSelection?: boolean,
+  disabled?: boolean,
 ): [(e: React.KeyboardEvent<HTMLElement>) => void, () => void] {
-  const { setValue, root, propsArray } = useContext(MenuListContext)
+  const { setValue, setNoSelection, root, propsArray } =
+    useContext(MenuListContext)
   const setContextValue = useCallback(() => {
-    if (value !== undefined) setValue(value)
-  }, [value, setValue])
+    if (noSelection) setNoSelection?.()
+    else if (value !== undefined) setValue(value)
+  }, [noSelection, setNoSelection, value, setValue])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLElement>) => {
       if (e.key === 'Enter') {
-        setContextValue()
+        if (!disabled) setContextValue()
       } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
         const isForward = e.key === 'ArrowDown'
         // prevent scroll
         e.preventDefault()
-        if (!propsArray || value === undefined) return
-        const values = propsArray
-          .map((props) => props.value)
-          .filter((v) => v) as string[]
-        let index = values.indexOf(value)
+        if (!propsArray) return
+        const options = Array.from(
+          root?.current?.querySelectorAll<HTMLElement>('[role="option"]') ?? [],
+        )
+        if (options.length === 0) return
+        let index = options.indexOf(e.currentTarget)
         if (index === -1) return
 
-        for (let n = 0; n < values.length; n++) {
-          const focusValue = isForward
-            ? // prev or last
-              index + 1 >= values.length
-              ? values[0]
-              : values[index + 1]
-            : // next or first
-              index - 1 < 0
-              ? values[values.length - 1]
-              : values[index - 1]
-          const next = root?.current?.querySelector(
-            `[data-key='${focusValue}']`,
-          )
+        for (let n = 0; n < options.length; n++) {
+          index = isForward
+            ? (index + 1) % options.length
+            : (index - 1 + options.length) % options.length
+          const next = options[index]
 
           if (next instanceof HTMLElement) {
             if (next.ariaDisabled === 'true') {
-              index += isForward ? 1 : -1
               continue
             }
             next.focus({ preventScroll: true })
@@ -60,7 +56,7 @@ export function useMenuItemHandleKeyDown(
         }
       }
     },
-    [setContextValue, propsArray, value, root],
+    [disabled, setContextValue, propsArray, root],
   )
   return [handleKeyDown, setContextValue]
 }

--- a/packages/react/src/components/DropdownSelector/MenuList/MenuListContext.ts
+++ b/packages/react/src/components/DropdownSelector/MenuList/MenuListContext.ts
@@ -1,11 +1,12 @@
 import { RefObject, createContext } from 'react'
-import { DropdownMenuItemProps } from '../DropdownMenuItem'
+import { MenuItemDescriptor } from './internals/getValuesRecursive'
 
 type MenuListContextType = {
   root?: RefObject<HTMLUListElement | null>
   value?: string
-  propsArray?: DropdownMenuItemProps[]
+  propsArray?: MenuItemDescriptor[]
   setValue: (v: string) => void
+  setNoSelection?: () => void
 }
 
 export const MenuListContext = createContext<MenuListContextType>({
@@ -15,4 +16,5 @@ export const MenuListContext = createContext<MenuListContextType>({
   setValue: (_v: string) => {
     // empty
   },
+  setNoSelection: undefined,
 })

--- a/packages/react/src/components/DropdownSelector/MenuList/index.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuList/index.tsx
@@ -1,6 +1,7 @@
 import './index.css'
 
 import { useMemo, useRef } from 'react'
+import warning from 'warning'
 import { MenuListContext } from './MenuListContext'
 import { getValuesRecursive } from './internals/getValuesRecursive'
 import MenuItem from '../MenuItem'
@@ -17,6 +18,7 @@ export type MenuListProps = {
   children: MenuListChildren
   value?: string
   onChange?: (v: string) => void
+  onNoSelection?: () => void
 }
 
 export default function MenuList(props: MenuListProps) {
@@ -25,6 +27,25 @@ export default function MenuList(props: MenuListProps) {
     () => getValuesRecursive(props.children),
     [props.children],
   )
+
+  if (process.env.NODE_ENV !== 'production') {
+    const noSelectionItems = propsArray.filter((item) => item.noSelection)
+    warning(
+      noSelectionItems.length <= 1,
+      '`noSelection` can only be specified on one DropdownMenuItem.',
+    )
+    warning(
+      propsArray.every(
+        (item) =>
+          item.noSelection || item.value === undefined || item.value !== '',
+      ),
+      'An empty string `value` is not supported. Use `noSelection` instead.',
+    )
+    warning(
+      noSelectionItems.every((item) => item.value === undefined),
+      '`noSelection` and `value` cannot be used together.',
+    )
+  }
 
   return (
     <ul className="charcoal-menu-list" ref={root}>
@@ -36,6 +57,7 @@ export default function MenuList(props: MenuListProps) {
           setValue: (v) => {
             props.onChange?.(v)
           },
+          setNoSelection: props.onNoSelection,
         }}
       >
         {props.children}

--- a/packages/react/src/components/DropdownSelector/MenuList/internals/getValuesRecursive.tsx
+++ b/packages/react/src/components/DropdownSelector/MenuList/internals/getValuesRecursive.tsx
@@ -2,7 +2,11 @@ import * as React from 'react'
 import MenuItem from '../../MenuItem'
 import { MenuListChildren } from '..'
 import MenuItemGroup from '../../MenuItemGroup'
-import { DropdownMenuItemProps } from '../../DropdownMenuItem'
+export type MenuItemDescriptor = {
+  value?: string
+  noSelection?: boolean
+  disabled?: boolean
+}
 
 /**
  * valueというpropsを持つ子要素の値を再起的に探索して配列にする
@@ -14,19 +18,24 @@ import { DropdownMenuItemProps } from '../../DropdownMenuItem'
  */
 export function getValuesRecursive(children: MenuListChildren) {
   const childArray = React.Children.toArray(children)
-  const propsArray: DropdownMenuItemProps[] = []
+  const propsArray: MenuItemDescriptor[] = []
   for (let i = 0; i < childArray.length; i++) {
     const child = childArray[i]
     if (React.isValidElement(child)) {
       const props = child.props as {
         value?: string
+        noSelection?: boolean
         disabled?: boolean
         children?: React.ReactElement<typeof MenuItem | typeof MenuItemGroup>[]
       }
-      if ('value' in props && typeof props.value === 'string') {
+      if (
+        ('value' in props && typeof props.value === 'string') ||
+        props.noSelection === true
+      ) {
         propsArray.push({
           disabled: props.disabled,
           value: props.value,
+          noSelection: props.noSelection,
         })
       }
       if ('children' in props && props.children) {

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import DropdownSelector from '.'
 import { Divider } from './Divider'
 import MenuItemGroup from './MenuItemGroup'
+import MenuItem from './MenuItem'
 import DropdownMenuItem from './DropdownMenuItem'
 import Modal from '../Modal'
 import { ModalBody, ModalHeader } from '../Modal/ModalPlumbing'
@@ -49,6 +50,28 @@ export const WithNoSelection: StoryObj<typeof DropdownSelector> = {
           <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
           <DropdownMenuItem noSelection>Unspecified</DropdownMenuItem>
           <DropdownMenuItem value="new">Newest</DropdownMenuItem>
+        </DropdownSelector>
+      </div>
+    )
+  },
+}
+
+// Opening this story focuses "Non-selectable item" instead of the selected
+// option. It reproduces the focus-index mismatch caused by a MenuItem without
+// a value preceding DropdownMenuItem options.
+export const WithValueLessMenuItem: StoryObj<typeof DropdownSelector> = {
+  render: function Render() {
+    const [selected, setSelected] = useState('selected')
+    return (
+      <div style={{ width: 288 }}>
+        <DropdownSelector
+          label="Focus regression"
+          value={selected}
+          onChange={setSelected}
+        >
+          <MenuItem>Non-selectable item</MenuItem>
+          <DropdownMenuItem value="selected">Selected option</DropdownMenuItem>
+          <DropdownMenuItem value="other">Other option</DropdownMenuItem>
         </DropdownSelector>
       </div>
     )

--- a/packages/react/src/components/DropdownSelector/index.story.tsx
+++ b/packages/react/src/components/DropdownSelector/index.story.tsx
@@ -35,6 +35,26 @@ export const Default: StoryObj<typeof DropdownSelector> = {
   },
 }
 
+export const WithNoSelection: StoryObj<typeof DropdownSelector> = {
+  render: function Render() {
+    const [selected, setSelected] = useState('')
+    return (
+      <div style={{ width: 288 }}>
+        <DropdownSelector
+          label="Sort"
+          value={selected}
+          placeholder="Select an option"
+          onChange={setSelected}
+        >
+          <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+          <DropdownMenuItem noSelection>Unspecified</DropdownMenuItem>
+          <DropdownMenuItem value="new">Newest</DropdownMenuItem>
+        </DropdownSelector>
+      </div>
+    )
+  },
+}
+
 export const Label: StoryObj<typeof DropdownSelector> = {
   render: function Render() {
     const [selected, setSelected] = useState('1')

--- a/packages/react/src/components/DropdownSelector/index.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.test.tsx
@@ -4,6 +4,7 @@ import { beforeAll, vi } from 'vitest'
 import DropdownSelector from '.'
 import DropdownMenuItem from './DropdownMenuItem'
 import MenuItemGroup from './MenuItemGroup'
+import MenuItem from './MenuItem'
 
 // Apple Pencil (pointerType: 'pen') の解除は index.browser.test.tsx で検証する。
 // jsdom は inert を実装しておらず、react-aria が外側を inert にする本番の挙動を
@@ -174,6 +175,22 @@ describe('DropdownSelector', () => {
 
     fireEvent.click(screen.getByRole('button'))
     expect(screen.getByRole('option', { name: 'Popular' })).toHaveFocus()
+  })
+
+  it('focuses the selected item when a preceding MenuItem has no value', () => {
+    render(
+      <DropdownSelector label="Sort" value="selected" onChange={vi.fn()}>
+        <MenuItem>Non-selectable item</MenuItem>
+        <DropdownMenuItem value="selected">Selected option</DropdownMenuItem>
+        <DropdownMenuItem value="other">Other option</DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(
+      screen.getByRole('option', { name: 'Selected option' }),
+    ).toHaveFocus()
   })
 
   it('warns for invalid noSelection children', () => {

--- a/packages/react/src/components/DropdownSelector/index.test.tsx
+++ b/packages/react/src/components/DropdownSelector/index.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
 import { beforeAll, vi } from 'vitest'
 import DropdownSelector from '.'
 import DropdownMenuItem from './DropdownMenuItem'
+import MenuItemGroup from './MenuItemGroup'
 
 // Apple Pencil (pointerType: 'pen') の解除は index.browser.test.tsx で検証する。
 // jsdom は inert を実装しておらず、react-aria が外側を inert にする本番の挙動を
@@ -30,6 +32,167 @@ const getUnderlay = () => {
 }
 
 describe('DropdownSelector', () => {
+  it('clears the controlled value through a noSelection item', () => {
+    const handleChange = vi.fn()
+    function Example() {
+      const [value, setValue] = useState('popular')
+      return (
+        <DropdownSelector
+          label="Sort"
+          value={value}
+          placeholder="Select an option"
+          onChange={(next) => {
+            handleChange(next)
+            setValue(next)
+          }}
+        >
+          <DropdownMenuItem noSelection>None</DropdownMenuItem>
+          <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+        </DropdownSelector>
+      )
+    }
+
+    const { container } = render(<Example />)
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByRole('option', { name: 'None' }))
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledWith('')
+    expect(document.querySelector('.charcoal-popover')).toBeNull()
+    expect(screen.getByRole('button')).toHaveTextContent('Select an option')
+    expect(container.querySelector('select')?.value).toBe('')
+    expect(container.querySelectorAll('option[value=""]').length).toBe(1)
+  })
+
+  it('supports keyboard selection and navigation for noSelection items', () => {
+    const handleChange = vi.fn()
+    render(
+      <DropdownSelector label="Sort" value="popular" onChange={handleChange}>
+        <DropdownMenuItem noSelection>None</DropdownMenuItem>
+        <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+        <DropdownMenuItem value="new" disabled>
+          New
+        </DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    const popular = screen.getByRole('option', { name: 'Popular' })
+    expect(popular).toHaveFocus()
+    fireEvent.keyDown(popular, { key: 'ArrowUp' })
+    const none = screen.getByRole('option', { name: 'None' })
+    expect(none).toHaveFocus()
+    fireEvent.keyDown(none, { key: 'Enter' })
+
+    expect(handleChange).toHaveBeenCalledWith('')
+  })
+
+  it('does not mark a noSelection item as selected', () => {
+    render(
+      <DropdownSelector label="Sort" value="" onChange={vi.fn()}>
+        <DropdownMenuItem noSelection>None</DropdownMenuItem>
+        <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('option', { name: 'None' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+    expect(document.querySelector('[data-selected="true"]')).toBeNull()
+    expect(screen.getByRole('option', { name: 'None' })).toHaveAttribute(
+      'data-no-selection',
+      'true',
+    )
+  })
+
+  it('clears through the pen pointer path', () => {
+    const handleChange = vi.fn()
+    render(
+      <DropdownSelector label="Sort" value="popular" onChange={handleChange}>
+        <DropdownMenuItem noSelection>None</DropdownMenuItem>
+        <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    const none = screen.getByRole('option', { name: 'None' })
+    fireEvent.pointerDown(none, { pointerType: 'pen', clientX: 0, clientY: 0 })
+    fireEvent.pointerUp(none, { pointerType: 'pen', clientX: 0, clientY: 0 })
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledWith('')
+  })
+
+  it('includes noSelection items in groups and skips disabled items while navigating', () => {
+    render(
+      <DropdownSelector label="Sort" value="popular" onChange={vi.fn()}>
+        <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+        <MenuItemGroup text="Other">
+          <DropdownMenuItem noSelection disabled>
+            Disabled none
+          </DropdownMenuItem>
+          <DropdownMenuItem noSelection>None</DropdownMenuItem>
+        </MenuItemGroup>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    const popular = screen.getByRole('option', { name: 'Popular' })
+    fireEvent.keyDown(popular, { key: 'ArrowDown' })
+    expect(screen.getByRole('option', { name: 'None' })).toHaveFocus()
+  })
+
+  it('focuses the noSelection item only in the opened popover', () => {
+    render(
+      <>
+        <DropdownSelector label="First" value="" onChange={vi.fn()}>
+          <DropdownMenuItem noSelection>First none</DropdownMenuItem>
+          <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+        </DropdownSelector>
+        <DropdownSelector label="Second" value="" onChange={vi.fn()}>
+          <DropdownMenuItem noSelection>Second none</DropdownMenuItem>
+          <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+        </DropdownSelector>
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Second' }))
+    expect(screen.getByRole('option', { name: 'Second none' })).toHaveFocus()
+  })
+
+  it('skips a disabled noSelection item when initially focusing an unselected menu', () => {
+    render(
+      <DropdownSelector label="Sort" value="" onChange={vi.fn()}>
+        <DropdownMenuItem noSelection disabled>
+          Disabled none
+        </DropdownMenuItem>
+        <DropdownMenuItem value="popular">Popular</DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('option', { name: 'Popular' })).toHaveFocus()
+  })
+
+  it('warns for invalid noSelection children', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    render(
+      <DropdownSelector label="Sort" value="" onChange={vi.fn()}>
+        <DropdownMenuItem noSelection value="popular">
+          Invalid
+        </DropdownMenuItem>
+        <DropdownMenuItem noSelection>Also invalid</DropdownMenuItem>
+      </DropdownSelector>,
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(error).toHaveBeenCalled()
+    error.mockRestore()
+  })
+
   describe('when `value` does not match any child `DropdownMenuItem`', () => {
     it('keeps the DOM `<select>.value` aligned with props `value` without breaking placeholder display', () => {
       const handleChange = vi.fn()

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -183,7 +183,6 @@ export default function DropdownSelector({
           onClose={handleClose}
           triggerRef={triggerRef}
           value={props.value}
-          items={propsArray}
           inertWorkaround={props.inertWorkaround}
         >
           <MenuList

--- a/packages/react/src/components/DropdownSelector/index.tsx
+++ b/packages/react/src/components/DropdownSelector/index.tsx
@@ -53,7 +53,13 @@ export default function DropdownSelector({
 
   const propsArray = getValuesRecursive(props.children)
   const hasMatchedValue = useMemo(
-    () => propsArray.some((itemProps) => itemProps.value === props.value),
+    () =>
+      props.value === ''
+        ? propsArray.some((itemProps) => itemProps.noSelection)
+        : propsArray.some(
+            (itemProps) =>
+              itemProps.noSelection !== true && itemProps.value === props.value,
+          ),
     [propsArray, props.value],
   )
 
@@ -78,6 +84,11 @@ export default function DropdownSelector({
     },
     [onChange],
   )
+
+  const handleNoSelection = useCallback(() => {
+    onChange('')
+    setIsOpen(false)
+  }, [onChange])
 
   const handleTriggerPointerUp = useCallback(
     (e: React.PointerEvent<HTMLButtonElement>) => {
@@ -127,17 +138,20 @@ export default function DropdownSelector({
           {!hasMatchedValue && (
             <option value={props.value}>{props.value}</option>
           )}
-          {propsArray.map((itemProps) => {
-            return (
-              <option
-                key={itemProps.value}
-                value={itemProps.value}
-                disabled={itemProps.disabled}
-              >
-                {itemProps.value}
-              </option>
-            )
-          })}
+          {propsArray.some((item) => item.noSelection) && <option value="" />}
+          {propsArray
+            .filter((itemProps) => itemProps.noSelection !== true)
+            .map((itemProps) => {
+              return (
+                <option
+                  key={itemProps.value}
+                  value={itemProps.value}
+                  disabled={itemProps.disabled}
+                >
+                  {itemProps.value}
+                </option>
+              )
+            })}
         </select>
       </div>
       {/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
@@ -169,9 +183,14 @@ export default function DropdownSelector({
           onClose={handleClose}
           triggerRef={triggerRef}
           value={props.value}
+          items={propsArray}
           inertWorkaround={props.inertWorkaround}
         >
-          <MenuList value={props.value} onChange={handleSelect}>
+          <MenuList
+            value={props.value}
+            onChange={handleSelect}
+            onNoSelection={handleNoSelection}
+          >
             {props.children}
           </MenuList>
         </DropdownPopover>

--- a/packages/react/src/components/DropdownSelector/utils/findPreviewRecursive.tsx
+++ b/packages/react/src/components/DropdownSelector/utils/findPreviewRecursive.tsx
@@ -19,8 +19,16 @@ export function findPreviewRecursive(
     const child = childArray[i]
     if (React.isValidElement(child)) {
       if ('value' in child.props) {
-        const childValue = (child.props as { value: string }).value
-        if (childValue === value && 'children' in child.props) {
+        const props = child.props as {
+          value: string
+          noSelection?: boolean
+          children?: ReactNode
+        }
+        if (
+          props.noSelection !== true &&
+          props.value === value &&
+          'children' in props
+        ) {
           const children = (child.props as { children: ReactNode }).children
           return children
         }


### PR DESCRIPTION
## やったこと

- `DropdownSelector` で `noSelection` を指定した項目を選択すると、未選択状態に戻せるようにした
- 未選択項目を含むメニューの初期フォーカス、キーボード操作、無効項目のスキップを実装した
- アクセシビリティ用の `<select>` とプレースホルダー表示を未選択状態に対応させた
- Storybookの表示例とユニットテストを追加した

## 破壊的変更

`DropdownMenuItem value=""` を通常の選択肢として使うことはできなくなります。空文字は常に `DropdownSelector` の未選択状態を表します。

既存の「指定なし」などの空文字の選択肢は、`noSelection` へ移行してください。

```tsx
// 変更前
<DropdownMenuItem value="">指定なし</DropdownMenuItem>

// 変更後
<DropdownMenuItem noSelection>指定なし</DropdownMenuItem>
```

開発環境では、空文字の `value`、複数の `noSelection`、または `noSelection` と `value` の併用に対して警告を出します。

## 動作確認環境

- `pnpm test packages/react/src/components/DropdownSelector/index.test.tsx`（11 tests passed）

## チェックリスト

- [x] README やドキュメントに影響がないことを確認した
