### PR TITLE
feat: Claude Code plugin marketplace と npx skills の土俵を追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "charcoal",
+  "owner": {
+    "name": "pixiv",
+    "url": "https://github.com/pixiv/charcoal"
+  },
+  "metadata": {
+    "description": "Claude Code plugins and agent skills for the pixiv charcoal design system (@charcoal-ui)"
+  },
+  "plugins": [
+    {
+      "name": "charcoal",
+      "source": "./plugins/charcoal",
+      "description": "Agent skills for adopting @charcoal-ui in an application",
+      "author": {
+        "name": "pixiv"
+      },
+      "homepage": "https://github.com/pixiv/charcoal/tree/main/plugins/charcoal",
+      "repository": "https://github.com/pixiv/charcoal",
+      "license": "Apache-2.0",
+      "keywords": ["charcoal", "pixiv", "design-system", "react"],
+      "category": "web-development"
+    }
+  ]
+}

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,0 +1,42 @@
+name: plugin
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/**'
+      - '.github/workflows/plugin.yml'
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - 'plugins/**'
+      - '.github/workflows/plugin.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+
+      - name: Check plugin version follows lerna.json
+        run: node misc/sync-plugin-version.mts --check
+
+      - name: Install Claude Code CLI
+        run: npm install --global @anthropic-ai/claude-code
+
+      - name: Validate marketplace
+        run: claude plugin validate --strict .
+
+      - name: Validate plugins
+        run: |
+          for plugin in plugins/*/; do
+            claude plugin validate --strict "$plugin"
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Set package version
         run: pnpm lerna version ${{ github.event.inputs.version }} --no-push --force-publish --yes
 
+      - name: Sync plugin version
+        run: |
+          node misc/sync-plugin-version.mts
+          git add plugins
+          git diff --cached --quiet || git commit -m "chore: sync plugin version [skip ci]"
+
       - name: Build & Publish to npmjs
         run: pnpm release --tag ${{ github.event.inputs.release_tag }}
         env:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is the monorepo for the `@charcoal-ui` packages by pixiv.
 
 See our [documentation](https://charcoal-web.pixiv.design/), or README of each package in `/packages`.
 
+## Agent skills / Claude Code plugin
+
+Skills that teach coding agents how to adopt `@charcoal-ui` live under `plugins/`. See [plugins/charcoal/README.md](./plugins/charcoal/README.md) for `/plugin install charcoal@charcoal` and `npx skills add pixiv/charcoal`.
+
 ## NPM Packages
 
 | package                      | version                                                                                                                                        |

--- a/misc/sync-plugin-version.mts
+++ b/misc/sync-plugin-version.mts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Copies the version in lerna.json into every plugins/*/.claude-plugin/plugin.json
+// so plugins carry the same version as the published @charcoal-ui packages.
+// The publish workflow runs it right after `lerna version`. `--check` only
+// reports drift (used in CI, where node_modules is absent, so prettier is
+// imported lazily).
+import { glob, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+type PluginManifest = { version?: string } & Record<string, unknown>
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+process.chdir(path.join(__dirname, '..'))
+
+const check = process.argv.includes('--check')
+const { version } = JSON.parse(await readFile('lerna.json', 'utf8')) as {
+  version: string
+}
+const manifests = await Array.fromAsync(
+  glob('plugins/*/.claude-plugin/plugin.json'),
+)
+
+const drifted: string[] = []
+for (const manifest of manifests) {
+  const json = JSON.parse(await readFile(manifest, 'utf8')) as PluginManifest
+  if (json.version === version) continue
+  drifted.push(manifest)
+  console.log(`${manifest}: ${json.version} -> ${version}`)
+  if (check) continue
+  const prettier = await import('prettier')
+  const options = await prettier.resolveConfig(manifest)
+  const formatted = await prettier.format(
+    JSON.stringify({ ...json, version }),
+    { ...options, filepath: manifest },
+  )
+  await writeFile(manifest, formatted)
+}
+
+if (check && drifted.length > 0) {
+  console.error(
+    `plugin.json version must match lerna.json (${version}). Run: node misc/sync-plugin-version.mts`,
+  )
+  process.exit(1)
+}

