### PR TITLE
docs: charcoal 導入用の agent skills を plugin に追加

### DIFF
--- a/plugins/charcoal/README.md
+++ b/plugins/charcoal/README.md
@@ -2,6 +2,17 @@
 
 Claude Code plugin that ships agent skills for `@charcoal-ui`. The same `skills/` directory is also readable by [`npx skills`](https://github.com/vercel-labs/skills), so Codex, Cursor, and other agents install from here too.
 
+## Skills
+
+| Skill                               | Use it for                                                      |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `choosing-charcoal-styling`         | Deciding between CSS variables, Tailwind, and styled-components |
+| `setting-up-charcoal-css-variables` | Plain CSS, CSS Modules, vanilla-extract — the default route     |
+| `setting-up-charcoal-tailwind`      | Adding the Tailwind preset                                      |
+| `setting-up-charcoal-styled`        | Existing styled-components codebases, and migrating off them    |
+
+They exist because charcoal's own documentation is not machine-readable: the docs site is a Storybook SPA that returns no content to a fetcher, npm package pages return 403, and the `pages/` docsify site has been stale since 2023. Agents that try to look charcoal up on the web reconstruct it from package internals — slowly — or invent it. Every one of the four skills spells out the Design Token 2.0 opt-in (`.ch-token-v2`), which is the step agents drop most often.
+
 ## Install
 
 ### Claude Code
@@ -75,7 +86,8 @@ Both installers read the same files. Claude Code copies `plugins/charcoal/` into
 ## Add a skill
 
 1. Create `plugins/charcoal/skills/<skill-name>/SKILL.md` with `name` and `description` in the frontmatter. `name` must match the directory name.
-2. Run the checks below.
+2. Write it against a real failure: run the scenario it covers with an agent that does _not_ have the skill, record what it gets wrong, and write only what closes that gap.
+3. Run the checks below.
 
 ## Versioning
 
@@ -104,6 +116,8 @@ To confirm `npx skills` discovery from a local checkout:
 ```bash
 cd "$(mktemp -d)" && npx skills add /path/to/charcoal -a codex -y && npx skills list
 ```
+
+Then ask the agent something the skills cover — "charcoal のボタンに色が当たらない" should get you `.ch-token-v2`, not a Tailwind setup.
 
 ## If a skill does not show up
 

--- a/plugins/charcoal/skills/choosing-charcoal-styling/SKILL.md
+++ b/plugins/charcoal/skills/choosing-charcoal-styling/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: choosing-charcoal-styling
+description: Use when adding pixiv's charcoal design system (@charcoal-ui) to an app, when deciding between CSS variables, Tailwind, and styled-components with it, or when charcoal components render with no colors, transparent backgrounds, or unresolved --charcoal-* variables.
+---
+
+# Choosing a charcoal styling approach
+
+`@charcoal-ui` is pixiv's design system. It ships tokens once and lets you consume them three different ways. Picking the wrong one — or picking right but skipping the opt-in — is the main source of failure.
+
+## The official docs are not readable by agents
+
+Do not try to look this up on the web first.
+
+- `https://charcoal-web.pixiv.design/` is a Storybook SPA. Fetching it returns a title and no content.
+- The npm package pages return 403.
+- `pages/` in the GitHub repo is a docsify site last updated 2023-03-22. It predates v4 and v6. **Its instructions are wrong** — it tells you `@charcoal-ui/react` needs a styled-components `ThemeProvider`, which stopped being true in v4.
+
+Trust this skill and the package contents (`node_modules/@charcoal-ui/*`, or jsDelivr/unpkg) over search results.
+
+## Three layers, one choice
+
+| Layer         | What it is                        | Packages                                                            | Your choice?                   |
+| ------------- | --------------------------------- | ------------------------------------------------------------------- | ------------------------------ |
+| Constants     | Design tokens                     | `@charcoal-ui/foundation`, `@charcoal-ui/theme`                     | No — everyone uses these       |
+| **Utilities** | Turning tokens into CSS you write | `@charcoal-ui/tailwind-config`, `@charcoal-ui/styled`, or plain CSS | **Yes — here only**            |
+| Components    | Prebuilt UI (Button, Modal…)      | `@charcoal-ui/react`                                                | No — plain CSS, no alternative |
+
+Two things people confuse:
+
+- **"styled → pure CSS"** describes the _component layer's internals_. v4 removed styled-components from `@charcoal-ui/react`. You get no say in it.
+- **"styled vs Tailwind"** is the _utility layer_ choice — how you style your own markup.
+
+Using `@charcoal-ui/react` does not require styled-components or Tailwind. They are unrelated decisions.
+
+## Pick the utility
+
+```
+Do you use @charcoal-ui/react components?
+  → Yes: install it and load the token CSS. No styling library needed.
+  → Either way, continue below for your own markup.
+
+How do you want to style your own markup?
+  ├─ Tailwind already in the project  → setting-up-charcoal-tailwind
+  ├─ Large existing styled-components codebase → setting-up-charcoal-styled
+  └─ Anything else (plain CSS, CSS Modules, vanilla-extract)
+                                       → setting-up-charcoal-css-variables
+```
+
+Default to `setting-up-charcoal-css-variables`. It has no extra dependency and works with any stack.
+
+## Design Token 2.0 is opt-in, and the default is silent
+
+This is the single most common failure. Every route has an opt-in flag, and every route silently gives you the old generation — or nothing at all — if you skip it.
+
+| Route             | Opt-in                                                                                                         | Skip it and you get                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| CSS variables     | Load `@charcoal-ui/theme/css/v2/{light,dark}.css` **and** put `class="ch-token-v2"` on `<html>` or an ancestor | **No tokens at all** — components render with no color |
+| Tailwind          | `unstableTokenV2: true` **plus** the same two steps above                                                      | Design Token 1.0                                       |
+| styled-components | not available                                                                                                  | Design Token 1.0 only — the package has no v2 support  |
+
+No error, no warning. The page just looks wrong.
+
+`.ch-token-v2` is not a CSS-variables-route detail. It gates the v2 variables themselves, so **every route that wants Design Token 2.0 needs it** — the Tailwind preset emits `var(--charcoal-color-*)` references but never defines them.
+
+## Is @charcoal-ui/styled deprecated?
+
+Not formally — only `createTheme` carries `@deprecated`. But the package has **no Design Token 2.0 support** and receives no new features, while `@charcoal-ui/tailwind-config` keeps getting them. Treat it as a dead end you migrate off, not as a forbidden API.
+
+Packages that _are_ formally deprecated: `@charcoal-ui/react-sandbox` (removal planned) and `@charcoal-ui/tailwind-diff` (announced as 廃止予定).
+
+## Common mistakes
+
+| Mistake                                                   | Reality                                                                                                                           |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Loading only `@charcoal-ui/react/dist/index.css`          | That file uses `var(--charcoal-color-*)` but never defines them. You must also load `@charcoal-ui/theme/css/v2/{light,dark}.css`. |
+| Reading light.css's selector as `:root:not([data-theme])` | The real selector is `:root:not([data-theme]) .ch-token-v2`. Drop `.ch-token-v2` and nothing matches.                             |
+| Prescribing Tailwind to fix missing colors                | Colors are not built by Tailwind. Static CSS ships in `@charcoal-ui/theme`.                                                       |
+| Wrapping the app in `ThemeProvider` for `<Button>`        | `Button` imports its own CSS and needs no provider. Only overlays (Modal, DropdownSelector) need `CharcoalProvider`.              |
+| Assuming v6 does not exist                                | It does. Search summaries lag; check `registry.npmjs.org/@charcoal-ui/react`.                                                     |

--- a/plugins/charcoal/skills/setting-up-charcoal-css-variables/SKILL.md
+++ b/plugins/charcoal/skills/setting-up-charcoal-css-variables/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: setting-up-charcoal-css-variables
+description: Use when wiring pixiv's charcoal (@charcoal-ui) into an app with plain CSS, CSS Modules, vanilla-extract, or any stack that is not Tailwind or styled-components, and when charcoal components show no colors or --charcoal-color-* resolves to nothing.
+---
+
+# Setting up charcoal with CSS variables
+
+The lowest-dependency way to use charcoal: load two stylesheets, add one class, then write `var(--charcoal-*)` anywhere.
+
+## Install
+
+```bash
+npm install @charcoal-ui/react@^6 @charcoal-ui/theme@^6 react-aria react-stately
+```
+
+Pin the major. Design Token 2.0 and the CSS layout below are v6; v5 and earlier differ. Keep every `@charcoal-ui/*` package on the same major.
+
+Peer dependencies of `@charcoal-ui/react`: `react >=17.0.0`, `react-aria >=3.48.0`, `react-stately >=3.46.0`. The two react-aria packages are **not** installed for you. React 18 and 19 both satisfy the range.
+
+Skip `@charcoal-ui/react` if you only want tokens — `@charcoal-ui/theme` alone is enough.
+
+## Load the CSS
+
+```ts
+// Load once at the app root.
+import '@charcoal-ui/react/dist/index.css' // component implementation CSS
+import '@charcoal-ui/theme/css/v2/light.css' // Design Token 2.0 — light
+import '@charcoal-ui/theme/css/v2/dark.css' // Design Token 2.0 — dark
+```
+
+`dist/index.css` only _consumes_ `var(--charcoal-color-*)`. It never defines them.
+
+The failure this causes is lopsided in a way that misleads people: **colors go through `var()`, but layout does not.** Padding, radius, font-size, and line-height are written as literal values, so they keep working. Load `dist/index.css` alone and you get a correctly shaped, correctly sized button with a transparent background and default black text. Nothing errors — an undefined custom property just makes that one declaration invalid, and the property falls back to its initial value.
+
+If a charcoal component looks _structurally_ right but _colorless_, this is why.
+
+Prefer `@charcoal-ui/react/dist/layered.css` over `dist/index.css` when you need to override charcoal styles from your own CSS. Its contents are wrapped in `@layer charcoal`, so any unlayered rule of yours wins without a specificity fight. It requires iOS 15.4+.
+
+## Opt in to Design Token 2.0 — required
+
+Token 2.0 only applies inside `.ch-token-v2`.
+
+```html
+<html class="ch-token-v2" lang="ja"></html>
+```
+
+The shipped selectors are:
+
+```css
+/* light.css */
+:root.ch-token-v2[data-theme='light'],
+:root.ch-token-v2:not([data-theme]),
+:root[data-theme='light'] .ch-token-v2,
+:root:not([data-theme]) .ch-token-v2 {
+  --charcoal-color-…: …;
+}
+
+/* dark.css */
+:root[data-theme='dark'] {
+  --charcoal-color-…: …;
+}
+```
+
+Two consequences:
+
+- Without `.ch-token-v2`, **no light-theme rule matches** and every token is undefined.
+- Dark is scoped to `:root` only, so `data-theme="dark"` applies page-wide regardless of `.ch-token-v2`.
+
+Put the class on `<html>`, or on an ancestor of the components you want themed. Variables inherit, so siblings are unaffected.
+
+## Use the tokens
+
+```css
+.card {
+  background-color: var(--charcoal-color-background-default);
+  color: var(--charcoal-color-text-default);
+  border: 1px solid var(--charcoal-color-border-secondary);
+  border-radius: var(--charcoal-radius-s);
+  padding: var(--charcoal-space-40);
+}
+```
+
+Names follow `--charcoal-<category>-<semantic>-<state>`. Common ones: `color-text-default` / `-secondary-default` / `-tertiary-default`, `color-background-default` / `-secondary` / `-tertiary`, `color-border-default` / `-secondary`, `color-container-primary-default`, `radius-xs|s|m|l`, `space-*`. Read `node_modules/@charcoal-ui/theme/dist/css/v2/light.css` for the full list.
+
+## Components need no provider
+
+```tsx
+import { Button } from '@charcoal-ui/react'
+
+export const Save = () => <Button variant="Primary">保存</Button>
+```
+
+`Button` imports its own CSS and uses no context. Wrap in `CharcoalProvider` **only** when you use overlays (`Modal`, `DropdownSelector`) — it supplies react-aria's `SSRProvider` and `OverlayProvider`.
+
+## Theme switching
+
+```tsx
+document.documentElement.dataset.theme = 'dark' // or 'light'
+```
+
+For SSR, run this before paint to avoid a flash:
+
+```tsx
+import { makeSetThemeScriptCode } from '@charcoal-ui/react'
+
+;<script dangerouslySetInnerHTML={{ __html: makeSetThemeScriptCode() }} />
+```
+
+Use `makeSetThemeScriptCode()`, not `<SetThemeScript />`. The component's props type requires both `localStorageKey` and `rootAttribute`, so `<SetThemeScript />` is a type error; `makeSetThemeScriptCode()` accepts zero arguments.
+
+## System theme does not follow the OS
+
+`useThemeSetter()` **removes** `data-theme` when the user is on "system", by design — it expects CSS to handle `prefers-color-scheme`. Design Token 2.0's CSS has no `prefers-color-scheme` block, so with the attribute removed `:root:not([data-theme]) .ch-token-v2` matches and the page is **stuck on light** even on a dark OS.
+
+Either always write an explicit `data-theme`, or add the missing bridge yourself:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']).ch-token-v2,
+  :root:not([data-theme='light']) .ch-token-v2 {
+    /* copy the declarations from @charcoal-ui/theme/css/v2/dark.css */
+  }
+}
+```
+
+Mirror light.css's selector shape. Targeting bare `:root` fails when `.ch-token-v2` sits on a descendant: that descendant's own light values beat inherited dark values from an ancestor.
+
+## Common mistakes
+
+| Mistake                            | Fix                                              |
+| ---------------------------------- | ------------------------------------------------ |
+| Only `dist/index.css` loaded       | Add `@charcoal-ui/theme/css/v2/{light,dark}.css` |
+| `.ch-token-v2` missing             | Add it to `<html>` or an ancestor                |
+| `<SetThemeScript />` with no props | Use `makeSetThemeScriptCode()`                   |
+| Own CSS loses to charcoal's        | Switch to `dist/layered.css`                     |
+| Dark mode ignored on "system"      | Add the `prefers-color-scheme` bridge above      |

--- a/plugins/charcoal/skills/setting-up-charcoal-styled/SKILL.md
+++ b/plugins/charcoal/skills/setting-up-charcoal-styled/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: setting-up-charcoal-styled
+description: Use when an app already uses styled-components and needs pixiv's charcoal (@charcoal-ui) tokens, when working with @charcoal-ui/styled, TokenInjector, createTheme, or addThemeUtils, or when deciding whether to keep styled-components with charcoal.
+---
+
+# Setting up charcoal with styled-components
+
+`@charcoal-ui/styled` exists for codebases already written in styled-components. Read the next section before wiring it in.
+
+## Choose this only for existing code
+
+`@charcoal-ui/styled` is **frozen at Design Token 1.0**. Its source contains no reference to Token 2.0, and it receives only maintenance commits while `@charcoal-ui/tailwind-config` keeps gaining v2 features.
+
+The package is not formally deprecated — only `createTheme` carries `@deprecated`. The problem is not that it is forbidden; it is that it cannot reach the current token generation.
+
+It also drags in the component library: `@charcoal-ui/styled` peer-depends on `@charcoal-ui/react`, because `useTheme`, `useThemeSetter`, `themeSelector`, and `SetThemeScript` are re-exports whose implementations live there. You get that dependency even if you never render a charcoal component.
+
+For a new project, or when you only want tokens, use setting-up-charcoal-css-variables instead.
+
+## Install
+
+```bash
+npm install @charcoal-ui/styled@^6 @charcoal-ui/theme@^6 @charcoal-ui/react@^6
+```
+
+Pin the major and keep every `@charcoal-ui/*` package on the same one. `styled-components >=5.1.1` and `react >=17.0.0` are peers.
+
+## Provider
+
+Two independent mechanisms, both usually needed:
+
+- `ThemeProvider` (styled-components) supplies the **JS theme object** so `${({ theme }) => theme.color.text1}` resolves. The values are literal hex strings, not `var()`.
+- `TokenInjector` (`@charcoal-ui/styled`) emits `--charcoal-color-*` **CSS variables** at runtime via `createGlobalStyle`, for anything not going through styled-components.
+
+```tsx
+import { ThemeProvider } from 'styled-components'
+import {
+  TokenInjector,
+  addThemeUtils,
+  useTheme,
+  useThemeSetter,
+  themeSelector,
+} from '@charcoal-ui/styled'
+import { light, dark } from '@charcoal-ui/theme'
+
+const lightTheme = addThemeUtils(light)
+const darkTheme = addThemeUtils(dark)
+
+export function ThemeRoot({ children }: { children: React.ReactNode }) {
+  const [mode] = useTheme()
+  useThemeSetter()
+
+  return (
+    <ThemeProvider theme={mode === 'dark' ? darkTheme : lightTheme}>
+      <TokenInjector
+        theme={{ ':root': light, [themeSelector('dark')]: dark }}
+        background="background1"
+      />
+      {children}
+    </ThemeProvider>
+  )
+}
+```
+
+`TokenInjector`'s optional `background` prop takes any key of `theme.color` (`background1`, `background2`, `surface1`…) and paints it as the page background on each selector.
+
+Because the JS objects hold literal colors, switching themes requires swapping `ThemeProvider`'s `theme` prop. Rewriting CSS variables alone does not change `${({ theme }) => …}` output. The two systems must be kept in sync — that is what `useTheme` plus `useThemeSetter` do here.
+
+## Types
+
+```ts
+// styled.d.ts
+import 'styled-components'
+import type { CharcoalTheme } from '@charcoal-ui/theme'
+import type { CharcoalThemeUtils } from '@charcoal-ui/styled'
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends CharcoalTheme, CharcoalThemeUtils {}
+}
+```
+
+## Writing components
+
+Use styled-components' own theming. Do **not** use `createTheme` / `theme(o => [...])` — it is `@deprecated` for runtime performance ([PR #377](https://github.com/pixiv/charcoal/pull/377)).
+
+```tsx
+const Card = styled.div`
+  background-color: ${({ theme }) => theme.color.background1};
+  color: ${({ theme }) => theme.color.text1};
+  border-radius: ${({ theme }) => theme.borderRadius[8]}px;
+  ${({ theme }) => theme.utils.padding(16)}
+  ${({ theme }) => theme.utils.typography(16)}
+`
+```
+
+`addThemeUtils()` adds `theme.utils`: `margin*`, `padding*`, `gap`, `typography`, `focusVisibleFocusRingCss`, `assertiveRingCss`, `disabledCss`.
+
+Constraints worth knowing before you hit them:
+
+- `theme.utils.typography(size)` accepts only `12 | 14 | 16 | 20`. **32 is not supported** — expand it by hand. `theme.typography.size[n]` is `{ fontSize: number; lineHeight: number }` in px, keyed by `12 | 14 | 16 | 20 | 32`:
+
+  ```tsx
+  font-size: ${({ theme }) => theme.typography.size[32].fontSize}px;
+  line-height: ${({ theme }) => theme.typography.size[32].lineHeight}px;
+  ```
+
+- `theme.utils.margin` / `padding` accept only the spacing scale (`0, 4, 8, 16, 24, 40, 64, 104, 168, 272, 440`) or `'auto'`. Arbitrary px values are rejected by the type.
+- `theme.spacing` and `theme.typography` are identical in light and dark.
+
+## Theme switching and SSR
+
+```tsx
+import { makeSetThemeScriptCode } from '@charcoal-ui/styled'
+
+;<script dangerouslySetInnerHTML={{ __html: makeSetThemeScriptCode() }} />
+```
+
+Prefer `makeSetThemeScriptCode()` over `<SetThemeScript />`; the component's props type requires both `localStorageKey` and `rootAttribute`.
+
+## Migrating off, in dependency order
+
+You do not have to leave in one step.
+
+1. **Drop `createTheme`.** The only `@deprecated` API here. Move to plain `${({ theme }) => theme.color.*}` or `addThemeUtils`.
+2. **Drop `TokenInjector`.** Import `@charcoal-ui/theme/css/v2/{light,dark}.css` instead — static CSS supplies the same variables with no runtime `createGlobalStyle`. This is also the step that unlocks Design Token 2.0.
+3. **Drop `ThemeProvider`.** Replace `theme.color.text1` reads with `var(--charcoal-color-text-default)`.
+4. **Drop styled-components** if you want. By this point charcoal no longer cares.
+
+If you only render `@charcoal-ui/react` components, steps 1–3 are already unnecessary — since v4 it does not depend on styled-components at all.
+
+## Common mistakes
+
+| Mistake                                         | Fix                                                                               |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- |
+| Reaching for `createTheme` because docs show it | It is `@deprecated`. Use styled-components theming.                               |
+| Expecting Design Token 2.0 here                 | Not supported. Move to CSS variables or Tailwind.                                 |
+| Swapping CSS variables to change theme          | JS theme objects hold literal colors — swap `ThemeProvider`'s `theme` too.        |
+| `theme.utils.typography(32)`                    | Type error. Expand `theme.typography.size[32]` manually.                          |
+| Following `pages/` docs in the repo             | Last updated 2023-03-22, pre-v4. Its `@charcoal-ui/react` instructions are wrong. |

--- a/plugins/charcoal/skills/setting-up-charcoal-tailwind/SKILL.md
+++ b/plugins/charcoal/skills/setting-up-charcoal-tailwind/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: setting-up-charcoal-tailwind
+description: Use when adding pixiv's charcoal (@charcoal-ui) design tokens to a Tailwind CSS project, when charcoal Tailwind classes are missing or resolve to the wrong generation of tokens, or when Tailwind's own color and spacing utilities stop working after adding the charcoal preset.
+---
+
+# Setting up charcoal with Tailwind
+
+`@charcoal-ui/tailwind-config` turns charcoal tokens into a Tailwind preset. This is the actively developed utility route — new Design Token 2.0 features land here first.
+
+## Install
+
+```bash
+npm install --save-dev @charcoal-ui/tailwind-config @charcoal-ui/theme
+```
+
+Peer dependencies: `tailwindcss >=1.4.6`, `postcss >=7.0.32`, `csstype >=3.0.0`. Tailwind v4 support is WIP — v4 works only by pointing `@config` at a v3-shaped config.
+
+## Configure
+
+```js
+// tailwind.config.js
+const { light, dark } = require('@charcoal-ui/theme')
+const { createTailwindConfig } = require('@charcoal-ui/tailwind-config')
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  presets: [
+    createTailwindConfig({
+      version: 'v3',
+      theme: {
+        ':root': light,
+        '@media (prefers-color-scheme: dark)': dark,
+      },
+      unstableTokenV2: true, // Design Token 2.0 — omit and you get 1.0
+      iconsV2: true,
+    }),
+  ],
+}
+```
+
+`createTailwindConfig()` options: `version` (`'v1' | 'v2' | 'v3'`, Tailwind's version — unrelated to charcoal's), `theme`, `cssVariablesV1`, `unstableTokenV2`, `iconsV1`, `iconsV2`. A bare default preset is also exported as `config`.
+
+## `unstableTokenV2: true` needs the theme CSS too
+
+The preset does **not** define Design Token 2.0 variables. `unstable_createTailwindConfigTokenV2()` contains no plugin and no `addBase()` — it only emits class values that _reference_ `var(--charcoal-color-*)`. Something else has to define them.
+
+Two disjoint namespaces are in play:
+
+| Defined by                                        | Names                         | Example                                      |
+| ------------------------------------------------- | ----------------------------- | -------------------------------------------- |
+| The preset, when `cssVariablesV1` is on (default) | `--charcoal-<v1 token>`       | `--charcoal-background1`, `--charcoal-text1` |
+| `@charcoal-ui/theme/css/v2/*.css`                 | `--charcoal-color-<v2 token>` | `--charcoal-color-container-default`         |
+
+`customPropertyToken()` produces `--charcoal-${id}`, so the v1 variables never satisfy a v2 reference. Turning on `unstableTokenV2` without loading the theme CSS gives you classes that resolve to nothing — colors silently disappear.
+
+So with `unstableTokenV2: true`, do all three:
+
+```css
+/* globals.css */
+@import '@charcoal-ui/theme/css/v2/light.css';
+@import '@charcoal-ui/theme/css/v2/dark.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+```html
+<html lang="ja" class="ch-token-v2">
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+```
+
+`.ch-token-v2` gates the light-theme rules in `light.css`. Without it, no light rule matches and every v2 variable is undefined — the same failure described in setting-up-charcoal-css-variables.
+
+If you stay on Design Token 1.0 (`unstableTokenV2` omitted), the preset's own `addBase()` supplies everything and the three `@tailwind` lines are all you need.
+
+## The preset replaces Tailwind's defaults
+
+`createTailwindConfig()` writes `colors`, `spacing`, `width`, `gap`, `borderRadius`, `screens`, and `transitionDuration` at the **top level of `theme`**, not under `extend`. Tailwind's preset merge therefore _replaces_ the stock scales:
+
+- `bg-red-500`, `text-blue-600` and the rest of the default palette stop existing. Only `transparent`, `current`, `black`, `white`, and charcoal tokens remain.
+- `p-4` no longer means 1rem. Spacing keys are charcoal's px values: `0, 4, 8, 16, 24, 40, 64, 104, 168, 272, 440` — so `p-16` is 16px.
+- `corePlugins: { lineHeight: false }` disables every `leading-*` utility.
+
+If existing markup relies on stock Tailwind classes, add them back explicitly:
+
+```js
+const colors = require('tailwindcss/colors')
+module.exports = {
+  presets: [createTailwindConfig({/* … */})],
+  theme: { extend: { colors: { red: colors.red } } },
+}
+```
+
+## Classes you get
+
+```tsx
+<div className="bg-background1 text-text1 rounded-8 p-16">
+  <h2 className="typography-20">タイトル</h2>
+  <button className="ch-focus-ring bg-brand hover:bg-brand-hover active:bg-brand-press">
+    送信
+  </button>
+</div>
+```
+
+- Colors carry `DEFAULT` / `hover` / `press` / `disabled` variants — `bg-brand`, `bg-brand-hover`, …
+- `typography-{12|14|16|20|32}` sets font-size and line-height together.
+- `.ch-focus-ring` reproduces the focus ring used by `@charcoal-ui/react`.
+- `w-col-span-{n}` and `w-{n}/12` come from the grid system.
+
+Those names are Design Token 1.0. They keep working when `unstableTokenV2` is on, because the preset merges v2 entries on top of v1 rather than replacing them.
+
+Design Token 2.0 adds five color groups — `background`, `border`, `container`, `icon`, `text` — folded so that a `default` key becomes the bare class:
+
+```
+color.container.default      → bg-container
+color.container.hover        → bg-container-hover
+color.text.default           → text-text
+color.text.info.default      → text-text-info
+color.text.negative.hover    → text-text-negative-hover
+color.background.secondary   → bg-background-secondary
+```
+
+Spacing splits into `component-*` and `layout-*` (`p-component-20`, `gap-layout-40`), radius becomes `rounded-{xs|s|m|l|xl|xxl|oval}`, and border colors take a `ch` prefix (`border-ch-secondary`).
+
+To see exactly what your config produces, resolve it rather than guessing:
+
+```js
+console.log(
+  require('tailwindcss/resolveConfig')(require('./tailwind.config.js')).theme
+    .colors,
+)
+```
+
+## Dark theme
+
+Tailwind's `dark:` variant is **not supported**. A charcoal token keeps its name across themes while its value changes, so `dark:bg-background1` is meaningless. Pass a theme map instead and the generated `var()` switches for you.
+
+```js
+// follow the OS
+theme: { ':root': light, '@media (prefers-color-scheme: dark)': dark }
+
+// or switch from JS
+theme: { ':root': light, 'html[data-theme="dark"]': dark }
+```
+
+```js
+document.documentElement.dataset.theme = 'dark'
+```
+
+Do not nest `:root` under the `@media` key — the build inserts it for you.
+
+**The `theme` map only drives Design Token 1.0.** It feeds `cssVariablesV1`, which defines `--charcoal-<v1 token>`. Token 2.0 variables come from `@charcoal-ui/theme/css/v2/*.css`, and that CSS defines dark only at `:root[data-theme='dark']` — it has no `prefers-color-scheme` block. So on `unstableTokenV2: true`, `'@media (prefers-color-scheme: dark)': dark` does **not** make v2 tokens follow the OS.
+
+Either write `data-theme` explicitly from JS, or add the bridge described in setting-up-charcoal-css-variables:
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']).ch-token-v2,
+  :root:not([data-theme='light']) .ch-token-v2 {
+    /* copy the declarations from @charcoal-ui/theme/css/v2/dark.css */
+  }
+}
+```
+
+## Common mistakes
+
+| Mistake                                                       | Fix                                                                                                                        |
+| ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `unstableTokenV2` omitted                                     | You silently get Design Token 1.0. Set it to `true`.                                                                       |
+| `unstableTokenV2: true` but no theme CSS                      | The preset never defines `--charcoal-color-*`. Import `@charcoal-ui/theme/css/v2/{light,dark}.css` and add `.ch-token-v2`. |
+| Assuming `.ch-token-v2` is a CSS-variables-route-only concern | It gates the v2 variables themselves, so the Tailwind v2 route needs it too.                                               |
+| Confusing `version: 'v3'` with charcoal v3                    | It means Tailwind v3.                                                                                                      |
+| `dark:bg-*`                                                   | Unsupported. Use the `theme` map.                                                                                          |
+| Stock Tailwind classes vanished                               | The preset replaces the default scales — add them back under `theme.extend`.                                               |
+| `leading-*` has no effect                                     | `corePlugins.lineHeight` is off. Use `typography-*`.                                                                       |
+| Nesting `':root'` inside the `@media` key                     | Pass the theme object directly.                                                                                            |
+
+## Using charcoal React components too
+
+`@charcoal-ui/react` is independent of this preset. It needs its own CSS and the `.ch-token-v2` opt-in — see setting-up-charcoal-css-variables. Set `corePlugins: { preflight: false }` if Tailwind's reset interferes with charcoal component styles.


### PR DESCRIPTION
## やったこと

#1093 の土俵に、#1057 の 4 skill を `plugins/charcoal/skills/` へそのまま移しました。skill の内容は変えていません。#1057 は Storybook の Styling Guide だけを残す想定です。

```
plugins/charcoal/skills/
├── choosing-charcoal-styling/          分岐
├── setting-up-charcoal-css-variables/  既定の経路
├── setting-up-charcoal-tailwind/       preset と Token 2.0 の有効化
└── setting-up-charcoal-styled/         既存資産向けと移行順序
```

`plugins/charcoal/README.md` に skill 一覧と「なぜ必要か」（公式ドキュメントがエージェントから読めない）を足し、Add a skill に「skill なしで失敗を再現してから書く」手順、Checks に動作確認用の質問を追記しました。

## 動作確認環境

- 4 skill の記述を現在の main と照合。`light.css` のセレクタ、`createTailwindConfig()` のオプション名、peerDependencies、`@charcoal-ui/styled` の export に変化なし。#1057 以降の theme 変更（`--charcoal-space-40` 修正 4f54757f7）は v1 `remap.css` のみで skill の記述に影響なし
- `claude plugin validate --strict` を marketplace と plugin の両方で通過（Claude Code 2.1.263）
- `node misc/sync-plugin-version.mts --check` exit 0、`pnpm exec prettier --check plugins .claude-plugin` 通過
- `CLAUDE_CONFIG_DIR` を隔離して `claude plugin marketplace add <worktree>` → `claude plugin install charcoal@charcoal`。キャッシュ `plugins/cache/charcoal/charcoal/6.1.1-beta.2/skills/` に 4 skill がコピーされることを確認
- `npx skills@1.5.24 add <worktree> -a codex -y` が 4 skill を `.agents/skills/` に install することを確認
- `claude -p --plugin-dir plugins/charcoal` で「Next.js で Button が透明になる」を質問し、回答が `.ch-token-v2` の付与と theme CSS の読み込みを指し、Tailwind 導入を提案しないことを確認

## チェックリスト

- [x] README やドキュメントに影響があることを確認した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