--- a/plugins/charcoal/.claude-plugin/plugin.json
+++ b/plugins/charcoal/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "charcoal",
+  "version": "6.1.1-beta.2",
+  "description": "Agent skills for adopting @charcoal-ui in an application",
+  "author": { "name": "pixiv" },
+  "homepage": "https://github.com/pixiv/charcoal/tree/main/plugins/charcoal",
+  "repository": "https://github.com/pixiv/charcoal",
+  "license": "Apache-2.0",
+  "keywords": ["charcoal", "pixiv", "design-system", "react"]
+}

--- a/plugins/charcoal/README.md
+++ b/plugins/charcoal/README.md
@@ -1,0 +1,112 @@
+# charcoal plugin
+
+Claude Code plugin that ships agent skills for `@charcoal-ui`. The same `skills/` directory is also readable by [`npx skills`](https://github.com/vercel-labs/skills), so Codex, Cursor, and other agents install from here too.
+
+## Install
+
+### Claude Code
+
+```
+/plugin marketplace add pixiv/charcoal
+/plugin install charcoal@charcoal
+```
+
+Non-interactive:
+
+```bash
+claude plugin marketplace add pixiv/charcoal
+claude plugin install charcoal@charcoal
+```
+
+### Codex, Cursor, and others
+
+```bash
+# pick agents interactively
+npx skills add pixiv/charcoal
+
+# Codex, in this project
+npx skills add pixiv/charcoal -a codex
+
+# Codex, for every project on this machine
+npx skills add pixiv/charcoal -a codex --global
+
+# one skill only
+npx skills add pixiv/charcoal -s <skill-name> -a codex
+```
+
+`-a` is repeated for multiple agents (`-a codex -a cursor`); comma-separated values are rejected.
+
+| Agent       | `-a` value    | Project           | `--global`                   |
+| ----------- | ------------- | ----------------- | ---------------------------- |
+| Claude Code | `claude-code` | `.claude/skills/` | `~/.claude/skills/`          |
+| Codex       | `codex`       | `.agents/skills/` | `~/.codex/skills/`           |
+| Cursor      | `cursor`      | `.agents/skills/` | `~/.cursor/skills/`          |
+| OpenCode    | `opencode`    | `.agents/skills/` | `~/.config/opencode/skills/` |
+
+Other commands: `npx skills list`, `npx skills update`, `npx skills remove`.
+
+### Try a branch before it is merged
+
+```bash
+git clone --branch <branch> https://github.com/pixiv/charcoal /tmp/charcoal
+npx skills add /tmp/charcoal -a codex
+```
+
+For Claude Code, `/plugin marketplace add /tmp/charcoal` then `/plugin install charcoal@charcoal`.
+
+## Layout
+
+```
+charcoal/
+├── .claude-plugin/
+│   └── marketplace.json          # marketplace "charcoal"; plugins[].source = ./plugins/<name>
+└── plugins/
+    └── charcoal/
+        ├── .claude-plugin/
+        │   └── plugin.json       # plugin "charcoal"
+        ├── README.md
+        └── skills/
+            └── <skill-name>/
+                └── SKILL.md      # auto-discovered; no listing in plugin.json
+```
+
+Both installers read the same files. Claude Code copies `plugins/charcoal/` into its plugin cache. `npx skills` follows `plugins[].source` in `marketplace.json` down to `plugins/charcoal/skills/`.
+
+## Add a skill
+
+1. Create `plugins/charcoal/skills/<skill-name>/SKILL.md` with `name` and `description` in the frontmatter. `name` must match the directory name.
+2. Run the checks below.
+
+## Versioning
+
+The plugin version is the `@charcoal-ui` version. Do not edit `version` in `plugin.json` by hand.
+
+- The `Publish to npmjs` workflow runs `lerna version`, then `misc/sync-plugin-version.mts`, which copies the new version into every `plugins/*/.claude-plugin/plugin.json` and commits it right after the `chore: publish` commit.
+- `marketplace.json` entries carry no `version`; `plugin.json` is the single source of truth. Claude Code only offers `/plugin update` when that version changes, so a skill fix reaches installed users at the next charcoal release (beta releases included). `npx skills update` copies the files directly and does not wait.
+
+## Add a plugin
+
+1. Create `plugins/<plugin-name>/.claude-plugin/plugin.json` with `version` set to the current `lerna.json` version.
+2. Append an entry to `plugins[]` in `.claude-plugin/marketplace.json` with `"source": "./plugins/<plugin-name>"` and no `version`.
+
+## Checks
+
+The `plugin` workflow runs these on every change under `plugins/` or `.claude-plugin/`.
+
+```bash
+node misc/sync-plugin-version.mts --check
+claude plugin validate --strict .
+claude plugin validate --strict plugins/charcoal
+```
+
+To confirm `npx skills` discovery from a local checkout:
+
+```bash
+cd "$(mktemp -d)" && npx skills add /path/to/charcoal -a codex -y && npx skills list
+```
+
+## If a skill does not show up
+
+- **Wrong directory.** Older `skills` CLI releases wrote to `~/.agents/skills/`, which Claude Code does not read. Use `-a claude-code`, or install the plugin instead.
+- **Stale CLI.** Manifest-aware discovery needs `skills` 1.5.16 or newer. Run `npx skills@latest add pixiv/charcoal`.
+- **Restart the agent.** Skills are read at startup.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "**/*.config.js",
     "**/*.config.ts",
     "misc/*.mjs",
+    "misc/*.mts",
     "**/.*.cjs",
     "**/.*.js",
     "__mocks__/*.ts",


### PR DESCRIPTION
## やったこと

Claude Code の plugin marketplace と、[`npx skills`](https://github.com/vercel-labs/skills)（Codex / Cursor など）の両方から charcoal の agent skills を install できる土俵を作りました。skills 本体は含みません。#1057 の 4 skills はこの土俵に rebase して `plugins/charcoal/skills/` へ移す想定です。

```
charcoal/
├── .claude-plugin/marketplace.json     # marketplace "charcoal"
└── plugins/charcoal/
    ├── .claude-plugin/plugin.json      # plugin "charcoal"
    ├── README.md                       # install 手順・skill / plugin の追加手順
    └── skills/<name>/SKILL.md          # 自動発見。plugin.json への列挙は不要
```

```
/plugin marketplace add pixiv/charcoal
/plugin install charcoal@charcoal
npx skills add pixiv/charcoal -a codex
```

### version は charcoal のリリースに追従

Claude Code は `plugin.json` の `version` が変わったときだけ `/plugin update` で新しい内容を配ります（version を上げないと内容を変えても届かない）。そこで plugin の version は `@charcoal-ui` と同じ値にし、`Publish to npmjs` workflow で `lerna version` の直後に `misc/sync-plugin-version.mts` が `lerna.json` の version を `plugin.json` に写して `chore: sync plugin version [skip ci]` として積みます。

- `marketplace.json` の entry には `version` を持たせません。install 時は `plugin.json` が優先され、marketplace 側は不一致だと黙って無視されるためです
- `package.json` の scripts は触っていません。`.mts` は `pullrequest-cli` と同じく Node 24 の型ストリップで `node` 直実行です
- plugin 用の git tag は打ちません。他 plugin からの semver 依存解決が必要になったら検討します
- skill の修正が Claude Code ユーザーに届くのは次の charcoal リリース（beta 含む）です。`npx skills update` はファイルを直接取り直すので即時です

### CI

`plugin.yml` が `plugins/**` と `.claude-plugin/**` の変更時に `node misc/sync-plugin-version.mts --check`（lerna.json とのずれ検出）と `claude plugin validate --strict` を実行します。validate は認証不要で動きます。

## 動作確認環境

- `claude plugin validate --strict` を marketplace と plugin の両方で通過（Claude Code 2.1.263）
- `CLAUDE_CONFIG_DIR` を隔離した上で `claude plugin marketplace add <worktree>` → `claude plugin install charcoal@charcoal` が成功し、キャッシュに `plugins/charcoal/` の中身だけがコピーされることを確認
- 仮の SKILL.md を置いて `npx skills@1.5.24 add <worktree> -a codex` が `plugins/charcoal/skills/` 配下を発見・install することを確認（仮 skill は削除済み）
- version を上げずに内容を変えても `claude plugin update` が「already at the latest version」になり、`plugin.json` だけ上げれば更新されることを確認
- リポジトリを scratch に複製して `lerna version 6.1.1-beta.3 --no-push` → 同期ステップを実行し、`chore: publish` の次に `plugin.json` だけのコミットが積まれ、`v6.1.1-beta.3` tag が publish コミットを指したままで、prettier も通ることを確認。ずれがない状態で再実行してもコミットは作られない
- node_modules のないディレクトリで `--check` が exit 0 / 1 を正しく返すことを確認
- `pnpm exec prettier --check` 通過、`tsc --noEmit` 通過。`misc/` は eslint の ignore 対象

## チェックリスト

- [x] README やドキュメントに影響があることを確認した